### PR TITLE
Updated json and re2 version as per ort req

### DIFF
--- a/cmake/externals/googlere2.cmake
+++ b/cmake/externals/googlere2.cmake
@@ -1,7 +1,7 @@
 FetchContent_Declare(
   googlere2
   GIT_REPOSITORY https://github.com/google/re2.git
-  GIT_TAG        2020-11-01
+  GIT_TAG        2021-06-01
 )
 
 FetchContent_GetProperties(googlere2)

--- a/cmake/externals/json.cmake
+++ b/cmake/externals/json.cmake
@@ -1,6 +1,6 @@
 FetchContent_Declare(json
   GIT_REPOSITORY https://github.com/nlohmann/json.git
-  GIT_TAG v3.7.3)
+  GIT_TAG v3.10.5)
 
 FetchContent_GetProperties(json)
 if(NOT json_POPULATED)


### PR DESCRIPTION
### Updated json and googlere2 versions in cmake/externals to match [onnxruntime requirements](https://github.com/microsoft/onnxruntime/tree/main/cmake/external).

**Old Versions**:
json: v3.7.3
googlere2: 2020-11-01

**New Versions**:
json: v3.10.5
googlere2: 2021-06-01

**Validation**
- [x] Ran all tests - all 90 passed, no errors
- [x] Using python 3.8, torch 1.10.0, torchvision 0.11.1, torchaudio 0.10.0, ort 1.12.1