### PR TITLE
Include requirements.txt from requirements-dev.txt.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+# include requirements.txt so pip has context to avoid installing incompatible dependencies
 -r requirements.txt
 pytest
 transformers     >= 4.9.2,<=4.24.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 pytest
 transformers     >= 4.9.2,<=4.24.0
 tensorflow_text  >=2.5.0
-protobuf         >=3.12.2,<=3.20.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest
 transformers     >= 4.9.2,<=4.24.0
 tensorflow_text  >=2.5.0
+protobuf         >=3.20, <4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
+-r requirements.txt
 pytest
 transformers     >= 4.9.2,<=4.24.0
 tensorflow_text  >=2.5.0
-protobuf         >=3.20, <4


### PR DESCRIPTION
Include requirements.txt from requirements-dev.txt so that pip has context to avoid installing incompatible dependencies.

Fix the CI build.