### PR TITLE
Android fixes/improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -625,6 +625,12 @@ if(OCOS_ENABLE_GPT2_TOKENIZER OR OCOS_ENABLE_WORDPIECE_TOKENIZER)
   list(APPEND ocos_libraries nlohmann_json::nlohmann_json)
 endif()
 
+# If building a shared library we can't throw an internal exception type across the library boundary as the type
+# will be unknown.
+if(NOT OCOS_ENABLE_STATIC_LIB)
+  list(APPEND OCOS_COMPILE_DEFINITIONS OCOS_SHARED_LIBRARY)
+endif()
+
 target_include_directories(noexcep_operators PUBLIC ${GSL_INCLUDE_DIR})
 list(APPEND ocos_libraries Microsoft.GSL::GSL)
 
@@ -678,18 +684,16 @@ endif()
 
 if(OCOS_ENABLE_AZURE)
   if (ANDROID)
-    # find_package doesn't work for nghttp2 so manually add the path and lib name
-    # target_link_directories(ocos_operators PUBLIC ${NGHTTP2_ROOT_DIR}/lib)
+    # If using static curl/openssl we need these
+    # target_include_directories(ocos_operators PUBLIC ${OPENSSL_ROOT_DIR}/include)
+    # target_include_directories(ocos_operators PUBLIC ${CURL_ROOT_DIR}/include)
+    # target_link_directories(ocos_operators PUBLIC ${OPENSSL_ROOT_DIR}/lib)
+    # target_link_directories(ocos_operators PUBLIC ${CURL_ROOT_DIR}/lib)
+    # target_link_libraries(ocos_operators PUBLIC curl crypto ssl)
 
-    # if using static curl/openssl we need to manually specify these things instead of using find_package values
-    # target_link_libraries(ocos_operators PUBLIC CURL::libcurl OpenSSL::Crypto OpenSSL::SSL) # nghttp2)
-    target_include_directories(ocos_operators PUBLIC ${OPENSSL_ROOT_DIR}/include)
-    target_include_directories(ocos_operators PUBLIC ${CURL_ROOT_DIR}/include)
-    target_link_directories(ocos_operators PUBLIC ${OPENSSL_ROOT_DIR}/lib)
-    target_link_directories(ocos_operators PUBLIC ${CURL_ROOT_DIR}/lib)
-    target_link_libraries(ocos_operators PUBLIC curl crypto ssl) # nghttp2)
-  elseif(IOS)
-    # TODO
+    # dynamic curl/openssl uses these
+    # the find_package calls were made immediately after `include(curl)` so we know CURL and OpenSSL are available.
+    target_link_libraries(ocos_operators PUBLIC CURL::libcurl OpenSSL::Crypto OpenSSL::SSL)
   else()
     # we need files from the triton client (e.g. curl header on linux) to be available for the ocos_operators build.
     # add a dependency so the fetch and build of triton happens first.
@@ -702,7 +706,6 @@ if(OCOS_ENABLE_AZURE)
     if (WIN32)
       # As per https://curl.se/docs/faq.html#Link_errors_when_building_libcur we need to set CURL_STATICLIB.
       target_compile_definitions(ocos_operators PRIVATE CURL_STATICLIB)
-
       target_include_directories(ocos_operators PUBLIC ${VCPKG_SRC}/installed/${vcpkg_triplet}/include)
 
       if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -757,6 +760,11 @@ target_link_libraries(ortcustomops PUBLIC ocos_operators)
 if(_BUILD_SHARED_LIBRARY)
   file(GLOB shared_TARGET_SRC "shared/*.cc" "shared/*.h" "shared/*.def")
   add_library(extensions_shared SHARED ${shared_TARGET_SRC})
+
+  # TODO: Need to propagate OCOS_SHARED_LIBRARY if set.
+  # Could manually do that if using OCOS_COMPILE_DEFINITIONS is too much
+  target_compile_definitions(extensions_shared PRIVATE ${OCOS_COMPILE_DEFINITIONS})
+
   source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${shared_TARGET_SRC})
   standardize_output_folder(extensions_shared)
 
@@ -764,7 +772,7 @@ if(_BUILD_SHARED_LIBRARY)
     set_property(TARGET extensions_shared APPEND_STRING PROPERTY LINK_FLAGS "-Wl,-s -Wl,--version-script -Wl,${PROJECT_SOURCE_DIR}/shared/ortcustomops.ver")
   endif()
 
-  target_include_directories(extensions_shared PUBLIC "$<TARGET_PROPERTY:ortcustomops,INTERFACE_INCLUDE_DIRECTORIES>")
+  target_include_directories(extensions_shared PUBLIC $<TARGET_PROPERTY:ortcustomops,INTERFACE_INCLUDE_DIRECTORIES>)
   target_link_libraries(extensions_shared PRIVATE ortcustomops)
   set_target_properties(extensions_shared PROPERTIES OUTPUT_NAME "ortextensions")
   if(MSVC AND ocos_target_platform MATCHES "x86|x64")
@@ -824,17 +832,20 @@ if(OCOS_ENABLE_CTEST)
   set(TEST_SRC_DIR ${PROJECT_SOURCE_DIR}/test)
   message(STATUS "Fetch googletest")
   include(googletest)
+
+  # -- static test --
   file(GLOB static_TEST_SRC "${TEST_SRC_DIR}/static_test/*.cc")
   add_executable(ocos_test ${static_TEST_SRC})
   standardize_output_folder(ocos_test)
   target_link_libraries(ocos_test PRIVATE gtest_main ocos_operators ${ocos_libraries})
   add_test(NAME ocos_test COMMAND $<TARGET_FILE:ocos_test>)
 
+  # -- shared test (needs onnxruntime) --
   SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
   find_library(ONNXRUNTIME onnxruntime HINTS "${ONNXRUNTIME_LIB_DIR}")
 
   if(ONNXRUNTIME-NOTFOUND)
-    message(WARNING "The prebuilt onnxruntime libraries directory cannot found (via ONNXRUNTIME_LIB_DIR), the extensions_test will be skipped.")
+    message(WARNING "The prebuilt onnxruntime libraries directory was not found (via ONNXRUNTIME_LIB_DIR), the extensions_test will be skipped.")
   else()
     set(LINUX_CC_FLAGS "")
 
@@ -845,18 +856,27 @@ if(OCOS_ENABLE_CTEST)
 
     file(GLOB shared_TEST_SRC "${TEST_SRC_DIR}/shared_test/*.cc" "${TEST_SRC_DIR}/shared_test/*.hpp")
     add_executable(extensions_test ${shared_TEST_SRC})
+
+    # TODO: This is required to use the ORT C++ API with delayed init which must be done conditionally using
+    # ifdef OCOS_BUILD_SHARED in RegisterCustomOps and where onnxruntime_cxx_api.h is included .
+    # ---
+    # We have to remove the OCOS_BUILD_SHARED when building the test code. It is used to delay population of the
+    # ORT api pointer until RegisterCustomOps is called, but the test code needs to create an ORT env which requires
+    # the pointer to exist.
+    # set(test_compile_definitions ${OCOS_COMPILE_DEFINITIONS})
+    # remove(test_compile_definitions "OCOS_SHARED_LIBRARY")
+    # target_compile_definitions(extensions_test PUBLIC ${test_compile_definitions})
     target_compile_definitions(extensions_test PUBLIC ${OCOS_COMPILE_DEFINITIONS})
 
     standardize_output_folder(extensions_test)
-    target_include_directories(extensions_test PRIVATE ${spm_INCLUDE_DIRS}
-      "$<TARGET_PROPERTY:extensions_shared,INTERFACE_INCLUDE_DIRECTORIES>")
 
-    if(ONNXRUNTIME_LIB_DIR)
-      target_link_directories(extensions_test PRIVATE ${ONNXRUNTIME_LIB_DIR})
-    endif()
+    target_include_directories(extensions_test PRIVATE
+      ${spm_INCLUDE_DIRS}
+      $<TARGET_PROPERTY:extensions_shared,INTERFACE_INCLUDE_DIRECTORIES>)
 
