### PR TITLE
Add ability to specify onnx opset when adding pre/post processing to model

### DIFF
--- a/tools/add_pre_post_processing_to_model.py
+++ b/tools/add_pre_post_processing_to_model.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from pre_post_processing import PrePostProcessor, Debug
 from pre_post_processing.steps import *
-from pre_post_processing.utils import create_named_value, IoMapEntry
+from pre_post_processing.utils import create_named_value, IoMapEntry, Settings
 
 
 class ModelSource(enum.Enum):
@@ -210,12 +210,20 @@ def main():
         help="Image output format for superresolution model to produce.",
     )
 
+    parser.add_argument(
+        "--opset", type=int, required=False, default=16,
+        help="ONNX opset to use. Opset 18 is required for Resize with anti-aliasing."
+    )
+
     parser.add_argument("model", type=Path, help="Provide path to ONNX model to update.")
 
     args = parser.parse_args()
 
     model_path = args.model.resolve(strict=True)
     new_model_path = model_path.with_suffix(".with_pre_post_processing.onnx")
+
+    if args.opset:
+        Settings.pre_post_processing_onnx_opset = args.opset
 
     if args.model_type == "mobilenet":
         source = ModelSource.PYTORCH if args.model_source == "pytorch" else ModelSource.TENSORFLOW

--- a/tools/pre_post_processing/pre_post_processor.py
+++ b/tools/pre_post_processing/pre_post_processor.py
@@ -10,7 +10,7 @@ from .utils import (
     IoMapEntry,
     get_opset_imports,
     sanitize_output_names,
-    PRE_POST_PROCESSING_ONNX_OPSET,
+    Settings,
     TENSOR_TYPE_TO_ONNX_TYPE,
 )
 from .step import Step
@@ -109,13 +109,13 @@ class PrePostProcessor:
             entry.version for entry in model.opset_import if entry.domain == "" or entry.domain == "ai.onnx"
         ][0]
 
-        if model_opset > PRE_POST_PROCESSING_ONNX_OPSET:
+        if model_opset > Settings.pre_post_processing_onnx_opset:
             # It will probably work if the user updates PRE_POST_PROCESSING_ONNX_OPSET to match the model
             # but there are no guarantees.
             # Would only break if ONNX operators used in the pre/post processing graphs have had spec changes.
             raise ValueError(f"Model opset is {model_opset} which is newer than the opset used by this script.")
-        elif model_opset < PRE_POST_PROCESSING_ONNX_OPSET:
-            model = onnx.version_converter.convert_version(model, PRE_POST_PROCESSING_ONNX_OPSET)
+        elif model_opset < Settings.pre_post_processing_onnx_opset:
+            model = onnx.version_converter.convert_version(model, Settings.pre_post_processing_onnx_opset)
 
         def name_nodes(new_graph: onnx.GraphProto, prefix: str):
             # simple helper so all nodes are named. this makes it far easier to debug any issues.

--- a/tools/pre_post_processing/steps/vision.py
+++ b/tools/pre_post_processing/steps/vision.py
@@ -7,7 +7,7 @@ import numpy as np
 from typing import List, Optional, Tuple, Union
 from ..step import Step
 from .general import Transpose
-from ..utils import PRE_POST_PROCESSING_ONNX_OPSET
+from ..utils import Settings
 
 #
 # Image conversion
@@ -339,7 +339,7 @@ class Resize(Step):
 
         # TODO: Make this configurable. Matching PIL resize for now.
         resize_attributes = 'mode = "linear", nearest_mode = "floor"'
-        if PRE_POST_PROCESSING_ONNX_OPSET >= 18:
+        if Settings.pre_post_processing_onnx_opset >= 18:
             # Resize matches PIL better if antialiasing is used, but that isn't available until ONNX opset 18.
             # Allow this to be used with older opsets as well.
             resize_attributes += ', antialias = 1'

--- a/tools/pre_post_processing/utils.py
+++ b/tools/pre_post_processing/utils.py
@@ -4,7 +4,7 @@
 import onnx
 
 from dataclasses import dataclass
-from typing import Dict, List, Union
+from typing import List, Union
 
 
 def create_named_value(name: str, data_type: int, shape: List[Union[str, int]]):
@@ -25,18 +25,21 @@ def create_named_value(name: str, data_type: int, shape: List[Union[str, int]]):
     return onnx.helper.make_value_info(name, tensor_type)
 
 
-# We need to use an opset that's valid for the pre/post processing operators we add.
-# Could alternatively use onnx.defs.onnx_opset_version to match the onnx version installed, but that's not deterministic
-# For now it's an arbitrary default of ONNX v16.
-# NOTE: If we update this value we need to make sure the operators used in all steps are also updated if their spec
-#       has changed.
-PRE_POST_PROCESSING_ONNX_OPSET = 16
+class Settings:
+    # We need to use an opset that's valid for the pre/post processing operators we add.
+    # Initial default is ONNX v16 which is supported by currently released ORT packages (as of 01/2023).
+    # Preferred is ONNX v18 as Resize supports the 'antialias' attribute from that opset on, which is required to match
+    # the Pillow image resize behavior.
+    #
+    # NOTE: If we update this value we need to make sure the operators used in all steps are also updated if their spec
+    #       has changed.
+    pre_post_processing_onnx_opset = 16
 
 
 def get_opset_imports():
     """Get the opset imports for a model updated by the PrePostProcessor."""
     return {
-        "": PRE_POST_PROCESSING_ONNX_OPSET,
+        "": Settings.pre_post_processing_onnx_opset,
         "com.microsoft.extensions": 1
     }  # fmt: skip
 


### PR DESCRIPTION
Add ability to specify opset so we can easily adjust to the opset supported by the onnxruntime package.