### PR TITLE
Update wheels_linux.yml: change the linux machine pool name

### DIFF
--- a/.pipelines/wheels_linux.yml
+++ b/.pipelines/wheels_linux.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: linux
   timeoutInMinutes: 120
-  pool: {vmImage: 'ubuntu-latest', name: 'Linux-CPU'}
+  pool: {name: 'Azure-Pipelines-EO-Ubuntu-2004-aiinfra'}
   variables:
     CIBW_BUILD: "cp3{7,8,9,10}-*"
 


### PR DESCRIPTION
In pool's settings, either you only specify the "name" attribute, or only "vmImage". The "Linux-CPU" was created by me, it only has one image. So your "vmImage" setting was ignored. 