### PR TITLE
Correct memory indexing issue.

### DIFF
--- a/ci_build/azure-pipelines/mshost.yaml
+++ b/ci_build/azure-pipelines/mshost.yaml
@@ -129,7 +129,7 @@ jobs:
 
   - job: MacOSWheel
     pool:
-      vmImage: 'macOS-latest'
+      vmImage: 'macOS-10.15'
 
     strategy:
       matrix:

--- a/operators/tokenizer/blingfire_sentencebreaker.cc
+++ b/operators/tokenizer/blingfire_sentencebreaker.cc
@@ -7,6 +7,7 @@
 #include <locale>
 #include <codecvt>
 #include <algorithm>
+#include <memory>
 
 KernelBlingFireSentenceBreaker::KernelBlingFireSentenceBreaker(OrtApi api, const OrtKernelInfo* info) : BaseKernel(api, info), max_sentence(-1) {
   model_data_ = ort_.KernelInfoGetAttribute<std::string>(info, "model");
@@ -41,10 +42,9 @@ void KernelBlingFireSentenceBreaker::Compute(OrtKernelContext* context) {
 
   std::string& input_string = input_data[0];
   int max_length = 2 * input_string.size() + 1;
-  std::string output_str;
-  output_str.reserve(max_length);
+  std::unique_ptr<char[]> output_str = std::make_unique<char[]>(max_length);
 
-  int output_length = TextToSentencesWithOffsetsWithModel(input_string.data(), input_string.size(), output_str.data(), nullptr, nullptr, max_length, model_.get());
+  int output_length = TextToSentencesWithOffsetsWithModel(input_string.data(), input_string.size(), output_str.get(), nullptr, nullptr, max_length, model_.get());
   if (output_length < 0) {
     ORT_CXX_API_THROW(MakeString("splitting input:\"", input_string, "\"  failed"), ORT_INVALID_ARGUMENT);
   }


### PR DESCRIPTION
`KernelBlingFireSentenceBreaker::Compute(OrtKernelContext* context)` from operators/tokenizer/blingfire_sentencebreaker.cc currently contains the following code:
```
  int max_length = 2 * input_string.size() + 1;
  std::string output_str;
  output_str.reserve(max_length);
```
... however, `std::string::reserve` only reserves memory and does not resize `std::string` so the use of `output_str.data()` and the use of `output_str[i]` that follow are not defined ... and in a Debug build where bounds checking based on the size of `std::string` is done, `output_str[i]` fails.

Either of the following can be used instead:
```
  std::string output_str;
  output_str.resize(max_length, '\0'); // or just output_str.resize(max_length); since '\0' is implied.
```
... or:
```
std::unique_ptr<char[]> output_str = std::make_unique<char[]>(max_length);
```
... with `output_str.get()` used in the place of `output_str.data()` where needed.

This PR uses the later since it retains the semantics of how `output_str` was being used inside `KernelBlingFireSentenceBreaker::Compute(OrtKernelContext* context)`.