-    target_link_libraries(extensions_test PRIVATE ocos_operators extensions_shared onnxruntime gtest_main gmock_main
-                          ${ocos_libraries} ${LINUX_CC_FLAGS})
+    target_link_directories(extensions_test PRIVATE ${ONNXRUNTIME_LIB_DIR})
+    target_link_libraries(extensions_test PRIVATE extensions_shared ${ocos_libraries} onnxruntime
+                                                  gtest_main gmock_main ${LINUX_CC_FLAGS})
 
     # Copy ONNXRuntime DLLs into bin folder for testing on Windows platform
     if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,7 +626,7 @@ if(OCOS_ENABLE_GPT2_TOKENIZER OR OCOS_ENABLE_WORDPIECE_TOKENIZER)
 endif()
 
 # If building a shared library we can't throw an internal exception type across the library boundary as the type
-# will be unknown.
+# will be unknown. Set a compile definition so the code can adjust to the build type.
 if(NOT OCOS_ENABLE_STATIC_LIB)
   list(APPEND OCOS_COMPILE_DEFINITIONS OCOS_SHARED_LIBRARY)
 endif()
@@ -761,8 +761,8 @@ if(_BUILD_SHARED_LIBRARY)
   file(GLOB shared_TARGET_SRC "shared/*.cc" "shared/*.h" "shared/*.def")
   add_library(extensions_shared SHARED ${shared_TARGET_SRC})
 
-  # TODO: Need to propagate OCOS_SHARED_LIBRARY if set.
-  # Could manually do that if using OCOS_COMPILE_DEFINITIONS is too much
+  # We need to propagate OCOS_SHARED_LIBRARY if set. 
+  # could specifically add that if using OCOS_COMPILE_DEFINITIONS is too much.
   target_compile_definitions(extensions_shared PRIVATE ${OCOS_COMPILE_DEFINITIONS})
 
   source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${shared_TARGET_SRC})
@@ -857,7 +857,7 @@ if(OCOS_ENABLE_CTEST)
     file(GLOB shared_TEST_SRC "${TEST_SRC_DIR}/shared_test/*.cc" "${TEST_SRC_DIR}/shared_test/*.hpp")
     add_executable(extensions_test ${shared_TEST_SRC})
 
-    # TODO: This is required to use the ORT C++ API with delayed init which must be done conditionally using
+    # FUTURE: This is required to use the ORT C++ API with delayed init which must be done conditionally using
     # ifdef OCOS_BUILD_SHARED in RegisterCustomOps and where onnxruntime_cxx_api.h is included .
     # ---
     # We have to remove the OCOS_BUILD_SHARED when building the test code. It is used to delay population of the
@@ -874,7 +874,10 @@ if(OCOS_ENABLE_CTEST)
       ${spm_INCLUDE_DIRS}
       $<TARGET_PROPERTY:extensions_shared,INTERFACE_INCLUDE_DIRECTORIES>)
 
-    target_link_directories(extensions_test PRIVATE ${ONNXRUNTIME_LIB_DIR})
+    if(ONNXRUNTIME_LIB_DIR)
+      target_link_directories(extensions_test PRIVATE ${ONNXRUNTIME_LIB_DIR})
+    endif()
+
     target_link_libraries(extensions_test PRIVATE extensions_shared ${ocos_libraries} onnxruntime
                                                   gtest_main gmock_main ${LINUX_CC_FLAGS})
 

--- a/cmake/ext_java.cmake
+++ b/cmake/ext_java.cmake
@@ -190,4 +190,20 @@ if (ANDROID)
         $<TARGET_FILE:extensions_shared>
         ${ANDROID_PACKAGE_ABI_DIR}/$<TARGET_LINKER_FILE_NAME:extensions_shared>)
   endif()
+
+  if (OCOS_ENABLE_AZURE)
+    add_custom_command(TARGET onnxruntime_extensions4j_jni
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different 
+        $<TARGET_FILE:OpenSSL::Crypto>
+        ${ANDROID_PACKAGE_ABI_DIR}/$<TARGET_LINKER_FILE_NAME:OpenSSL::Crypto>
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different 
+        $<TARGET_FILE:OpenSSL::SSL>
+        ${ANDROID_PACKAGE_ABI_DIR}/$<TARGET_LINKER_FILE_NAME:OpenSSL::SSL>
+      # not sure why but we need to use the library name directly for curl instead of CURL::libcurl
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different 
+        ${CURL_ROOT_DIR}/lib/libcurl.so
+        ${ANDROID_PACKAGE_ABI_DIR}/libcurl.so
+    )
+  endif()
 endif()

