### PR TITLE
Initial BertTokenizer offset mapping implementation

### DIFF
--- a/onnxruntime_extensions/_cuops.py
+++ b/onnxruntime_extensions/_cuops.py
@@ -237,7 +237,8 @@ class BertTokenizer(CustomOp):
         return [
             cls.io_def('input_ids', onnx_proto.TensorProto.INT64, [None]),
             cls.io_def('token_type_ids', onnx_proto.TensorProto.INT64, [None]),
-            cls.io_def('attention_mask', onnx_proto.TensorProto.INT64, [None])
+            cls.io_def('attention_mask', onnx_proto.TensorProto.INT64, [None]),
+            cls.io_def('offset_mapping', onnx.TensorProto.INT64, [None, 2])
         ]
 
     @classmethod

--- a/operators/tokenizer/bert_tokenizer.cc
+++ b/operators/tokenizer/bert_tokenizer.cc
@@ -2,6 +2,8 @@
 
 #include <utility>
 #include <iostream>
+#include <optional>
+#include <list>
 
 BertTokenizerVocab::BertTokenizerVocab(std::string_view vocab) : raw_vocab_(vocab) {
   auto tokens = SplitString(raw_vocab_, "\r\n", true);

--- a/operators/tokenizer/bert_tokenizer.hpp
+++ b/operators/tokenizer/bert_tokenizer.hpp
@@ -10,6 +10,7 @@
 #include "basic_tokenizer.hpp"
 
 #include <unordered_map>
+#include <list>
 
 class BertTokenizerVocab final {
  public:

--- a/operators/tokenizer/bert_tokenizer.hpp
+++ b/operators/tokenizer/bert_tokenizer.hpp
@@ -44,8 +44,9 @@ class WordpieceTokenizer final {
   WordpieceTokenizer(
       std::shared_ptr<BertTokenizerVocab> vocab, ustring unk_token,
       ustring suffix_indicator, int max_input_chars_per_word = 100);
-  std::vector<ustring> Tokenize(const ustring& text);
-  std::vector<ustring> Tokenize(const std::vector<ustring>& tokens);
+  using OffsetMappingType = std::list<std::pair<size_t, size_t>>;
+  std::vector<ustring> Tokenize(const ustring& text, std::list<OffsetMappingType>& offset_map);
+  std::vector<ustring> Tokenize(const std::vector<ustring>& tokens, std::list<OffsetMappingType>& offset_map);
   std::vector<int64_t> Encode(const std::vector<ustring>& tokens);
 
  private:
@@ -64,7 +65,8 @@ class BertTokenizer final {
                 ustring unk_token, ustring sep_token, ustring pad_token, ustring cls_token,
                 ustring mask_token, bool tokenize_chinese_chars, bool strip_accents,
                 ustring suffix_indicator, int32_t max_len, const std::string& truncation_strategy);
-  std::vector<ustring> Tokenize(const ustring& text);
+  using OffsetMappingType = std::list<std::pair<size_t, size_t>>;
+  std::vector<ustring> Tokenize(const ustring& text, std::list<OffsetMappingType>& offset_map);
   std::vector<int64_t> Encode(const std::vector<ustring>& tokens);
 
   void Truncate(std::vector<int64_t>& ids);
@@ -94,7 +96,9 @@ struct KernelBertTokenizer : BaseKernel {
   void Compute(const ortc::Tensor<std::string>& input,
                ortc::Tensor<int64_t>& output,
                ortc::Tensor<int64_t>& output1,
-               ortc::Tensor<int64_t>& output2);
+               ortc::Tensor<int64_t>& output2,
+               std::optional<ortc::Tensor<int64_t>*> offset_mapping);
+  using OffsetMappingType = std::list<std::pair<size_t, size_t>>;
 
  protected:
   std::unique_ptr<BertTokenizer> tokenizer_;
@@ -102,8 +106,10 @@ struct KernelBertTokenizer : BaseKernel {
 
 struct KernelHfBertTokenizer : KernelBertTokenizer {
   KernelHfBertTokenizer(const OrtApi& api, const OrtKernelInfo& info);
+  using OffsetMappingType = std::list<std::pair<size_t, size_t>>;
   void Compute(const ortc::Tensor<std::string>& input,
                ortc::Tensor<int64_t>& output,
                ortc::Tensor<int64_t>& output1,
-               ortc::Tensor<int64_t>& output2);
+               ortc::Tensor<int64_t>& output2,
+               std::optional<ortc::Tensor<int64_t>*> offset_mapping);
 };

--- a/test/test_bert_tokenizer.py
+++ b/test/test_bert_tokenizer.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 import transformers
 from onnxruntime_extensions import PyOrtFunction, BertTokenizer, util
+from transformers import BertTokenizerFast
 
 
 bert_cased_tokenizer = transformers.BertTokenizer(
@@ -33,9 +34,31 @@ def _run_combined_case(input, vocab_path):
     np.testing.assert_array_equal(result[1], expect_result["token_type_ids"])
     np.testing.assert_array_equal(result[2], expect_result["attention_mask"])
 
+def _run_basic_with_offset_check(input, vocab_path):
+    t2stc = PyOrtFunction.from_customop(
+        BertTokenizer, vocab_file=vocab_path, do_lower_case=0, strip_accents=1
+    )
+    result = t2stc([input])
+    expect_result = bert_cased_tokenizer.encode_plus(input)
+    np.testing.assert_array_equal(result[0], expect_result["input_ids"])
+    np.testing.assert_array_equal(result[1], expect_result["token_type_ids"])
+    np.testing.assert_array_equal(result[2], expect_result["attention_mask"])
+    tokenizer = BertTokenizerFast.from_pretrained("bert-base-cased")
+    bert_out = tokenizer(input, return_offsets_mapping=True)
+    np.testing.assert_array_equal(result[3], bert_out['offset_mapping'])
+    print("\nTest sentence: " + str(input))
+    print("HF offset mapping: " + str(bert_out['offset_mapping']))
+    print("EXT offset mapping: ", end='')
+    for row in result[3]:
+        print("(" + str(row[0]) + ", " + str(row[1]) + "), ", end='')
+    print("\n")
+
 
 class TestBertTokenizer(unittest.TestCase):
     def test_text_to_case1(self):
+
+        print("\n\n****** Starting input ids, token type ids, and attention mask tests. ******\n")
+
         _run_basic_case(
             input="Input 'text' must not be empty.",
             vocab_path=util.get_test_data_file("data", "bert_basic_cased_vocab.txt"),
@@ -53,23 +76,43 @@ class TestBertTokenizer(unittest.TestCase):
             input="本想好好的伤感　想放任　但是没泪痕",
             vocab_path=util.get_test_data_file("data", "bert_basic_cased_vocab.txt"),
         )
-        _run_basic_case(
-            input="网 易 云 音 乐",
-            vocab_path=util.get_test_data_file("data", "bert_basic_cased_vocab.txt"),
-        )
-        _run_basic_case(
-            input="cat is playing toys",
-            vocab_path=util.get_test_data_file("data", "bert_basic_cased_vocab.txt"),
-        )
-        _run_basic_case(
-            input="cat isnot playing toyssss",
-            vocab_path=util.get_test_data_file("data", "bert_basic_cased_vocab.txt"),
-        )
         _run_combined_case(
             ["网 易 云 音 乐", "cat isnot playing toyssss"],
             vocab_path=util.get_test_data_file("data", "bert_basic_cased_vocab.txt"),
         )
+        print("\n****** Input ids, token type ids, and attention mask tests complete. ******\n\n\n")
+        print("*** Starting offset mapping tests. ***\n")
 
+        _run_basic_with_offset_check(
+            input="网 易 云 音 乐",
+            vocab_path=util.get_test_data_file("data", "bert_basic_cased_vocab.txt"),
+        )
+        _run_basic_with_offset_check(
+            input="cat is playing toys",
+            vocab_path=util.get_test_data_file("data", "bert_basic_cased_vocab.txt"),
+        )
+        _run_basic_with_offset_check(
+            input="cat isnot playing toyssss",
+            vocab_path=util.get_test_data_file("data", "bert_basic_cased_vocab.txt"),
+        )
+        _run_basic_with_offset_check(
+            input="ah oui on peut parler francais",
+            vocab_path=util.get_test_data_file("data", "bert_basic_cased_vocab.txt"),
+        )
+        _run_basic_with_offset_check(
+            input="und eigentlich auch deutsch",
+            vocab_path=util.get_test_data_file("data", "bert_basic_cased_vocab.txt"),
+        )
+        _run_basic_with_offset_check(
+            input="podemos hablar muchos idiomas",
+            vocab_path=util.get_test_data_file("data", "bert_basic_cased_vocab.txt"),
+        )
+        _run_basic_with_offset_check(
+            input="力",
+            vocab_path=util.get_test_data_file("data", "bert_basic_cased_vocab.txt"),
+        )
+
+        print("\n*** Offset mapping tests complete. ***\n")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Supports most basic sentences in En, Fr, De, Es, Cn, and Jp, given vocab handles tokens. Special or unknown tokens are not supported at the moment, as model training (the common use-case for offset mapping) does not usually include unknown tokens.

Validation:
- [x] Tested against HuggingFace expected offset mapping values.