### PR TITLE
Fix PreFast warning

### DIFF
--- a/operators/vision/decode_image.cc
+++ b/operators/vision/decode_image.cc
@@ -31,11 +31,13 @@ void KernelDecodeImage::Compute(OrtKernelContext* context) {
 
   // Setup output & copy to destination
   const cv::Size decoded_image_size = decoded_image.size();
+  const int64_t height = decoded_image_size.height;
+  const int64_t width = decoded_image_size.width;
   const int64_t colors = decoded_image.elemSize();  //  == 3 as it's BGR
 
-  const std::vector<int64_t> output_dims{decoded_image_size.height, decoded_image_size.width, colors};
+  const std::vector<int64_t> output_dims{height, width, colors};
   OrtValue* output_value = ort_.KernelContext_GetOutput(context, 0, output_dims.data(), output_dims.size());
   uint8_t* decoded_image_data = ort_.GetTensorMutableData<uint8_t>(output_value);
-  memcpy(decoded_image_data, decoded_image.data, decoded_image_size.height * decoded_image_size.width * colors);
+  memcpy(decoded_image_data, decoded_image.data, height * width * colors);
 }
 }  // namespace ort_extensions


### PR DESCRIPTION
Convert opencv values to int64_t to avoid prefast warning.

Couldn't repro the warning locally but this will make all types in calculating the memcpy size the same.