### PR TITLE
Update tsaoptions.json to explicitly set template name

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -4,5 +4,6 @@
   "codebaseName": "onnx-runtime-extensions_main",
   "instanceUrl": "https://aiinfra.visualstudio.com/",
   "projectName": "ONNX Runtime",
-  "ignoreBranchName": true
+  "ignoreBranchName": true,
+  "template": "AIINFRA_TSA"
 }


### PR DESCRIPTION
This is a follow-up to #297. The changes in #297 didn't work.  For unknown reason, we need to add this setting. 