### PR TITLE
Move remaining MacOS 12 CI build agents to MacOS 13.

### DIFF
--- a/.pipelines/android_packaging.yml
+++ b/.pipelines/android_packaging.yml
@@ -3,9 +3,7 @@
 jobs:
   - job: AndroidPackaging
     pool:
-      # We need macOS-12 to run the Android emulator for now.
-      # https://github.com/actions/runner-images/issues/7671
-      vmImage: "macOS-12"
+      vmImage: "macOS-13"
     timeoutInMinutes: 120
     variables:
       buildConfig: Release

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -368,9 +368,7 @@ jobs:
   #############
   - job: AndroidPackage
     pool:
-      # We need macOS-12 to run the Android emulator for now.
-      # https://github.com/actions/runner-images/issues/7671
-      vmImage: 'macOS-12'
+      vmImage: 'macOS-13'
     timeoutInMinutes: 120
     steps:
       - task: UsePythonVersion@0

--- a/.pipelines/templates/android-shared-lib-build.yml
+++ b/.pipelines/templates/android-shared-lib-build.yml
@@ -21,9 +21,7 @@ parameters:
 jobs:
   - job: Android_C_API_Packaging_${{ parameters.JobSuffix }}
     pool:
-      # We need macOS-12 to run the Android emulator for now.
-      # https://github.com/actions/runner-images/issues/7671
-      vmImage: "macOS-12"
+      vmImage: "macOS-13"
     timeoutInMinutes: 120
     variables:
       buildConfig: Release

--- a/.pipelines/templates/build-package-for-android-aar.yml
+++ b/.pipelines/templates/build-package-for-android-aar.yml
@@ -40,9 +40,7 @@ stages:
     - Android_C_API_Packaging_armeabi_v7a
     - Android_C_API_Packaging_arm64_v8a
     pool:
-      # We need macOS-12 to run the Android emulator for now.
-      # https://github.com/actions/runner-images/issues/7671
-      vmImage: 'macOS-12'
+      vmImage: 'macOS-13'
     timeoutInMinutes: 120
     variables:
       buildConfig: Release

--- a/tools/utils/android.py
+++ b/tools/utils/android.py
@@ -112,7 +112,7 @@ def start_emulator(
             "-no-boot-anim",
             "-no-window",
             "-gpu",
-            "guest",
+            "swiftshader_indirect",
         ]
         if extra_args is not None:
             emulator_args += extra_args

--- a/tools/utils/android.py
+++ b/tools/utils/android.py
@@ -111,6 +111,8 @@ def start_emulator(
             "-no-audio",
             "-no-boot-anim",
             "-no-window",
+            "-gpu",
+            "guest",
         ]
         if extra_args is not None:
             emulator_args += extra_args


### PR DESCRIPTION
Pass `-gpu swiftshader_indirect` emulator args as a workaround to get Android emulator running on the MacOS 13 hosted agents.

See https://github.com/actions/runner-images/issues/7671