### PR TITLE
Possible fix for "FetchContent" builds, always use ONNXRUNTIME_PKG_DIR when defined.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,7 @@ include(FetchContent)
 
 # PROJECT_IS_TOP_LEVEL is available until 3.21
 get_property(not_top DIRECTORY PROPERTY PARENT_DIRECTORY)
-if(not_top)
+if(not_top AND ONNXRUNTIME_ROOT)
   set(_ONNXRUNTIME_EMBEDDED TRUE)
 endif()
 include(ext_ortlib)


### PR DESCRIPTION
I'm not sure what the purpose of `_ONNXRUNTIME_EMBEDDED` is, but the if branch checking it's existence in `ext_ortlib.cmake` uses the path `${CMAKE_SOURCE_DIR}/incluude/onnxruntime/core/session` to attempt to find libs and headers for ORT.

When using ` `${CMAKE_SOURCE_DIR}/../include/onnxruntime/core/session`, unless you have the ONNX library in located in `include/onnxruntime/core/session` above the project root (a bit of a random place?), it will fail to find headers and libs.

This will cause the variable `ONNXRUNTIME_PKG_DIR` to be ignored, but the user can set that variable to the root of ONNX runtime, causing it to actually find the lib.

My suggestion is to always use `${ONNXRUNTIME_PKG_DIR}` when defined, as users like myself, can pull prebuilt packages (or build from source), find the libs and headers with CMake find package and then simply define `ONNXRUNTIME_PKG_DIR` prior to calling `FetchContent`.

I've left the previous branch in there, as a secondary check in case there's some need. But from a glance, we can just remove that branch as it's not really doing anything useful?