### PR TITLE
Add ORT_API_CALL to AddExternalCustomOp in ocos.h

### DIFF
--- a/includes/ocos.h
+++ b/includes/ocos.h
@@ -13,7 +13,7 @@
 
 // A helper API to support test kernels.
 // Must be invoked before RegisterCustomOps.
-extern "C" bool AddExternalCustomOp(const OrtCustomOp* c_op);
+extern "C" bool ORT_API_CALL AddExternalCustomOp(const OrtCustomOp* c_op);
 
 const char c_OpDomain[] = "ai.onnx.contrib";
 


### PR DESCRIPTION
Add ORT_API_CALL to AddExternalCustomOp so that the calling convention of the declaration in ocos.h matches the calling convention of the definition in ortcustomops.cc for x86 builds.