### PR TITLE
Fix ORT combined build nlohmann_json fetch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,7 @@ if(OCOS_ENABLE_BLINGFIRE)
 endif()
 
 if(OCOS_ENABLE_GPT2_TOKENIZER OR OCOS_ENABLE_WORDPIECE_TOKENIZER)
-  target_include_directories(ocos_operators PRIVATE ${json_SOURCE_DIR}/single_include)
+  target_include_directories(ocos_operators PRIVATE ${nlohmann_json_SOURCE_DIR}/single_include)
   list(APPEND ocos_libraries nlohmann_json::nlohmann_json)
 endif()
 

--- a/cmake/externals/json.cmake
+++ b/cmake/externals/json.cmake
@@ -1,11 +1,11 @@
-FetchContent_Declare(json
+FetchContent_Declare(nlohmann_json
   GIT_REPOSITORY https://github.com/nlohmann/json.git
   GIT_TAG v3.10.5)
 
 set(JSON_BuildTests OFF CACHE INTERNAL "")
 
-FetchContent_GetProperties(json)
-if(NOT json_POPULATED)
-  FetchContent_Populate(json)
-  add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR} EXCLUDE_FROM_ALL)
+FetchContent_GetProperties(nlohmann_json)
+if(NOT nlohmann_json_POPULATED)
+  FetchContent_Populate(nlohmann_json)
+  add_subdirectory(${nlohmann_json_SOURCE_DIR} ${nlohmann_json_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()


### PR DESCRIPTION
Use dependency name 'nlohmann_json' which is the same name that ORT uses.

https://github.com/microsoft/onnxruntime/blob/4a676b011a71f5a1ddacdac566f5579f0e132976/cmake/external/onnxruntime_external_deps.cmake#L154-L159

Then the FetchContent calls in both ORT and ORT Extensions won't try to fetch this dependency as two separate dependencies and complain about an existing target created by the first fetch.