### PR TITLE
correct CLIP tokenizer name

### DIFF
--- a/nuget/NativeNuget.nuspec
+++ b/nuget/NativeNuget.nuspec
@@ -11,7 +11,7 @@
       2. Support for pre-processing and post-processing of the Whisper model, inclusive of Audio and Tokenizer decoding operators.
       3. Extends support for pre-processing and post-processing of object-detection models, including a new DrawBoundingBoxes operator. Pre/post processing tools can add non-max-suppression to the model to select the best bounding boxes, and scale those to the original image. See the end-to-end example in yolo_e2e.py.
       4. Introduces the Audio Domain, complemented with AudioCodec and optimized STFT Operators, enhancing audio processing capabilities.
-      5. Enabled optional input/output support for some operators such as GPT2Tokenizer, ClipTokenizer, and RobertaTokenizer.
+      5. Enabled optional input/output support for some operators such as GPT2Tokenizer, CLIPTokenizer, and RobertaTokenizer.
       6. Refined the implementation of offset mapping for BBPE-style tokenizers for more operators and efficiency improvement.
       7. Other bug and security fixes.
 	</releaseNotes>

--- a/onnxruntime_extensions/_hf_cvt.py
+++ b/onnxruntime_extensions/_hf_cvt.py
@@ -135,7 +135,7 @@ _PROCESSOR_DICT = {
                                      'BertDecoder',     HFTokenizerConverter.bpe_decoder, None),
     "GPT2Tokenizer":    TokenOpParam('GPT2Tokenizer',   HFTokenizerConverter.bpe_tokenizer,
                                      'BpeDecoder',      HFTokenizerConverter.bpe_decoder, None),
-    "ClipTokenizer":    TokenOpParam('ClipTokenizer',   HFTokenizerConverter.clip_tokenizer,
+    "CLIPTokenizer":    TokenOpParam('CLIPTokenizer',   HFTokenizerConverter.clip_tokenizer,
                                      'BpeDecoder',      HFTokenizerConverter.bpe_decoder, None),
     "RobertaTokenizer": TokenOpParam("RobertaTokenizer",    HFTokenizerConverter.roberta_tokenizer,
                                      None, None, None),

--- a/tools/android/package_ops.config
+++ b/tools/android/package_ops.config
@@ -1,1 +1,1 @@
-com.microsoft.extensions;1;DecodeImage,EncodeImage,BertTokenizer,ClipTokenizer,BpeDecoder,DrawBoundingBoxes,OpenAIAudioToText
+com.microsoft.extensions;1;DecodeImage,EncodeImage,BertTokenizer,CLIPTokenizer,BpeDecoder,DrawBoundingBoxes,OpenAIAudioToText

--- a/tools/ios/package_ops.config
+++ b/tools/ios/package_ops.config
@@ -1,1 +1,1 @@
-com.microsoft.extensions;1;DecodeImage,EncodeImage,BertTokenizer,ClipTokenizer,BpeDecoder,DrawBoundingBoxes
+com.microsoft.extensions;1;DecodeImage,EncodeImage,BertTokenizer,CLIPTokenizer,BpeDecoder,DrawBoundingBoxes


### PR DESCRIPTION
Most usage of this tokenizer is wrong, which causes some bugs.

The reason of 'CLIP' instead of 'Clip' is to align with HF's
https://github.com/huggingface/transformers/blob/36f183ebab1261b388739d628aaa0b4150068df0/src/transformers/models/clip/tokenization_clip_fast.py#L50