### PR TITLE
Handle ONNX 1.14 in test scripts

### DIFF
--- a/onnxruntime_extensions/tools/pre_post_processing/pre_post_processor.py
+++ b/onnxruntime_extensions/tools/pre_post_processing/pre_post_processor.py
@@ -57,10 +57,10 @@ class PrePostProcessor:
         self._post_processing_joins = None  # type: Union[None,List[Tuple[Union[Step, str], int, str]]]
 
         self._inputs = inputs if inputs else []
-        
+
         # preserve outputs from IOMapEntry, avoid it's consumed by the Follow-up steps.
         # we now can support a output value has more than one consumers with IOEntryValuePreserver.
-        # IOEntryValuePreserver will preserve the output value and add it to the graph output 
+        # IOEntryValuePreserver will preserve the output value and add it to the graph output
         # until consumer step is done.
         self.outputs_preserver = []  # type: List[IOEntryValuePreserver]
 
@@ -206,7 +206,7 @@ class PrePostProcessor:
                 io_map.append((step.output_names[step_idx], graph_input))
                 step_graph_outputs.remove((step.output_names[step_idx]))
 
-            # add outputs from previous IoMapEntry producers to maintain them as graph outputs 
+            # add outputs from previous IoMapEntry producers to maintain them as graph outputs
             # until consumed by the final Step that requires them.
             step_graph_outputs += [
                 o.name for o in graph.output if o.name not in step_graph_outputs]
@@ -253,7 +253,8 @@ class PrePostProcessor:
 
         opset_imports = [onnx.helper.make_operatorsetid(domain, opset)
                          for domain, opset in self._custom_op_checker_context.opset_imports.items()]
-        new_model = onnx.helper.make_model(graph, opset_imports=opset_imports)
+        ir_version = onnx.helper.find_min_ir_version_for(opset_imports, ignore_unknown=True)
+        new_model = onnx.helper.make_model(graph, opset_imports=opset_imports, ir_version=ir_version)
 
         onnx.checker.check_model(new_model)
 
@@ -275,7 +276,7 @@ class PrePostProcessor:
                    Can be:
                      A Step instance. This will be implicitly joined to the immediately previous Step if one exists.
                      A tuple of (Step instance, list of IoMapEntry)
-                      The IoMapEntry values are used to manually join an output from a producer Step to an input 
+                      The IoMapEntry values are used to manually join an output from a producer Step to an input
                       of the current Step.
                         In each IoMapEntry, if a step name is provided the producer Step will be searched for in all
                         predecessor steps. It is valid for a post-processor step to consume output from a

--- a/onnxruntime_extensions/tools/pre_post_processing/pre_post_processor.py
+++ b/onnxruntime_extensions/tools/pre_post_processing/pre_post_processor.py
@@ -253,7 +253,10 @@ class PrePostProcessor:
 
         opset_imports = [onnx.helper.make_operatorsetid(domain, opset)
                          for domain, opset in self._custom_op_checker_context.opset_imports.items()]
-        ir_version = onnx.helper.find_min_ir_version_for(opset_imports, ignore_unknown=True)
+        # find_min_ir_version_for doesn't support custom domains until ONNX 1.14 so extract the ONNX opset from the
+        # imports and only pass that in.
+        ir_version = onnx.helper.find_min_ir_version_for([entry for entry in opset_imports
+                                                          if entry.domain == "" or entry.domain == "ai.onnx"])
         new_model = onnx.helper.make_model(graph, opset_imports=opset_imports, ir_version=ir_version)
 
         onnx.checker.check_model(new_model)

--- a/test/data/ppp_vision/create_boxdrawing_model.py
+++ b/test/data/ppp_vision/create_boxdrawing_model.py
@@ -14,7 +14,7 @@ def create_model(output_file: Path, **kwargs):
     """
     Create unit test model. If input is bytes from a jpg we do the following
       - DecodeImage: jpg to BGR
-      - Resize: for simulate fixed input size, 
+      - Resize: for simulate fixed input size,
       - LetterBox: for simulate fixed input size, copy border to fill the rest
       - DrawBoundingBoxes: draw bounding boxes on the image
       - EncodeImage: BGR to png (output format is set in the node)
@@ -61,7 +61,9 @@ def create_model(output_file: Path, **kwargs):
     )
 
     onnx_import = onnx.helper.make_operatorsetid('', onnx_opset)
-    model = onnx.helper.make_model(g, opset_imports=[onnx_import])
+    ir_version = onnx.helper.find_min_ir_version_for([onnx_import])
+    model = onnx.helper.make_model_gen_version(g, opset_imports=[onnx_import], ir_version=ir_version)
+
     new_model = pipeline.run(model)
     new_model.doc_string = "Model for testing drawing box."
     new_model.graph.doc_string = ""  # clear out all the messages from graph merges

--- a/test/data/ppp_vision/create_decode_encode_test_model.py
+++ b/test/data/ppp_vision/create_decode_encode_test_model.py
@@ -48,7 +48,9 @@ def create_model(output_file: Path):
     )
 
     onnx_import = onnx.helper.make_operatorsetid('', onnx_opset)
-    model = onnx.helper.make_model(g, opset_imports=[onnx_import])
+    ir_version = onnx.helper.find_min_ir_version_for([onnx_import])
+    model = onnx.helper.make_model_gen_version(g, opset_imports=[onnx_import], ir_version=ir_version)
+
     new_model = pipeline.run(model)
     new_model.doc_string = "Model for testing DecodeImage and EncodeImage."
     new_model.graph.doc_string = ""  # clear out all the messages from graph merges


### PR DESCRIPTION
Calculate and specify ir_version so we use the oldest possible for maximum compatibility.
Remove requirement for ONNX version < 1.14