### PR TITLE
Update requirements.txt to restrict protobuf version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy
 onnx>=1.9.0
 onnxruntime>=1.6.0
+protobuf>=3.12.2,<=3.20.1


### PR DESCRIPTION
Similar to: https://github.com/onnx/onnx/pull/4223

We will need this change until onnx publishes a patch release to include the above change.