### PR TITLE
Fix OneBranch PR pipeline CodeQL issue

### DIFF
--- a/.pipelines/OneBranch.PullRequest.yml
+++ b/.pipelines/OneBranch.PullRequest.yml
@@ -48,7 +48,7 @@ extends:
         break: true # always break the build on binskim issues in addition to TSA upload
         analyzeTargetGlob: '**\RelWithDebInfo\ortextensions.dll'  # avoid scanning the 3rd party DLLs.
       codeql:
-        python:
+        compiled:
           enabled: true
         cadence: 10
       policheck:

--- a/.pipelines/OneBranch.PullRequest.yml
+++ b/.pipelines/OneBranch.PullRequest.yml
@@ -48,7 +48,7 @@ extends:
         break: true # always break the build on binskim issues in addition to TSA upload
         analyzeTargetGlob: '**\RelWithDebInfo\ortextensions.dll'  # avoid scanning the 3rd party DLLs.
       codeql:
-        compiled:
+        python:
           enabled: true
         cadence: 10
       policheck:

--- a/.pipelines/OneBranch.PullRequest.yml
+++ b/.pipelines/OneBranch.PullRequest.yml
@@ -48,8 +48,9 @@ extends:
         break: true # always break the build on binskim issues in addition to TSA upload
         analyzeTargetGlob: '**\RelWithDebInfo\ortextensions.dll'  # avoid scanning the 3rd party DLLs.
       codeql:
-        python:
+        compiled:
           enabled: true
+        cadence: 10
       policheck:
         break: true # always break the build on policheck issues. You can disable it by setting to 'false'
         exclusionsFile: '$(REPOROOT)\.config\policheck_exclusions.xml'


### PR DESCRIPTION
CodeQL needs to be updated from Guardian to CodeQL 3000 Extension as Guardian is outdated, however the CodeQL 3000 Extension does not support PR or tag branches.

However, switching codeql option from `python` to `compiled` (as used here: https://onebranch.visualstudio.com/OneBranch/_wiki/wikis/OneBranch.wiki/6249/CodeQL-3000) automatically skips it in the pipeline, thus adding that instead of disabling completely.