### PR TITLE
Add support for Fairseq models (like XLMRobertaTokenizer)

### DIFF
--- a/onnxruntime_extensions/_cuops.py
+++ b/onnxruntime_extensions/_cuops.py
@@ -315,7 +315,8 @@ class SentencepieceTokenizer(CustomOp):
             cls.io_def('alpha', onnx_proto.TensorProto.FLOAT, [None]),
             cls.io_def('add_bos', onnx_proto.TensorProto.BOOL, [None]),
             cls.io_def('add_eos', onnx_proto.TensorProto.BOOL, [None]),
-            cls.io_def('reverse', onnx_proto.TensorProto.BOOL, [None])
+            cls.io_def('reverse', onnx_proto.TensorProto.BOOL, [None]),
+            cls.io_def('xlm_roberta', onnx_proto.TensorProto.BOOL, [None])
         ]
 
     # beyond Python 3.7, the order of the dict is guaranteed to be insertion order
@@ -326,7 +327,8 @@ class SentencepieceTokenizer(CustomOp):
             'alpha': [0],
             'add_bos': [False],
             'add_eos': [False],
-            'reverse': [False]
+            'reverse': [False],
+            'xlm_roberta': [False]
         }
 
     @classmethod

--- a/onnxruntime_extensions/_cuops.py
+++ b/onnxruntime_extensions/_cuops.py
@@ -316,7 +316,7 @@ class SentencepieceTokenizer(CustomOp):
             cls.io_def('add_bos', onnx_proto.TensorProto.BOOL, [None]),
             cls.io_def('add_eos', onnx_proto.TensorProto.BOOL, [None]),
             cls.io_def('reverse', onnx_proto.TensorProto.BOOL, [None]),
-            cls.io_def('xlm_roberta', onnx_proto.TensorProto.BOOL, [None])
+            cls.io_def('fairseq', onnx_proto.TensorProto.BOOL, [None])
         ]
 
     # beyond Python 3.7, the order of the dict is guaranteed to be insertion order
@@ -328,7 +328,7 @@ class SentencepieceTokenizer(CustomOp):
             'add_bos': [False],
             'add_eos': [False],
             'reverse': [False],
-            'xlm_roberta': [False]
+            'fairseq': [False]
         }
 
     @classmethod

--- a/operators/tokenizer/sentencepiece_tokenizer.cc
+++ b/operators/tokenizer/sentencepiece_tokenizer.cc
@@ -63,7 +63,7 @@ void KernelSentencepieceTokenizer::Compute(const ortc::Tensor<std::string>& inpu
         content.push_back(tokenizer_.eos_id());
       }
 
-      if (fairseq.has_value() && fairseq.value()) {
+      if (fairseq.has_value() && (*fairseq)) {
         // HF Fairseq Example (XLMRobertaTokenizer) : https://huggingface.co/transformers/v4.6.0/_modules/transformers/models/xlm_roberta/tokenization_xlm_roberta.html#XLMRobertaTokenizer
         //
         // Original fairseq vocab and spm vocab must be "aligned":

--- a/operators/tokenizer/sentencepiece_tokenizer.hpp
+++ b/operators/tokenizer/sentencepiece_tokenizer.hpp
@@ -16,8 +16,12 @@ struct KernelSentencepieceTokenizer : BaseKernel {
                bool add_eos,
                bool add_rev,
                ortc::Tensor<int32_t>& output,
-               ortc::Tensor<int64_t>& output1) const;
+               ortc::Tensor<int64_t>& output1,
+               std::optional<bool> xlm_roberta) const;
 
  private:
   sentencepiece::SentencePieceProcessor tokenizer_;
+  // current HF ids for BOS and EOS tokens for XLMRobertaTokenizer
+  int xlm_bos = 0;
+  int xlm_eos = 2;
 };

--- a/operators/tokenizer/sentencepiece_tokenizer.hpp
+++ b/operators/tokenizer/sentencepiece_tokenizer.hpp
@@ -17,11 +17,8 @@ struct KernelSentencepieceTokenizer : BaseKernel {
                bool add_rev,
                ortc::Tensor<int32_t>& output,
                ortc::Tensor<int64_t>& output1,
-               std::optional<bool> xlm_roberta) const;
+               std::optional<bool> fairseq) const;
 
  private:
   sentencepiece::SentencePieceProcessor tokenizer_;
-  // current HF ids for BOS and EOS tokens for XLMRobertaTokenizer
-  int xlm_bos = 0;
-  int xlm_eos = 2;
 };

--- a/test/test_sentencepiece_ops.py
+++ b/test/test_sentencepiece_ops.py
@@ -5,6 +5,7 @@ import base64
 import numpy as np
 from numpy.testing import assert_almost_equal
 from onnx import helper, onnx_pb as onnx_proto
