### PR TITLE
Fix Android AAR in nuget package. Requires libortextensions.so.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,6 +491,10 @@ if(OCOS_ENABLE_SPM_TOKENIZER)
   target_include_directories(ocos_operators PUBLIC ${spm_INCLUDE_DIRS})
   list(APPEND OCOS_COMPILE_DEFINITIONS ENABLE_SPM_TOKENIZER)
   list(APPEND ocos_libraries sentencepiece-static)
+
+  if(ANDROID)
+    list(APPEND ocos_libraries log)
+  endif()
 endif()
 
 if(OCOS_ENABLE_BLINGFIRE)
@@ -566,13 +570,7 @@ if(_BUILD_SHARED_LIBRARY)
   source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${shared_TARGET_SRC})
   standardize_output_folder(extensions_shared)
 
-  if(CMAKE_SYSTEM_NAME STREQUAL "Android")
-    if(OCOS_ENABLE_SPM_TOKENIZER)
-      target_link_libraries(extensions_shared PUBLIC log)
-    endif()
-  endif()
-
-  if(LINUX OR CMAKE_SYSTEM_NAME STREQUAL "Android")
+  if(LINUX OR ANDROID)
     set_property(TARGET extensions_shared APPEND_STRING PROPERTY LINK_FLAGS "-Wl,-s -Wl,--version-script -Wl,${PROJECT_SOURCE_DIR}/shared/ortcustomops.ver")
   endif()
 
@@ -652,7 +650,7 @@ if(OCOS_ENABLE_CTEST)
     set(LINUX_CC_FLAGS "")
 
     # needs to link with stdc++fs in Linux
