### PR TITLE
clean up the deprecated warnings from pytest

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -355,7 +355,6 @@ jobs:
           python -m pip install onnxruntime==$(ort.version)
           python -m pip install -r requirements.txt
           python -m pip install -r requirements-dev.txt
-          python -m pip install cmake
         displayName: Install requirements{-dev}.txt and cmake python modules
 
       - script: |

--- a/test/test_processing.py
+++ b/test/test_processing.py
@@ -4,7 +4,7 @@ import torch
 import unittest
 from typing import List, Tuple
 from PIL import Image
-from distutils.version import LooseVersion
+from packaging import version
 from onnxruntime_extensions import OrtPyFunction
 from onnxruntime_extensions import pnp, util
 from transformers import GPT2Config, GPT2LMHeadModel
@@ -52,10 +52,6 @@ class _MobileNetProcessingModule(pnp.ProcessingScriptModule):
         )
 
 
-@unittest.skipIf(
-    LooseVersion(torch.__version__) < LooseVersion("1.9"),
-    "Not works with older PyTorch",
-)
 class TestPreprocessing(unittest.TestCase):
     def test_imagenet_preprocessing(self):
         mnv2 = onnx.load_model(util.get_test_data_file("data", "mobilev2.onnx"))
@@ -125,7 +121,7 @@ class TestPreprocessing(unittest.TestCase):
         ]
         res = seq_m.forward(test_input)
         numpy.testing.assert_allclose(res, numpy.array([4, 5]))
-        if LooseVersion(torch.__version__) >= LooseVersion("1.11"):
+        if version.parse(torch.__version__) >= version.parse("1.11"):
             # The fixing for the sequence tensor support is only released in 1.11 and the above.
             oxml = pnp.export(
                 seq_m, test_input, opset_version=12, output_path="temp_seqtest.onnx"

--- a/test/test_torch_ops.py
+++ b/test/test_torch_ops.py
@@ -7,7 +7,7 @@ import torch
 import torchvision
 import onnxruntime as _ort
 
-from distutils.version import LooseVersion
+from packaging import version
 from torch.onnx import register_custom_op_symbolic
 from onnxruntime_extensions import (
     PyOp,
@@ -21,7 +21,7 @@ def my_inverse(g, self):
     return g.op("ai.onnx.contrib::Inverse", self)
 
 
-if LooseVersion(torch.__version__) >= LooseVersion("1.13"):
+if version.parse(torch.__version__) >= version.parse("1.13"):
     register_custom_op_symbolic('::linalg_inv', my_inverse, 1)
 else:
     register_custom_op_symbolic('::inverse', my_inverse, 1)
@@ -100,7 +100,7 @@ class TestPyTorchCustomOp(unittest.TestCase):
         return x
 
     @unittest.skipIf(
-        (platform.system() == 'Darwin') or (LooseVersion(_ort.__version__) > LooseVersion("1.11")),
+        (platform.system() == 'Darwin') or (version.parse(_ort.__version__) > version.parse("1.11")),
         "pytorch.onnx crashed for this case! and test asserts with higher versions of ort"
     )
     def test_pyop_hooking(self):    # type: () -> None


### PR DESCRIPTION
1. replace the LooseVersion with version from packaging.
2. move the generated test onnx files into temp_4onnx folder which match the .gitignore patttern.