### PR TITLE
Add perf changes for Bert, CLIP and Roberta with offset mapping

### DIFF
--- a/operators/tokenizer/bert_tokenizer.hpp
+++ b/operators/tokenizer/bert_tokenizer.hpp
@@ -12,6 +12,8 @@
 #include <unordered_map>
 #include <list>
 
+extern bool compute_offset_mapping;
+
 class BertTokenizerVocab final {
  public:
   explicit BertTokenizerVocab(std::string_view vocab);

--- a/operators/tokenizer/bert_tokenizer.hpp
+++ b/operators/tokenizer/bert_tokenizer.hpp
@@ -12,8 +12,6 @@
 #include <unordered_map>
 #include <list>
 
-extern bool compute_offset_mapping;
-
 class BertTokenizerVocab final {
  public:
   explicit BertTokenizerVocab(std::string_view vocab);
@@ -48,8 +46,8 @@ class WordpieceTokenizer final {
       std::shared_ptr<BertTokenizerVocab> vocab, ustring unk_token,
       ustring suffix_indicator, int max_input_chars_per_word = 100);
   using OffsetMappingType = std::list<std::pair<size_t, size_t>>;
-  std::vector<ustring> Tokenize(const ustring& text, std::list<OffsetMappingType>& offset_map);
-  std::vector<ustring> Tokenize(const std::vector<ustring>& tokens, std::list<OffsetMappingType>& offset_map);
+  std::vector<ustring> Tokenize(const ustring& text, std::list<OffsetMappingType>& offset_map, bool compute_offset_mapping);
+  std::vector<ustring> Tokenize(const std::vector<ustring>& tokens, std::list<OffsetMappingType>& offset_map, bool compute_offset_mapping);
   std::vector<int64_t> Encode(const std::vector<ustring>& tokens);
 
  private:
@@ -69,7 +67,7 @@ class BertTokenizer final {
                 ustring mask_token, bool tokenize_chinese_chars, bool strip_accents,
                 ustring suffix_indicator, int32_t max_len, const std::string& truncation_strategy);
   using OffsetMappingType = std::list<std::pair<size_t, size_t>>;
-  std::vector<ustring> Tokenize(const ustring& text, std::list<OffsetMappingType>& offset_map);
+  std::vector<ustring> Tokenize(const ustring& text, std::list<OffsetMappingType>& offset_map, bool compute_offset_mapping);
   std::vector<int64_t> Encode(const std::vector<ustring>& tokens);
 
   void Truncate(std::vector<int64_t>& ids);
@@ -102,6 +100,7 @@ struct KernelBertTokenizer : BaseKernel {
                ortc::Tensor<int64_t>& output2,
                std::optional<ortc::Tensor<int64_t>*> offset_mapping);
   using OffsetMappingType = std::list<std::pair<size_t, size_t>>;
+  bool compute_offset_mapping;
 
  protected:
   std::unique_ptr<BertTokenizer> tokenizer_;

--- a/operators/tokenizer/clip_tokenizer.cc
+++ b/operators/tokenizer/clip_tokenizer.cc
@@ -65,8 +65,10 @@ std::vector<int64_t> KernelClipBpeTokenizer::Tokenize(ustring& input, int64_t ma
     size_t offset = 0;
     OffsetMappingType offset_mapping;
 
-    // Add offset mapping for BOS token
-    offset_mapping.push_back(std::make_pair(0, 0));
+    if (compute_offset_mapping) {
+      // Add offset mapping for BOS token
+      offset_mapping.push_back(std::make_pair(0, 0));
+    }
 
     while (static_cast<int64_t>(res.size()) < max_length) {
       auto [b, tok] = regcmp.GetNextToken();
@@ -74,9 +76,11 @@ std::vector<int64_t> KernelClipBpeTokenizer::Tokenize(ustring& input, int64_t ma
 
       std::string utf8_token = std::string(ustring(tok));
 
-      // Handle special case for offset mapping
-      if (utf8_token.at(0) == ' ') {
-        offset++;
+      if (compute_offset_mapping) {
+        // Handle special case for offset mapping
+        if (utf8_token.at(0) == ' ') {
+          offset++;
+        }
       }
 
       // Whitespace clean
@@ -103,15 +107,21 @@ std::vector<int64_t> KernelClipBpeTokenizer::Tokenize(ustring& input, int64_t ma
         }
 
         res.push_back(p.first);
-        offset_mapping.emplace_back(std::make_pair(offset, ort_extensions::narrow<size_t>(offset + p.second)));
-        offset += p.second;
+
+        if (compute_offset_mapping) {
+          offset_mapping.emplace_back(std::make_pair(offset, ort_extensions::narrow<size_t>(offset + p.second)));
+          offset += p.second;
+        }
       }
     }
-    // Add offset mapping for EOS token
-    offset_mapping.emplace_back(std::make_pair(0, 0));
 
-    // Add offset mappings for input in this instance to list of offset mappings for all inputs
-    offset_map.emplace_back(offset_mapping);
+    if (compute_offset_mapping) {
+      // Add offset mapping for EOS token
+      offset_mapping.emplace_back(std::make_pair(0, 0));
+
+      // Add offset mappings for input in this instance to list of offset mappings for all inputs
+      offset_map.emplace_back(offset_mapping);
+    }
   }
   // Add EOS token to result
   res.push_back(bbpe_tokenizer_->GetEncoding("<|endoftext|>"));
@@ -128,6 +138,13 @@ void KernelClipBpeTokenizer::Compute(const ortc::Tensor<std::string>& input,
   const auto& input_dim = input.Shape();
 
   std::vector<std::vector<int64_t>> tokenize_results;
+
+  // Only compute offset mapping if optional output for it exists.
+  compute_offset_mapping = false;
+  if (offset_mapping.has_value()) {
+    compute_offset_mapping = true;
+  }
+
   for (auto& str : str_input) {
     ustring ustr = ustring(str);
     tokenize_results.emplace_back(Tokenize(ustr, padding_length_ < 0 ? INT64_MAX : padding_length_, offset_map));

--- a/operators/tokenizer/clip_tokenizer.hpp
+++ b/operators/tokenizer/clip_tokenizer.hpp
@@ -10,6 +10,7 @@ struct KernelClipBpeTokenizer : BaseKernel {
                ortc::Tensor<int64_t>& tokenize_output,
                std::optional<ortc::Tensor<int64_t>*> attention_mask,
                std::optional<ortc::Tensor<int64_t>*> offset_mapping);
+  bool compute_offset_mapping;
 
  private:
   using OffsetMappingType = std::list<std::pair<size_t, size_t>>;

--- a/operators/tokenizer/roberta_tokenizer.hpp
+++ b/operators/tokenizer/roberta_tokenizer.hpp
@@ -10,6 +10,7 @@ struct KernelRobertaBpeTokenizer : BaseKernel {
                ortc::Tensor<int64_t>& tokenize_output,
                std::optional<ortc::Tensor<int64_t>*> attention_mask,
                std::optional<ortc::Tensor<int64_t>*> offset_mapping);
+  bool compute_offset_mapping;
 
  private:
   using OffsetMappingType = std::list<std::pair<size_t, size_t>>;


### PR DESCRIPTION
Originally, there were some issues with simply using a C++ tokenizer class variable for skipping offset mapping computations as needed for BertTokenizer, so had to use global variable. CLIP and Roberta tokenizers were fine.