+from transformers import AutoTokenizer
 import onnxruntime as _ort
 from onnxruntime_extensions import (
     util,
@@ -241,6 +242,44 @@ def _create_test_model_ragged_to_dense(
     model = make_onnx_model(graph)
     return model
 
+def _create_test_model_sentencepiece_xlm(
+        model, domain='ai.onnx.contrib'):
+    nodes = []
+    mkv = helper.make_tensor_value_info
+    nodes.append(helper.make_node(
+        'SentencepieceTokenizer',
+        inputs=[
+            'inputs',  # inputs
+            'nbest_size',
+            'alpha',
+            'add_bos',
+            'add_eos',
+            'reverse',
+            'xlm_roberta'
+        ],
+        outputs=['out0', 'out1'],
+        model=model,
+        name='SentencepieceTokenizeOpName',
+        domain='ai.onnx.contrib'
+    ))
+    inputs = [
+        mkv('inputs', onnx_proto.TensorProto.STRING, [None]),
+        mkv('nbest_size', onnx_proto.TensorProto.INT64, [None]),
+        mkv('alpha', onnx_proto.TensorProto.FLOAT, [None]),
+        mkv('add_bos', onnx_proto.TensorProto.BOOL, [None]),
+        mkv('add_eos', onnx_proto.TensorProto.BOOL, [None]),
+        mkv('reverse', onnx_proto.TensorProto.BOOL, [None]),
+        mkv('xlm_roberta', onnx_proto.TensorProto.BOOL, [None])
+    ]
+
+    graph = helper.make_graph(
+        nodes, 'test0', inputs, [
+            mkv('out0', onnx_proto.TensorProto.INT32, [None]),
+            mkv('out1', onnx_proto.TensorProto.INT64, [None])
+        ])
+    model = make_onnx_model(graph)
+    return model
+
 
 @unittest.skipIf(not _is_tensorflow_avaliable, "tensorflow/tensorflow-text is unavailable")
 class TestPythonOpSentencePiece(unittest.TestCase):
@@ -437,6 +476,33 @@ class TestPythonOpSentencePiece(unittest.TestCase):
         for i in range(0, 2):
             assert_almost_equal(exp[i], py_txout[i])
             assert_almost_equal(exp[i], cc_txout[i])
+            
+    def test_xlm_roberta_tokenizer(self):
+        so = _ort.SessionOptions()
+        so.register_custom_ops_library(_get_library_path())
+        tokenizer = AutoTokenizer.from_pretrained("xlm-roberta-base", use_fast=False)
+        text = "Wow, these models are getting popular."
+        ids = tokenizer.encode(text, return_tensors="np")
+        model = util.read_file(tokenizer.vocab_file, 'rb')
+        cc_onnx_model = _create_test_model_sentencepiece_xlm(model)
+        self.assertIn('op_type: "SentencepieceTokenizer"', str(cc_onnx_model))
+        cc_sess = _ort.InferenceSession(cc_onnx_model.SerializeToString(), so)
+
+        inputs = dict(
+            model=model,
+            inputs=np.array(
+                [text],
+                dtype=object),
+            nbest_size=np.array(
+                [0], dtype=np.int64),
+            alpha=np.array([0], dtype=np.float32),
+            add_bos=np.array([False], dtype=np.bool_),
+            add_eos=np.array([False], dtype=np.bool_),
+            reverse=np.array([False], dtype=np.bool_),
+            xlm_roberta=np.array([True], dtype=np.bool_))
+        del inputs['model']
+        cc_txout = cc_sess.run(None, inputs)
+        assert_almost_equal(ids[0], cc_txout[0])
 
 
 class TestOrtXSentencePiece(unittest.TestCase):
@@ -456,7 +522,7 @@ class TestOrtXSentencePiece(unittest.TestCase):
             np.array([flags & 2], dtype=np.bool_),
             np.array([flags & 4], dtype=np.bool_))
         self.assertEqual(tokens.tolist(), [1095, 4054, 26, 2022, 755, 99935])
-
+    
 
     def test_spm_decoder(self):
         fullname = util.get_test_data_file('data', 'en.wiki.bpe.vs100000.model')


### PR DESCRIPTION
### Add support for Fairseq models (like XLMRobertaTokenizer), built on SPM.

**Usage**: pass in value `true` for `add_bos`, `add_eos`, and new optional input boolean `fairseq` when creating SentencePieceTokenizer.

Validation:
- [x] Tested against HuggingFace XLMRobertaTokenizer (uses Fairseq, SPM)