--- a/includes/exceptions.h
+++ b/includes/exceptions.h
@@ -23,7 +23,6 @@
 
 namespace OrtW {
 
-#if !defined(OCOS_SHARED_LIBRARY)
 // All C++ methods that can fail will throw an exception of this type
 struct Exception : std::exception {
   Exception(std::string message, OrtErrorCode code) : message_{std::move(message)}, code_{code} {}
@@ -35,7 +34,6 @@ struct Exception : std::exception {
   std::string message_;
   OrtErrorCode code_;
 };
-#endif 
 
 // helper that outputs an error message in a platform aware manner
 // Usages:

--- a/includes/exceptions.h
+++ b/includes/exceptions.h
@@ -42,6 +42,9 @@ struct Exception : std::exception {
 inline void LogError(const ORTCHAR_T* file, int line, const char* msg) {
 #if defined(__ANDROID__)
   __android_log_print(ANDROID_LOG_ERROR, "onnxruntime-extensions", "Error in %s line %d: %s", file, line, msg);
+#elif defined(_WIN32)
+  // need to use wcerr as ORTCHAR_T is wchar_t on Windows
+  std::wcerr << "Error in " << file << " line " << line << ": " << msg << std::endl;
 #else
   std::cerr << "Error in " << file << " line " << line << ": " << msg << std::endl;
 #endif
@@ -75,7 +78,7 @@ inline void LogError(const ORTCHAR_T* file, int line, const char* msg) {
     std::string msg(msg_in);                                               \
     OrtW::LogError(ORT_FILE, __LINE__, msg.c_str());                       \
     throw std::runtime_error((std::to_string(code) + ": " + msg).c_str()); \
-  } while(false)
+  } while (false)
 #else
 #define ORTX_CXX_API_THROW(msg, code) \
   throw std::runtime_error((std::to_string(code) + ": " + msg).c_str())

--- a/includes/exceptions.h
+++ b/includes/exceptions.h
@@ -35,7 +35,7 @@ struct Exception : std::exception {
   std::string message_;
   OrtErrorCode code_;
 };
-#endif
+#endif 
 
 // helper that outputs an error message in a platform aware manner
 // Usages:

--- a/includes/exceptions.h
+++ b/includes/exceptions.h
@@ -3,20 +3,27 @@
 
 #pragma once
 
-#if defined(OCOS_NO_EXCEPTIONS) || defined(OCOS_PREVENT_EXCEPTION_PROPAGATION)
 #if defined(__ANDROID__)
 #include <android/log.h>
 #else
 #include <iostream>
 #endif
-#endif
 
 #include <stdexcept>
 
+// TODO: We need to do manual init in RegisterCustomOps if we want to use the ORT C++ API
+// #ifdef OCOS_SHARED_LIBRARY
+//   #define ORT_API_MANUAL_INIT
+//   #include "onnxruntime_cxx_api.h"
+//   #undef ORT_API_MANUAL_INIT
+// #else
+//   #include "onnxruntime_cxx_api.h"
+// #endif
 #include "onnxruntime_c_api.h"
 
 namespace OrtW {
 
+#if !defined(OCOS_SHARED_LIBRARY)
 // All C++ methods that can fail will throw an exception of this type
 struct Exception : std::exception {
   Exception(std::string message, OrtErrorCode code) : message_{std::move(message)}, code_{code} {}
@@ -28,22 +35,25 @@ struct Exception : std::exception {
   std::string message_;
   OrtErrorCode code_;
 };
+#endif
 
-#if defined(OCOS_NO_EXCEPTIONS) || defined(OCOS_PREVENT_EXCEPTION_PROPAGATION)
-inline void PrintFinalMessage(const char* file, int line, const char* msg) {
+// helper that outputs an error message in a platform aware manner
+// Usages:
+//  - logging exception message when they may not propagate up
+//  - logging failure when using the ORT logger
+inline void LogError(const ORTCHAR_T* file, int line, const char* msg) {
 #if defined(__ANDROID__)
-  __android_log_print(ANDROID_LOG_ERROR, "onnxruntime-extensions", "Exception in %s line %d: %s", file, line, msg);
+  __android_log_print(ANDROID_LOG_ERROR, "onnxruntime-extensions", "Error in %s line %d: %s", file, line, msg);
 #else
-  std::cerr << "Exception in " << file << " line " << line << ": " << msg << std::endl;
+  std::cerr << "Error in " << file << " line " << line << ": " << msg << std::endl;
 #endif
 }
-#endif
 
 #ifdef OCOS_NO_EXCEPTIONS
-#define ORTX_CXX_API_THROW(string, code)                                               \
-  do {                                                                                 \
-    OrtW::PrintFinalMessage(__FILE__, __LINE__, OrtW::Exception(string, code).what()); \
-    abort();                                                                           \
+#define ORTX_CXX_API_THROW(msg, code)                                      \
+  do {                                                                     \
+    OrtW::LogError(ORT_FILE, __LINE__, OrtW::Exception(msg, code).what()); \
+    abort();                                                               \
   } while (false)
 
 #define OCOS_TRY if (true)
@@ -54,8 +64,28 @@ inline void PrintFinalMessage(const char* file, int line, const char* msg) {
 // a lambda function. otherwise the exception referred will be undefined and cause build break
 #define OCOS_HANDLE_EXCEPTION(func)
 #else
-#define ORTX_CXX_API_THROW(string, code) \
-  throw OrtW::Exception(string, code)
+
+// if this is a shared library we need to throw a known exception type as onnxruntime will not know about
+// OrtW::Exception.
+#ifdef OCOS_SHARED_LIBRARY
+#if defined(__ANDROID__)
+// onnxruntime and extensions are built with a static libc++ so each has a different definition of
+// std::runtime_error, so the ORT output from catching this exception will be 'unknown exception' and the error
+// message is lost. log it first so at least it's somewhere
+#define ORTX_CXX_API_THROW(msg_in, code)                                   \
+  do {                                                                     \
+    std::string msg(msg_in);                                               \
+    OrtW::LogError(ORT_FILE, __LINE__, msg.c_str());                       \
+    throw std::runtime_error((std::to_string(code) + ": " + msg).c_str()); \
+  } while(false)
+#else
+#define ORTX_CXX_API_THROW(msg, code) \
+  throw std::runtime_error((std::to_string(code) + ": " + msg).c_str())
+#endif
+#else
+#define ORTX_CXX_API_THROW(msg, code) \
+  throw OrtW::Exception(msg, code)
+#endif
 
 #define OCOS_TRY try
 #define OCOS_CATCH(x) catch (x)
@@ -79,13 +109,13 @@ inline void ThrowOnError(const OrtApi& ort, OrtStatus* status) {
 // if exceptions are disabled (a 3rd party library could throw so we need to handle that)
 // or we're preventing exception propagation, log and abort().
 #if defined(OCOS_NO_EXCEPTIONS) || defined(OCOS_PREVENT_EXCEPTION_PROPAGATION)
-#define OCOS_API_IMPL_END                                     \
-  }                                                           \
-  OCOS_CATCH(const std::exception& ex) {                      \
-    OCOS_HANDLE_EXCEPTION([&]() {                             \
-      OrtW::PrintFinalMessage(__FILE__, __LINE__, ex.what()); \
-      abort();                                                \
-    });                                                       \
+#define OCOS_API_IMPL_END                            \
+  }                                                  \
+  OCOS_CATCH(const std::exception& ex) {             \
+    OCOS_HANDLE_EXCEPTION([&]() {                    \
+      OrtW::LogError(ORT_FILE, __LINE__, ex.what()); \
+      abort();                                       \
+    });                                              \
   }
 #else
 // rethrow.

--- a/includes/exceptions.h
+++ b/includes/exceptions.h
@@ -11,7 +11,7 @@
 
 #include <stdexcept>
 
-// TODO: We need to do manual init in RegisterCustomOps if we want to use the ORT C++ API
+// FUTURE: We need to do manual init in RegisterCustomOps to use the ORT C++ API
 // #ifdef OCOS_SHARED_LIBRARY
 //   #define ORT_API_MANUAL_INIT
 //   #include "onnxruntime_cxx_api.h"

--- a/includes/ocos.h
+++ b/includes/ocos.h
@@ -20,24 +20,9 @@ extern "C" bool ORT_API_CALL AddExternalCustomOp(const OrtCustomOp* c_op);
 constexpr const char* c_OpDomain = "ai.onnx.contrib";
 constexpr const char* c_ComMsExtOpDomain = "com.microsoft.extensions";
 
-// for use in code of classes that derive from BaseKernel to log via the ORT logger 
-// requires the logger_ variable to exist and be valid.
-// severity is an ORT_LOGGING_LEVEL_... value (e.g. ORT_LOGGING_LEVEL_WARNING)
-#define KERNEL_LOG(severity, msg)                                                                   \
-  do {                                                                                              \
-    auto status = api_.Logger_LogMessage(logger_, severity, msg, ORT_FILE, __LINE__, __FUNCTION__); \
-    if (status != nullptr) {                                                                        \
-      OrtW::LogError(ORT_FILE, __LINE__, api_.GetErrorMessage(status));                             \
-      api_.ReleaseStatus(status);                                                                   \
-    }                                                                                               \
-  } while (false)
-
 struct BaseKernel {
-  BaseKernel(const OrtApi& api, const OrtKernelInfo& info) noexcept : api_(api), info_(info), ort_(api_) {
-    // Get logger from the OrtKernelInfo should never fail. The logger comes from the EP, and is set when the EP is
-    // registered in the InferenceSession, which happens before model load.
-    auto status = api.KernelInfo_GetLogger(&info, &logger_);
-    assert(status == nullptr);
+  BaseKernel(const OrtApi& api, const OrtKernelInfo& info) noexcept
+      : api_(api), info_(info), ort_(api_) {
   }
 
   template <class T>
@@ -59,7 +44,6 @@ struct BaseKernel {
   const OrtApi& api_;
   OrtW::CustomOpApi ort_;
   const OrtKernelInfo& info_;
-  const OrtLogger* logger_{nullptr};
 };
 
 struct OrtTensorDimensions : std::vector<int64_t> {

--- a/operators/azure/azure_triton_invoker.cc
+++ b/operators/azure/azure_triton_invoker.cc
@@ -98,7 +98,7 @@ int8_t* CreateNonStrTensor(const std::string& data_type,
 
 #define CHECK_TRITON_ERR(ret, msg)                                                    \
   if (!ret.IsOk()) {                                                                  \
-    return ORTX_CXX_API_THROW("Triton err: " + ret.Message(), ORT_RUNTIME_EXCEPTION); \
+    ORTX_CXX_API_THROW("Triton err: " + ret.Message(), ORT_RUNTIME_EXCEPTION); \
   }
 
 void AzureTritonInvoker::Compute(const ortc::Variadic& inputs, ortc::Variadic& outputs) const {

--- a/operators/azure/azure_triton_invoker.cc
+++ b/operators/azure/azure_triton_invoker.cc
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "azure_triton_invoker.hpp"
+#include "string_utils.h"
 
 ////////////////////// AzureTritonInvoker //////////////////////
 
@@ -96,9 +97,9 @@ int8_t* CreateNonStrTensor(const std::string& data_type,
   }
 }
 
-#define CHECK_TRITON_ERR(ret, msg)                                                    \
-  if (!ret.IsOk()) {                                                                  \
-    ORTX_CXX_API_THROW("Triton err: " + ret.Message(), ORT_RUNTIME_EXCEPTION); \
+#define CHECK_TRITON_ERR(ret, msg)                                                                          \
+  if (!ret.IsOk()) {                                                                                        \
+    ORTX_CXX_API_THROW(MakeString("Error: ", msg, ", Triton err: ", ret.Message()), ORT_RUNTIME_EXCEPTION); \
   }
 
 void AzureTritonInvoker::Compute(const ortc::Variadic& inputs, ortc::Variadic& outputs) const {
@@ -121,7 +122,7 @@ void AzureTritonInvoker::Compute(const ortc::Variadic& inputs, ortc::Variadic& o
     tc::InferInput* triton_input = {};
     std::string triton_data_type = MapDataType(inputs[ith_input]->Type());
     if (triton_data_type.empty()) {
-      ORTX_CXX_API_THROW("unknow onnx data type", ORT_RUNTIME_EXCEPTION);
+      ORTX_CXX_API_THROW("unknown onnx data type", ORT_RUNTIME_EXCEPTION);
     }
 
     err = tc::InferInput::Create(&triton_input, property_names[ith_input], inputs[ith_input]->Shape(),

--- a/operators/azure/cloud_base_kernel.cc
+++ b/operators/azure/cloud_base_kernel.cc
@@ -6,7 +6,9 @@
 #include <sstream>
 
 namespace ort_extensions {
-CloudBaseKernel::CloudBaseKernel(const OrtApi& api, const OrtKernelInfo& info) : BaseKernel(api, info) {
+CloudBaseKernel::CloudBaseKernel(const OrtApi& api, const OrtKernelInfo& info)
+    : BaseKernel(api, info),
+      logger_(api, info) {
   auto ver = GetActiveOrtAPIVersion();
   if (ver < kMinimumSupportedOrtVersion) {
     ORTX_CXX_API_THROW("Azure custom operators require onnxruntime version >= 1.14", ORT_RUNTIME_EXCEPTION);

--- a/operators/azure/cloud_base_kernel.hpp
+++ b/operators/azure/cloud_base_kernel.hpp
@@ -6,6 +6,8 @@
 #include "ocos.h"
 #include "gsl/span"
 
+#include "azure/logger.hpp"
+
 namespace ort_extensions {
 
 /// <summary>
@@ -49,6 +51,9 @@ class CloudBaseKernel : public BaseKernel {
   /// <returns>Request property name the input is providing data for.</returns>
   static std::string GetPropertyNameFromInputName(const std::string& input_name);
 
+  using TLogger = has_Logger_LogMessage<OrtApi>::type;
+  const Logger<TLogger> GetLogger() const { return logger_; }
+
  private:
   std::string model_uri_;
   std::string model_name_;
@@ -58,6 +63,8 @@ class CloudBaseKernel : public BaseKernel {
   std::vector<std::string> input_names_;
   std::vector<std::string> property_names_;
   std::vector<std::string> output_names_;
+
+  Logger<TLogger> logger_;
 };
 
 }  // namespace ort_extensions

--- a/operators/azure/cloud_base_kernel.hpp
+++ b/operators/azure/cloud_base_kernel.hpp
@@ -51,8 +51,7 @@ class CloudBaseKernel : public BaseKernel {
   /// <returns>Request property name the input is providing data for.</returns>
   static std::string GetPropertyNameFromInputName(const std::string& input_name);
 
-  using TLogger = has_Logger_LogMessage<OrtApi>::type;
-  const Logger<TLogger> GetLogger() const { return logger_; }
+  const Logger GetLogger() const { return logger_; }
 
  private:
   std::string model_uri_;
@@ -64,7 +63,7 @@ class CloudBaseKernel : public BaseKernel {
   std::vector<std::string> property_names_;
   std::vector<std::string> output_names_;
 
-  Logger<TLogger> logger_;
+  Logger logger_;
 };
 
 }  // namespace ort_extensions

--- a/operators/azure/curl_invoker.cc
+++ b/operators/azure/curl_invoker.cc
@@ -38,6 +38,10 @@ CurlHandler::CurlHandler(WriteCallBack callback) : curl_(curl_easy_init(), curl_
   curl_easy_setopt(curl, CURLOPT_FTP_SKIP_PASV_IP, 1L);      // what does this have to do with http requests?
   curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, callback);
+  
+  // TEMP
+  // https://stackoverflow.com/questions/25253823/how-to-make-ssl-peer-verify-work-on-android
+  // curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
 
   // should this be configured via a node attribute? different endpoints may have different timeouts
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, 15);
@@ -79,7 +83,10 @@ void CurlInvoker::ExecuteRequest(CurlHandler& curl_handler) const {
   // this is where we could add any logic required to make the request async or maybe handle retries/cancellation.
   auto curl_ret = curl_handler.Perform();
   if (CURLE_OK != curl_ret) {
-    ORTX_CXX_API_THROW(curl_easy_strerror(curl_ret), ORT_FAIL);
+    const char* err = curl_easy_strerror(curl_ret);
+    KERNEL_LOG(ORT_LOGGING_LEVEL_ERROR, ("Curl error (CURLcode=" + std::to_string(curl_ret) + "): " + err).c_str());
+ 
+    ORTX_CXX_API_THROW(err, ORT_FAIL);
   }
 }
 }  // namespace ort_extensions

--- a/operators/azure/curl_invoker.cc
+++ b/operators/azure/curl_invoker.cc
@@ -38,10 +38,6 @@ CurlHandler::CurlHandler(WriteCallBack callback) : curl_(curl_easy_init(), curl_
   curl_easy_setopt(curl, CURLOPT_FTP_SKIP_PASV_IP, 1L);      // what does this have to do with http requests?
   curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, callback);
-  
-  // TEMP
-  // https://stackoverflow.com/questions/25253823/how-to-make-ssl-peer-verify-work-on-android
-  // curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
 
   // should this be configured via a node attribute? different endpoints may have different timeouts
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, 15);

--- a/operators/azure/logger.hpp
+++ b/operators/azure/logger.hpp
@@ -5,7 +5,17 @@
 
 #include "ocos.h"
 
+// may or may not be available depending on the ORT version
+struct OrtLogger;
+
 namespace ort_extensions {
+// Disable GCC 'ignoring attributes on template argument' warning due to Logger_LogMessage using
+// `__attribute__((warn_unused_result))`.
+// The template here is about whether Logger_LogMessage exists or not, so the attribute is irrelevant.
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
 
 template <class, class = void>
 struct has_Logger_LogMessage : std::false_type {};
@@ -14,58 +24,91 @@ struct has_Logger_LogMessage : std::false_type {};
 template <class T>
 struct has_Logger_LogMessage<T, std::void_t<decltype(&T::Logger_LogMessage)>> : std::true_type {};
 
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
 // for use in implementation of classes that have a GetLogger() member that returns an ort_extensions::Logger<T>.
 // severity is an ORT_LOGGING_LEVEL_... value (e.g. ORT_LOGGING_LEVEL_WARNING)
+#ifdef _WIN32
 #define KERNEL_LOG(severity, msg) \
-  GetLogger().LogMessage(severity, ORT_FILE, __LINE__, __FUNCTION__, msg)
+  GetLogger().LogMessage(severity, __FILEW__, __LINE__, __FUNCTION__, msg)
+#else
+#define KERNEL_LOG(severity, msg) \
+  GetLogger().LogMessage(severity, __FILE__, __LINE__, __FUNCTION__, msg)
+#endif
 
-// Logging wrapper to use the ORT logger if available, otherwise fallback to default logging.
-class Logger {
- public:
-  Logger(const OrtApi& api, const OrtKernelInfo& info) noexcept
-      : api_{api}, api_version_{GetActiveOrtAPIVersion()} {
-    if constexpr (has_Logger_LogMessage<OrtApi>::value) {
-      // Get logger from the OrtKernelInfo should never fail. The logger comes from the EP, and is set when the EP is
-      // registered in the InferenceSession, which happens before model load.
-      const OrtLogger* logger = nullptr;
-      auto status = api.KernelInfo_GetLogger(&info, &logger);
-      assert(status == nullptr);
-      ort_logger_ = logger;  // save in type agnostic member and static_cast to use.
-    }
-  }
-
-  void LogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
-                  const char* func_name, const char* message) const noexcept {
-    if constexpr (has_Logger_LogMessage<OrtApi>::value) {
-      // Logger_LogMessage was added in ORT 1.15
-      if (api_version_ >= 15) {
-        auto status = api_.Logger_LogMessage(static_cast<const OrtLogger*>(ort_logger_), log_severity_level, message,
-                                             file_path, line_number, func_name);
-        if (status == nullptr) {
-          return;
-        }
-
-        // Logger_LogMessage shouldn't fail. log why it did and fall through to use DefaultLogMessage.
-        OrtW::LogError(ORT_FILE, __LINE__, api_.GetErrorMessage(status));
-        api_.ReleaseStatus(status);
-      }
-    }
-
-    // use fallback
-    Logger::DefaultLogMessage(log_severity_level, file_path, line_number, func_name, message);
-  }
-
-  static void DefaultLogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
-                                const char* func_name, const char* message) noexcept {
+struct FallbackLogger {
+  static void LogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
+                         const char* func_name, const char* message) noexcept {
     // hardcoded when using fallback due to old ORT version.
     if (log_severity_level >= ORT_LOGGING_LEVEL_WARNING) {
       OrtW::LogError(file_path, line_number, (std::string(func_name) + ": " + message).c_str());
     }
   }
+};
+
+// implementation for ORT versions < 1.15
+template <class T = OrtApi, bool HasLogger = has_Logger_LogMessage<T>::value>
+struct LoggerImpl {
+  LoggerImpl(const T& api, const OrtKernelInfo& /*info*/) noexcept : api_{api} {
+  }
+
+  void LogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
+                  const char* func_name, const char* message) const noexcept {
+    FallbackLogger::LogMessage(log_severity_level, file_path, line_number, func_name, message);
+  }
+
+  const T& api_;
+};
+
+// implementation for ORT version >= 1.15 where we can use the ORT logger
+template <class T>
+struct LoggerImpl<T, true> {
+  LoggerImpl(const T& api, const OrtKernelInfo& info) noexcept
+      : api_{api}, api_version_{GetActiveOrtAPIVersion()} {
+    // Get logger from the OrtKernelInfo should never fail. The logger comes from the EP, and is set when the EP is
+    // registered in the InferenceSession, which happens before model load.
+    auto status = api_.KernelInfo_GetLogger(&info, &ort_logger_);
+    assert(status == nullptr);
+  }
+
+  void LogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
+                  const char* func_name, const char* message) const noexcept {
+    // Logger_LogMessage was added in ORT 1.15
+    if (api_version_ >= 15) {
+      auto status = api_.Logger_LogMessage(ort_logger_, log_severity_level, message, file_path, line_number, func_name);
+      if (status == nullptr) {
+        return;
+      }
+
+      // Logger_LogMessage shouldn't fail. log why it did and fall through to use DefaultLogMessage.
+      OrtW::LogError(file_path, line_number, api_.GetErrorMessage(status));
+      api_.ReleaseStatus(status);
+    }
+
+    FallbackLogger::LogMessage(log_severity_level, file_path, line_number, func_name, message);
+  }
+
+  // T == OrtApi, but we must use T so it compiles when KernelInfo_GetLogger and Logger_LogMessage are not available
+  const T& api_;
+  const int api_version_;  // runtime API version that RegisterCustomOps was called with
+  const OrtLogger* ort_logger_{nullptr};
+};
+
+// Logging wrapper to use the ORT logger if available, otherwise fallback to default logging.
+class Logger {
+ public:
+  Logger(const OrtApi& api, const OrtKernelInfo& info) noexcept
+      : impl_{api, info} {
+  }
+
+  void LogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
+                  const char* func_name, const char* message) const noexcept {
+    impl_.LogMessage(log_severity_level, file_path, line_number, func_name, message);
+  }
 
  private:
-  const OrtApi& api_;
-  int api_version_{0};               // ORT API version RegisterCustomOps was called with
-  const void* ort_logger_{nullptr};  // OrtLogger if available. Unused otherwise
+  LoggerImpl<OrtApi> impl_;
 };
 }  // namespace ort_extensions

--- a/operators/azure/logger.hpp
+++ b/operators/azure/logger.hpp
@@ -9,6 +9,7 @@
 struct OrtLogger;  // may or may not exist
 
 namespace ort_extensions {
+namespace detail {
 // Disable GCC 'ignoring attributes on template argument' warning due to Logger_LogMessage using
 // `__attribute__((warn_unused_result))`.
 // The template here is about whether Logger_LogMessage exists or not, so the attribute is irrelevant.
@@ -89,7 +90,8 @@ class LoggerImpl {
   int api_version_;                       // runtime ORT API version RegisterCustomOps was called with
   const OrtLogger* ort_logger_{nullptr};  // OrtLogger if available
 };
+}  // namespace detail
 
-using Logger = LoggerImpl<OrtApi>;
+using Logger = detail::LoggerImpl<OrtApi>;
 
 }  // namespace ort_extensions

--- a/operators/azure/logger.hpp
+++ b/operators/azure/logger.hpp
@@ -29,16 +29,6 @@ struct has_Logger_LogMessage<T, std::void_t<decltype(&T::Logger_LogMessage)>> : 
 #pragma GCC diagnostic pop
 #endif
 
-// for use in implementation of classes that have a GetLogger() member that returns an ort_extensions::Logger<T>.
-// severity is an ORT_LOGGING_LEVEL_... value (e.g. ORT_LOGGING_LEVEL_WARNING)
-#ifdef _WIN32
-#define KERNEL_LOG(severity, msg) \
-  GetLogger().LogMessage(severity, __FILEW__, __LINE__, __FUNCTION__, msg)
-#else
-#define KERNEL_LOG(severity, msg) \
-  GetLogger().LogMessage(severity, __FILE__, __LINE__, __FUNCTION__, msg)
-#endif
-
 // Logging wrapper to use the ORT logger if available, otherwise fallback to default logging.
 template <class T>
 class LoggerImpl {
@@ -91,6 +81,16 @@ class LoggerImpl {
   const OrtLogger* ort_logger_{nullptr};  // OrtLogger if available
 };
 }  // namespace detail
+
+// for use in implementation of classes that have a GetLogger() member that returns an ort_extensions::Logger<T>.
+// severity is an ORT_LOGGING_LEVEL_... value (e.g. ORT_LOGGING_LEVEL_WARNING)
+#ifdef _WIN32
+#define KERNEL_LOG(severity, msg) \
+  GetLogger().LogMessage(severity, __FILEW__, __LINE__, __FUNCTION__, msg)
+#else
+#define KERNEL_LOG(severity, msg) \
+  GetLogger().LogMessage(severity, __FILE__, __LINE__, __FUNCTION__, msg)
+#endif
 
 using Logger = detail::LoggerImpl<OrtApi>;
 

--- a/operators/azure/logger.hpp
+++ b/operators/azure/logger.hpp
@@ -10,36 +10,50 @@ namespace ort_extensions {
 template <class, class = void>
 struct has_Logger_LogMessage : std::false_type {};
 
-// Disable GCC 'ignoring attributes on template argument' warning due to Logger_LogMessage using 
-// `__attribute__((warn_unused_result))`. 
-// The template here is about whether the function exists or not so the attribute is irrelevant.
-// FWIW using `[[nodiscard]]` would be fine, but that would require a change to the ORT_MUST_USE_RESULT
-// definition in onnxruntime_c_api.h.
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wignored-attributes"
-#endif
+// check if Logger_LogMessage exists in OrtApi. Available from 1.15 onwards
 template <class T>
 struct has_Logger_LogMessage<T, std::void_t<decltype(&T::Logger_LogMessage)>> : std::true_type {};
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+
 // for use in implementation of classes that have a GetLogger() member that returns an ort_extensions::Logger<T>.
 // severity is an ORT_LOGGING_LEVEL_... value (e.g. ORT_LOGGING_LEVEL_WARNING)
 #define KERNEL_LOG(severity, msg) \
   GetLogger().LogMessage(severity, ORT_FILE, __LINE__, __FUNCTION__, msg)
 
-// Logging wrapper to enable use the ORT logger if available, otherwise fallback to default logging.
-template <typename T = std::false_type>
+// Logging wrapper to use the ORT logger if available, otherwise fallback to default logging.
 class Logger {
  public:
-  Logger(const OrtApi& api, const OrtKernelInfo& /*info*/) noexcept : api_{api} {
+  Logger(const OrtApi& api, const OrtKernelInfo& info) noexcept
+      : api_{api}, api_version_{GetActiveOrtAPIVersion()} {
+    if constexpr (has_Logger_LogMessage<OrtApi>::value) {
+      // Get logger from the OrtKernelInfo should never fail. The logger comes from the EP, and is set when the EP is
+      // registered in the InferenceSession, which happens before model load.
+      const OrtLogger* logger = nullptr;
+      auto status = api.KernelInfo_GetLogger(&info, &logger);
+      assert(status == nullptr);
+      ort_logger_ = logger;  // save in type agnostic member and static_cast to use.
+    }
   }
 
   void LogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
                   const char* func_name, const char* message) const noexcept {
-    DefaultLogMessage(log_severity_level, file_path, line_number, func_name, message);
-  };
+    if constexpr (has_Logger_LogMessage<OrtApi>::value) {
+      // Logger_LogMessage was added in ORT 1.15
+      if (api_version_ >= 15) {
+        auto status = api_.Logger_LogMessage(static_cast<const OrtLogger*>(ort_logger_), log_severity_level, message,
+                                             file_path, line_number, func_name);
+        if (status == nullptr) {
+          return;
+        }
+
+        // Logger_LogMessage shouldn't fail. log why it did and fall through to use DefaultLogMessage.
+        OrtW::LogError(ORT_FILE, __LINE__, api_.GetErrorMessage(status));
+        api_.ReleaseStatus(status);
+      }
+    }
+
+    // use fallback
+    Logger::DefaultLogMessage(log_severity_level, file_path, line_number, func_name, message);
+  }
 
   static void DefaultLogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
                                 const char* func_name, const char* message) noexcept {
@@ -51,44 +65,7 @@ class Logger {
 
  private:
   const OrtApi& api_;
-  int api_version_{0};  // api version in use
-  // OrtLogger if available. Unused otherwise
-  const void* ort_logger_{nullptr};
+  int api_version_{0};               // ORT API version RegisterCustomOps was called with
+  const void* ort_logger_{nullptr};  // OrtLogger if available. Unused otherwise
 };
-
-// specialization for when ORT logger is available (compiled against and running with ORT version > 1.15
-// return 'bool'. the actual type doesn't matter - just has to be different to the default of 'void'
-template <>
-inline Logger<has_Logger_LogMessage<OrtApi>::type>::Logger(const OrtApi& api,
-                                                    const OrtKernelInfo& info) noexcept
-    : api_{api}, api_version_{GetActiveOrtAPIVersion()} {
-  // Get logger from the OrtKernelInfo should never fail. The logger comes from the EP, and is set when the EP is
-  // registered in the InferenceSession, which happens before model load.
-  const OrtLogger* logger = nullptr;
-  auto status = api.KernelInfo_GetLogger(&info, &logger);
-  assert(status == nullptr);
-  ort_logger_ = logger;  // save in type agnostic member and static_cast to use.
-}
-
-template <>
-inline void Logger<has_Logger_LogMessage<OrtApi>::type>::LogMessage(
-    OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
-    const char* func_name, const char* message) const noexcept {
-  // Logger_LogMessage was added in ORT 1.15
-  if (api_version_ >= 15) {
-    auto status = api_.Logger_LogMessage(static_cast<const OrtLogger*>(ort_logger_), log_severity_level, message,
-                                         file_path, line_number, func_name);
-    if (status == nullptr) {
-      return;
-    }
-
-    // error logging. should never happen but log that it did and fall through to using DefaultLogMessage
-    OrtW::LogError(ORT_FILE, __LINE__, api_.GetErrorMessage(status));
-    api_.ReleaseStatus(status);
-  }
-
-  // use fallback
-  Logger::DefaultLogMessage(log_severity_level, file_path, line_number, func_name, message);
-}
-
 }  // namespace ort_extensions

--- a/operators/azure/logger.hpp
+++ b/operators/azure/logger.hpp
@@ -6,7 +6,7 @@
 #include "ocos.h"
 
 // may or may not be available depending on the ORT version
-struct OrtLogger;
+struct OrtLogger;  // may or may not exist
 
 namespace ort_extensions {
 // Disable GCC 'ignoring attributes on template argument' warning due to Logger_LogMessage using
@@ -38,77 +38,58 @@ struct has_Logger_LogMessage<T, std::void_t<decltype(&T::Logger_LogMessage)>> : 
   GetLogger().LogMessage(severity, __FILE__, __LINE__, __FUNCTION__, msg)
 #endif
 
-struct FallbackLogger {
-  static void LogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
-                         const char* func_name, const char* message) noexcept {
+// Logging wrapper to use the ORT logger if available, otherwise fallback to default logging.
+template <class T>
+class LoggerImpl {
+ public:
+  LoggerImpl(const T& api, const OrtKernelInfo& info) noexcept
+      : api_{api}, api_version_{GetActiveOrtAPIVersion()} {
+    if constexpr (has_Logger_LogMessage<T>::value) {
+      // Get logger from the OrtKernelInfo should never fail. The logger comes from the EP, and is set when the EP is
+      // registered in the InferenceSession, which happens before model load.
+      const OrtLogger* logger = nullptr;
+      auto status = api.KernelInfo_GetLogger(&info, &logger);
+      assert(status == nullptr);
+      ort_logger_ = logger;  // save in type agnostic member and static_cast to use.
+    }
+  }
+
+  void LogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
+                  const char* func_name, const char* message) const noexcept {
+    if constexpr (has_Logger_LogMessage<T>::value) {
+      // Logger_LogMessage was added in ORT 1.15
+      if (api_version_ >= 15) {
+        auto status = api_.Logger_LogMessage(static_cast<const OrtLogger*>(ort_logger_), log_severity_level, message,
+                                             file_path, line_number, func_name);
+        if (status == nullptr) {
+          return;
+        }
+
+        // Logger_LogMessage shouldn't fail. log why it did and fall through to use DefaultLogMessage.
+        OrtW::LogError(file_path, line_number, api_.GetErrorMessage(status));
+        api_.ReleaseStatus(status);
+      }
+    }
+
+    // use fallback
+    DefaultLogMessage(log_severity_level, file_path, line_number, func_name, message);
+  }
+
+  static void DefaultLogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
+                                const char* func_name, const char* message) noexcept {
     // hardcoded when using fallback due to old ORT version.
     if (log_severity_level >= ORT_LOGGING_LEVEL_WARNING) {
       OrtW::LogError(file_path, line_number, (std::string(func_name) + ": " + message).c_str());
     }
   }
-};
-
-// implementation for ORT versions < 1.15
-template <class T = OrtApi, bool HasLogger = has_Logger_LogMessage<T>::value>
-struct LoggerImpl {
-  LoggerImpl(const T& api, const OrtKernelInfo& /*info*/) noexcept : api_{api} {
-  }
-
-  void LogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
-                  const char* func_name, const char* message) const noexcept {
-    FallbackLogger::LogMessage(log_severity_level, file_path, line_number, func_name, message);
-  }
-
-  const T& api_;
-};
-
-// implementation for ORT version >= 1.15 where we can use the ORT logger
-template <class T>
-struct LoggerImpl<T, true> {
-  LoggerImpl(const T& api, const OrtKernelInfo& info) noexcept
-      : api_{api}, api_version_{GetActiveOrtAPIVersion()} {
-    // Get logger from the OrtKernelInfo should never fail. The logger comes from the EP, and is set when the EP is
-    // registered in the InferenceSession, which happens before model load.
-    auto status = api_.KernelInfo_GetLogger(&info, &ort_logger_);
-    assert(status == nullptr);
-  }
-
-  void LogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
-                  const char* func_name, const char* message) const noexcept {
-    // Logger_LogMessage was added in ORT 1.15
-    if (api_version_ >= 15) {
-      auto status = api_.Logger_LogMessage(ort_logger_, log_severity_level, message, file_path, line_number, func_name);
-      if (status == nullptr) {
-        return;
-      }
-
-      // Logger_LogMessage shouldn't fail. log why it did and fall through to use DefaultLogMessage.
-      OrtW::LogError(file_path, line_number, api_.GetErrorMessage(status));
-      api_.ReleaseStatus(status);
-    }
-
-    FallbackLogger::LogMessage(log_severity_level, file_path, line_number, func_name, message);
-  }
-
-  // T == OrtApi, but we must use T so it compiles when KernelInfo_GetLogger and Logger_LogMessage are not available
-  const T& api_;
-  const int api_version_;  // runtime API version that RegisterCustomOps was called with
-  const OrtLogger* ort_logger_{nullptr};
-};
-
-// Logging wrapper to use the ORT logger if available, otherwise fallback to default logging.
-class Logger {
- public:
-  Logger(const OrtApi& api, const OrtKernelInfo& info) noexcept
-      : impl_{api, info} {
-  }
-
-  void LogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
-                  const char* func_name, const char* message) const noexcept {
-    impl_.LogMessage(log_severity_level, file_path, line_number, func_name, message);
-  }
 
  private:
-  LoggerImpl<OrtApi> impl_;
+  // api_ is really OrtApi but we must use T so compilation works when Logger_LogMessage is not available
+  const T& api_;
+  int api_version_;                       // runtime ORT API version RegisterCustomOps was called with
+  const OrtLogger* ort_logger_{nullptr};  // OrtLogger if available
 };
+
+using Logger = LoggerImpl<OrtApi>;
+
 }  // namespace ort_extensions

--- a/operators/azure/logger.hpp
+++ b/operators/azure/logger.hpp
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "ocos.h"
+
+namespace ort_extensions {
+
+template <class, class = void>
+struct has_Logger_LogMessage : std::false_type {};
+
+template <class T>
+struct has_Logger_LogMessage<T, std::void_t<decltype(&T::Logger_LogMessage)>> : std::true_type {};
+
+// for use in implementation of classes that have a GetLogger() member that returns an ort_extensions::Logger<T>.
+// severity is an ORT_LOGGING_LEVEL_... value (e.g. ORT_LOGGING_LEVEL_WARNING)
+#define KERNEL_LOG(severity, msg) \
+  GetLogger().LogMessage(severity, ORT_FILE, __LINE__, __FUNCTION__, msg)
+
+// Logging wrapper to enable use the ORT logger if available, otherwise fallback to default logging.
+template <typename T = std::false_type>
+class Logger {
+ public:
+  Logger(const OrtApi& api, const OrtKernelInfo& /*info*/) : api_{api} {
+  }
+
+  void LogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
+                  const char* func_name, const char* message) const {
+    DefaultLogMessage(log_severity_level, file_path, line_number, func_name, message);
+  };
+
+  static void DefaultLogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
+                                const char* func_name, const char* message) {
+    // hardcoded when using fallback due to old ORT version.
+    if (log_severity_level >= ORT_LOGGING_LEVEL_WARNING) {
+      OrtW::LogError(file_path, line_number, (std::string(func_name) + ": " + message).c_str());
+    }
+  }
+
+ private:
+  const OrtApi& api_;
+  int api_version_{0};  // api version in use
+  // OrtLogger if available. Unused otherwise
+  const void* ort_logger_{nullptr};
+};
+
+// specialization for when ORT logger is available (compiled against and running with ORT version > 1.15
+// return 'bool'. the actual type doesn't matter - just has to be different to the default of 'void'
+template <>
+Logger<has_Logger_LogMessage<OrtApi>::type>::Logger(const OrtApi& api,
+                                                    const OrtKernelInfo& info)
+    : api_{api}, api_version_{GetActiveOrtAPIVersion()} {
+  // Get logger from the OrtKernelInfo should never fail. The logger comes from the EP, and is set when the EP is
+  // registered in the InferenceSession, which happens before model load.
+  const OrtLogger* logger = nullptr;
+  auto status = api.KernelInfo_GetLogger(&info, &logger);
+  assert(status == nullptr);
+  ort_logger_ = logger;  // save in type agnostic member and static_cast to use.
+}
+
+template <>
+void Logger<has_Logger_LogMessage<OrtApi>::type>::LogMessage(
+    OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
+    const char* func_name, const char* message) const {
+  // Logger_LogMessage was added in ORT 1.15
+  if (api_version_ >= 15) {
+    auto status = api_.Logger_LogMessage(static_cast<const OrtLogger*>(ort_logger_), log_severity_level, message,
+                                         file_path, line_number, func_name);
+    if (status == nullptr) {
+      return;
+    }
+
+    // error logging. should never happen but log that it did and fall through to using DefaultLogMessage
+    OrtW::LogError(ORT_FILE, __LINE__, api_.GetErrorMessage(status));
+    api_.ReleaseStatus(status);
+  }
+
+  // use fallback
+  Logger::DefaultLogMessage(log_severity_level, file_path, line_number, func_name, message);
+}
+
+}  // namespace ort_extensions

--- a/operators/azure/logger.hpp
+++ b/operators/azure/logger.hpp
@@ -10,9 +10,20 @@ namespace ort_extensions {
 template <class, class = void>
 struct has_Logger_LogMessage : std::false_type {};
 
+// Disable GCC 'ignoring attributes on template argument' warning due to Logger_LogMessage using 
+// `__attribute__((warn_unused_result))`. 
+// The template here is about whether the function exists or not so the attribute is irrelevant.
+// FWIW using `[[nodiscard]]` would be fine, but that would require a change to the ORT_MUST_USE_RESULT
+// definition in onnxruntime_c_api.h.
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
 template <class T>
 struct has_Logger_LogMessage<T, std::void_t<decltype(&T::Logger_LogMessage)>> : std::true_type {};
-
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 // for use in implementation of classes that have a GetLogger() member that returns an ort_extensions::Logger<T>.
 // severity is an ORT_LOGGING_LEVEL_... value (e.g. ORT_LOGGING_LEVEL_WARNING)
 #define KERNEL_LOG(severity, msg) \
@@ -22,16 +33,16 @@ struct has_Logger_LogMessage<T, std::void_t<decltype(&T::Logger_LogMessage)>> : 
 template <typename T = std::false_type>
 class Logger {
  public:
-  Logger(const OrtApi& api, const OrtKernelInfo& /*info*/) : api_{api} {
+  Logger(const OrtApi& api, const OrtKernelInfo& /*info*/) noexcept : api_{api} {
   }
 
   void LogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
-                  const char* func_name, const char* message) const {
+                  const char* func_name, const char* message) const noexcept {
     DefaultLogMessage(log_severity_level, file_path, line_number, func_name, message);
   };
 
   static void DefaultLogMessage(OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
-                                const char* func_name, const char* message) {
+                                const char* func_name, const char* message) noexcept {
     // hardcoded when using fallback due to old ORT version.
     if (log_severity_level >= ORT_LOGGING_LEVEL_WARNING) {
       OrtW::LogError(file_path, line_number, (std::string(func_name) + ": " + message).c_str());
@@ -48,8 +59,8 @@ class Logger {
 // specialization for when ORT logger is available (compiled against and running with ORT version > 1.15
 // return 'bool'. the actual type doesn't matter - just has to be different to the default of 'void'
 template <>
-Logger<has_Logger_LogMessage<OrtApi>::type>::Logger(const OrtApi& api,
-                                                    const OrtKernelInfo& info)
+inline Logger<has_Logger_LogMessage<OrtApi>::type>::Logger(const OrtApi& api,
+                                                    const OrtKernelInfo& info) noexcept
     : api_{api}, api_version_{GetActiveOrtAPIVersion()} {
   // Get logger from the OrtKernelInfo should never fail. The logger comes from the EP, and is set when the EP is
   // registered in the InferenceSession, which happens before model load.
@@ -60,9 +71,9 @@ Logger<has_Logger_LogMessage<OrtApi>::type>::Logger(const OrtApi& api,
 }
 
 template <>
-void Logger<has_Logger_LogMessage<OrtApi>::type>::LogMessage(
+inline void Logger<has_Logger_LogMessage<OrtApi>::type>::LogMessage(
     OrtLoggingLevel log_severity_level, const ORTCHAR_T* file_path, int line_number,
-    const char* func_name, const char* message) const {
+    const char* func_name, const char* message) const noexcept {
   // Logger_LogMessage was added in ORT 1.15
   if (api_version_ >= 15) {
     auto status = api_.Logger_LogMessage(static_cast<const OrtLogger*>(ort_logger_), log_severity_level, message,

--- a/prebuild/build_curl_for_android.sh
+++ b/prebuild/build_curl_for_android.sh
@@ -4,7 +4,6 @@
 
 set -e
 set -u
-set -x
 
 # change to the directory the script is in in case it's being executed from elsewhere
 echo `pwd`
@@ -26,7 +25,7 @@ fi
 cd tools
 
 # we target Android API level 21 but allow override by environment variable
-if [ -z ${ANDROID_API_LEVEL} ]; then 
+if [ -z ${ANDROID_API_LEVEL+x} ]; then 
     export api=21
 else
     export api=${ANDROID_API_LEVEL}

--- a/prebuild/build_curl_for_android_on_linux.patch
+++ b/prebuild/build_curl_for_android_on_linux.patch
@@ -111,7 +111,7 @@ index b82d2bd..cfb0fd2 100755
      else
          log_error "not support" && exit 1
 diff --git a/tools/build-android-openssl.sh b/tools/build-android-openssl.sh
-index e13c314..8ed232f 100755
+index e13c314..4e57334 100755
 --- a/tools/build-android-openssl.sh
 +++ b/tools/build-android-openssl.sh
 @@ -16,7 +16,7 @@
@@ -123,28 +123,29 @@ index e13c314..8ed232f 100755
  
  source ./build-android-common.sh
  
-@@ -88,19 +88,19 @@ function configure_make() {
+@@ -87,20 +87,20 @@ function configure_make() {
+     android_printf_global_params "$ARCH" "$ABI" "$ABI_TRIPLE" "$PREFIX_DIR" "$OUTPUT_ROOT"
  
      if [[ "${ARCH}" == "x86_64" ]]; then
- 
+-
 -        ./Configure android-x86_64 --prefix="${PREFIX_DIR}"
 +        #./Configure android-x86_64 no-tests -static --prefix="${PREFIX_DIR}"
 +        ./Configure android-x86_64 no-tests --prefix="${PREFIX_DIR}"
  
      elif [[ "${ARCH}" == "x86" ]]; then
- 
+-
 -        ./Configure android-x86 --prefix="${PREFIX_DIR}"
 +        #./Configure android-x86 no-tests -static --prefix="${PREFIX_DIR}"
 +        ./Configure android-x86 no-tests --prefix="${PREFIX_DIR}"
  
      elif [[ "${ARCH}" == "arm" ]]; then
- 
+-
 -        ./Configure android-arm --prefix="${PREFIX_DIR}"
 +        #./Configure android-arm no-tests -static --prefix="${PREFIX_DIR}"
 +        ./Configure android-arm no-tests --prefix="${PREFIX_DIR}"
  
      elif [[ "${ARCH}" == "arm64" ]]; then
- 
+-
 -        ./Configure android-arm64 --prefix="${PREFIX_DIR}"
 +        #./Configure android-arm64 no-tests -static --prefix="${PREFIX_DIR}"
 +        ./Configure android-arm64 no-tests --prefix="${PREFIX_DIR}"

--- a/prebuild/build_curl_for_android_on_linux.patch
+++ b/prebuild/build_curl_for_android_on_linux.patch
@@ -62,10 +62,10 @@ index 87df207..6f3ec66 100755
      export LDFLAGS="-march=x86-64 -Wl,--gc-sections -Os -ffunction-sections -fdata-sections $(get_common_linked_libraries ${api} ${arch})"
      export CPPFLAGS=${CFLAGS}
 diff --git a/tools/build-android-curl.sh b/tools/build-android-curl.sh
-index b82d2bd..98ed6b9 100755
+index b82d2bd..cfb0fd2 100755
 --- a/tools/build-android-curl.sh
 +++ b/tools/build-android-curl.sh
-@@ -84,29 +84,34 @@ function configure_make() {
+@@ -84,29 +84,38 @@ function configure_make() {
      echo ANDROID_NDK_HOME=${ANDROID_NDK_HOME}
  
      OPENSSL_OUT_DIR="${pwd_path}/../output/android/openssl-${ABI}"
@@ -82,32 +82,36 @@ index b82d2bd..98ed6b9 100755
      if [[ "${ARCH}" == "x86_64" ]]; then
  
 -        ./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} --with-nghttp2=${NGHTTP2_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
-+        ./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --disable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
++        ./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --enable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
++        #./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --disable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
 +        #./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --disable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} --with-nghttp2=${NGHTTP2_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
  
      elif [[ "${ARCH}" == "x86" ]]; then
  
 -        ./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} --with-nghttp2=${NGHTTP2_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
-+        ./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --disable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
++        ./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --enable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
++        #./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --disable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
 +        #./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --disable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} --with-nghttp2=${NGHTTP2_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
  
      elif [[ "${ARCH}" == "arm" ]]; then
  
 -        ./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} --with-nghttp2=${NGHTTP2_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
-+        ./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --disable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
++        ./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --enable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
++        #./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --disable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
 +        #./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --disable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} --with-nghttp2=${NGHTTP2_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
  
      elif [[ "${ARCH}" == "arm64" ]]; then
  
          # --enable-shared need nghttp2 cpp compile
 -        ./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --disable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} --with-nghttp2=${NGHTTP2_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
-+        ./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --disable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
++        ./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --enable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
++        #./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --disable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
 +        #./configure --host=$(android_get_build_host "${ARCH}") --prefix="${PREFIX_DIR}" --disable-shared --enable-ipv6 --with-ssl=${OPENSSL_OUT_DIR} --with-nghttp2=${NGHTTP2_OUT_DIR} >"${OUTPUT_ROOT}/log/${ABI}.log" 2>&1
  
      else
          log_error "not support" && exit 1
 diff --git a/tools/build-android-openssl.sh b/tools/build-android-openssl.sh
-index e13c314..97963fb 100755
+index e13c314..8ed232f 100755
 --- a/tools/build-android-openssl.sh
 +++ b/tools/build-android-openssl.sh
 @@ -16,7 +16,7 @@
@@ -124,22 +128,26 @@ index e13c314..97963fb 100755
      if [[ "${ARCH}" == "x86_64" ]]; then
  
 -        ./Configure android-x86_64 --prefix="${PREFIX_DIR}"
-+        ./Configure android-x86_64 no-tests -static --prefix="${PREFIX_DIR}"
++        #./Configure android-x86_64 no-tests -static --prefix="${PREFIX_DIR}"
++        ./Configure android-x86_64 no-tests --prefix="${PREFIX_DIR}"
  
      elif [[ "${ARCH}" == "x86" ]]; then
  
 -        ./Configure android-x86 --prefix="${PREFIX_DIR}"
-+        ./Configure android-x86 no-tests -static --prefix="${PREFIX_DIR}"
++        #./Configure android-x86 no-tests -static --prefix="${PREFIX_DIR}"
++        ./Configure android-x86 no-tests --prefix="${PREFIX_DIR}"
  
      elif [[ "${ARCH}" == "arm" ]]; then
  
 -        ./Configure android-arm --prefix="${PREFIX_DIR}"
-+        ./Configure android-arm no-tests -static --prefix="${PREFIX_DIR}"
++        #./Configure android-arm no-tests -static --prefix="${PREFIX_DIR}"
++        ./Configure android-arm no-tests --prefix="${PREFIX_DIR}"
  
      elif [[ "${ARCH}" == "arm64" ]]; then
  
 -        ./Configure android-arm64 --prefix="${PREFIX_DIR}"
-+        ./Configure android-arm64 no-tests -static --prefix="${PREFIX_DIR}"
++        #./Configure android-arm64 no-tests -static --prefix="${PREFIX_DIR}"
++        ./Configure android-arm64 no-tests --prefix="${PREFIX_DIR}"
  
      else
          log_error "not support" && exit 1

--- a/test/shared_test/test_ortops_azure.cc
+++ b/test/shared_test/test_ortops_azure.cc
@@ -6,7 +6,6 @@
 
 #include "gtest/gtest.h"
 
-#include "ocos.h"
 #include "narrow.h"
 #include "test_kernel.hpp"
 #include "utils.hpp"

--- a/tools/android/build_aar.py
+++ b/tools/android/build_aar.py
@@ -108,6 +108,13 @@ def do_build_by_mode(output_dir: Path,
             for jnilib_name in jnilib_names:
                 shutil.copyfile(build_dir / config / "java" / "android" / abi / jnilib_name, jnilibs_dir / jnilib_name)
 
+            # depending on the build settings these libraries may not be build
+            optional_jnilib_names = ["libcrypto.so", "libssl.so", "libcurl.so"]
+            for jnilib_name in optional_jnilib_names:
+                src = build_dir / config / "java" / "android" / abi / jnilib_name
+                if src.exists():
+                    shutil.copyfile(src, jnilibs_dir / jnilib_name)
+
     # early return if only building JNI libraries
     # To accelerate the build pipeline, we can build the JNI libraries first in parallel for different abi,
     # and then build the AAR package.


### PR DESCRIPTION
- Ensure we log an error message before throwing on Android
  - message in exception will be lost due to how the shared libraries are built (both onnxruntime and extensions use static libc++ so there are no shared exception types between them)
- support static or dynamic build of curl/openssl on android
  - TBD which we want to use. static is smaller but build fails on x86 currently so might need a mix
- add infra for anything deriving from BaseKernel to log messages using the ORT logger
  - ensures messages from custom kernels end up in the same place as messages from ORT