-    if(UNIX AND NOT APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+    if(UNIX AND NOT APPLE AND NOT ANDROID)
       list(APPEND LINUX_CC_FLAGS stdc++fs -pthread)
     endif()
 

--- a/cmake/ext_java.cmake
+++ b/cmake/ext_java.cmake
@@ -1,7 +1,7 @@
 include(FindJava)
 find_package(Java REQUIRED)
 include(UseJava)
-if (NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+if (NOT ANDROID)
     find_package(JNI REQUIRED)
 endif()
 
@@ -30,7 +30,7 @@ set(JAVA_OUTPUT_JAR ${JAVA_OUTPUT_TEMP}/build/libs/onnxruntime_extensions.jar)
 set(GRADLE_ARGS --console=plain clean jar -p ${JAVA_ROOT} -x test )
 if(WIN32)
   set(GRADLE_ARGS ${GRADLE_ARGS} -Dorg.gradle.daemon=false)
-elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
+elseif (ANDROID)
   # For Android build, we may run gradle multiple times in same build,
   # sometimes gradle JVM will run out of memory if we keep the daemon running
   # it is better to not keep a daemon running
@@ -58,14 +58,16 @@ add_dependencies(onnxruntime_extensions4j_jni onnxruntime_extensions4j)
 target_include_directories(onnxruntime_extensions4j_jni PRIVATE ortcustomops)
 # the JNI headers are generated in the onnxruntime_extensions4j target
 target_include_directories(onnxruntime_extensions4j_jni PRIVATE ${JAVA_ROOT}/build/headers ${JNI_INCLUDE_DIRS})
-target_link_libraries(onnxruntime_extensions4j_jni PRIVATE ortcustomops)
+
+# use shared lib for extensions on Android as NuGet requires the extensions .so
+if (ANDROID AND _BUILD_SHARED_LIBRARY)
+  target_link_libraries(onnxruntime_extensions4j_jni PRIVATE extensions_shared)
+else()
+  target_link_libraries(onnxruntime_extensions4j_jni PRIVATE ortcustomops)
+endif()
+
 standardize_output_folder(onnxruntime_extensions4j_jni)
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Android")
-  if (OCOS_ENABLE_SPM_TOKENIZER)
-    target_link_libraries(onnxruntime_extensions4j_jni PUBLIC log)
-  endif()
-endif()
 # Set platform and arch for packaging
 # Checks the names set by MLAS on non-Windows platforms first
 if(APPLE)
@@ -87,7 +89,7 @@ if(APPLE)
    elseif(JNI_ARCH STREQUAL "arm64")
        set(JNI_ARCH aarch64)
    endif()
-elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
+elseif (ANDROID)
   set(JNI_ARCH ${ANDROID_ABI})
 elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
   set(JNI_ARCH x64)
@@ -148,7 +150,7 @@ endif()
 set(GRADLE_ARGS --console=plain cmakeBuild -p ${JAVA_ROOT} -DcmakeBuildDir=${CMAKE_CURRENT_BINARY_DIR})
 if(WIN32)
   set(GRADLE_ARGS ${GRADLE_ARGS} -Dorg.gradle.daemon=false)
-elseif (CMAKE_SYSTEM_NAME STREQUAL "Android")
+elseif (ANDROID)
   # For Android build, we may run gradle multiple times in same build,
   # sometimes gradle JVM will run out of memory if we keep the daemon running
   # it is better to not keep a daemon running
@@ -158,15 +160,23 @@ endif()
 message(STATUS "GRADLE_ARGS: ${GRADLE_ARGS}")
 add_custom_command(TARGET onnxruntime_extensions4j_jni POST_BUILD COMMAND ${GRADLE_EXECUTABLE} ${GRADLE_ARGS} WORKING_DIRECTORY ${JAVA_OUTPUT_TEMP})
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Android")
+if (ANDROID)
   set(ANDROID_PACKAGE_JNILIBS_DIR ${JAVA_OUTPUT_DIR}/android)
   set(ANDROID_PACKAGE_ABI_DIR ${ANDROID_PACKAGE_JNILIBS_DIR}/${ANDROID_ABI})
 
-  # Copy onnxruntime_extensions4j_jni.so for building Android AAR package
+  # Copy onnxruntime_extensions4j_jni.so and ortextensions.so for building Android AAR package and use in NuGet
   add_custom_command(TARGET onnxruntime_extensions4j_jni
     POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory ${ANDROID_PACKAGE_ABI_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
       $<TARGET_FILE:onnxruntime_extensions4j_jni>
       ${ANDROID_PACKAGE_ABI_DIR}/$<TARGET_LINKER_FILE_NAME:onnxruntime_extensions4j_jni>)
+
+  if (_BUILD_SHARED_LIBRARY)
+    add_custom_command(TARGET onnxruntime_extensions4j_jni
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        $<TARGET_FILE:extensions_shared>
+        ${ANDROID_PACKAGE_ABI_DIR}/$<TARGET_LINKER_FILE_NAME:extensions_shared>)
+  endif()
 endif()

--- a/tools/android/build_aar.py
+++ b/tools/android/build_aar.py
@@ -21,13 +21,8 @@ _supported_abis = ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
 _log = get_logger("build_aar")
 
 
-def build_for_abi(build_dir: Path,
-                  config: str,
-                  abi: str,
-                  api_level: int,
-                  sdk_path: Path,
-                  ndk_path: Path,
-                  other_args: List[str]):
+def build_for_abi(
+    build_dir: Path, config: str, abi: str, api_level: int, sdk_path: Path, ndk_path: Path, other_args: List[str]):
     build_cmd = [
         sys.executable,
         str(_repo_dir / "tools" / "build.py"),
@@ -49,13 +44,13 @@ def build_for_abi(build_dir: Path,
 
 
 def do_build_by_mode(output_dir: Path,
-                             config: str,
-                             mode: str,
-                             abis: List[str],
-                             api_level: int,
-                             sdk_path: Path,
-                             ndk_path: Path,
-                             other_args: List[str]):
+                     config: str,
+                     mode: str,
+                     abis: List[str],
+                     api_level: int,
+                     sdk_path: Path,
+                     ndk_path: Path,
+                     other_args: List[str]):
     output_dir = output_dir.resolve()
 
     sdk_path = sdk_path.resolve(strict=True)
@@ -76,7 +71,7 @@ def do_build_by_mode(output_dir: Path,
             jnilibs_dir = base_jnilibs_dir / abi
             jnilibs_dir.mkdir(parents=True, exist_ok=True)
 
-            jnilib_names = ["libonnxruntime_extensions4j_jni.so"]
+            jnilib_names = ["libortextensions.so", "libonnxruntime_extensions4j_jni.so"]
             for jnilib_name in jnilib_names:
                 shutil.copyfile(build_dir / config / "java" / "android" / abi / jnilib_name, jnilibs_dir / jnilib_name)
 
@@ -150,8 +145,8 @@ def parse_args():
         type=str,
         choices=["build_aar", "build_so_only", "pack_aar_only"],
         default="build_aar",
-        help="""Build mode: 
-                'build_aar' builds the AAR package. 
+        help="""Build mode:
+                'build_aar' builds the AAR package.
                 'build_so_only' builds the so libraries.
                 'pack_aar_only' only pack aar from existing so files.
             """,


### PR DESCRIPTION
Link against the shared library in an Android build so libortextensions.so is available for nuget to use. 
Include libortextensions.so in the AAR
Cleanup some misc things. 