### PR TITLE
Configure header path for SPM build

### DIFF
--- a/includes/onnxruntime_extensions.h
+++ b/includes/onnxruntime_extensions.h
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 #pragma once
+#ifdef SPM_BUILD
 #include "onnxruntime/onnxruntime_c_api.h"
+#else
+#include "onnxruntime_c_api.h"
 
 #ifdef _WIN32
 #define ORTX_EXPORT __declspec(dllexport)

--- a/includes/onnxruntime_extensions.h
+++ b/includes/onnxruntime_extensions.h
@@ -8,8 +8,8 @@
 // The reason why we need a prefix is that when Xcode includes the package it copies it to an internally generated path with 
 // the package name as a prefix. 
 // And we don't have control over the include paths when that happens in the user's iOS app. 
-// The Only way we find to make the include path work automatically for now.
-#ifdef SPM_BUILD
+// The only way we found to make the include path work automatically for now.
+#ifdef ORT_SWIFT_PACKAGE_MANAGER_BUILD
 #include "onnxruntime/onnxruntime_c_api.h"
 #else
 #include "onnxruntime_c_api.h"

--- a/includes/onnxruntime_extensions.h
+++ b/includes/onnxruntime_extensions.h
@@ -6,6 +6,7 @@
 #include "onnxruntime/onnxruntime_c_api.h"
 #else
 #include "onnxruntime_c_api.h"
+#endif
 
 #ifdef _WIN32
 #define ORTX_EXPORT __declspec(dllexport)

--- a/includes/onnxruntime_extensions.h
+++ b/includes/onnxruntime_extensions.h
@@ -2,6 +2,13 @@
 // Licensed under the MIT License.
 
 #pragma once
+
+// Note: The following include path is used for building Swift Package Manager support for ORT Extensions.
+// The macro is defined in cxxSettings config in Package.swift.
+// The reason why we need a prefix is that when Xcode includes the package it copies it to an internally generated path with 
+// the package name as a prefix. 
+// And we don't have control over the include paths when that happens in the user's iOS app. 
+// The Only way we find to make the include path work automatically for now.
 #ifdef SPM_BUILD
 #include "onnxruntime/onnxruntime_c_api.h"
 #else

--- a/includes/onnxruntime_extensions.h
+++ b/includes/onnxruntime_extensions.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "onnxruntime_c_api.h"
+#include "onnxruntime/onnxruntime_c_api.h"
 
 #ifdef _WIN32
 #define ORTX_EXPORT __declspec(dllexport)


### PR DESCRIPTION
Add ifdef for swift package manager support.

It requires a prefix for headers searching path.

Similarly as what we do for ORT C headers