### PR TITLE
Update pyfunc.cc for the prefast warning.

### DIFF
--- a/pyop/pyfunc.cc
+++ b/pyop/pyfunc.cc
@@ -401,7 +401,7 @@ void PyCustomOpDef::AddOp(const PyCustomOpDef* cod) {
   auto val = std::make_pair(op_domain, std::vector<PyCustomOpFactory>());
   auto [it_domain_op, success] = PyOp_container().insert(val);
   assert(success || !it_domain_op->second.empty());
-  it_domain_op->second.emplace_back(PyCustomOpFactory(cod, op_domain, op));
+  it_domain_op->second.emplace_back(cod, op_domain, op);
 }
 
 const PyCustomOpFactory* PyCustomOpDef_FetchPyCustomOps(size_t num) {

--- a/pyop/pyfunc.cc
+++ b/pyop/pyfunc.cc
@@ -399,7 +399,7 @@ void PyCustomOpDef::AddOp(const PyCustomOpDef* cod) {
 
   // No need to protect against concurrent access, GIL is doing that.
   auto val = std::make_pair(op_domain, std::vector<PyCustomOpFactory>());
-  const auto [it_domain_op, success] = PyOp_container().insert(val);
+  auto [it_domain_op, success] = PyOp_container().insert(val);
   assert(success || !it_domain_op->second.empty());
   it_domain_op->second.emplace_back(PyCustomOpFactory(cod, op_domain, op));
 }


### PR DESCRIPTION

PyCustomOpDef::AddOppyop/pyfunc.cc | Don't use std::move on constant variables. (es.56).
