### PR TITLE
Address iOS CI build flakiness

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -638,7 +638,7 @@ stages:
       workingDirectory: $(Build.SourcesDirectory)/test/ios/OrtExtensionsUsage
 
     - script: |
-        set -e -x
+        set -e
 
         SIMULATOR_DEVICE_INFO=$(python ./tools/ios/get_simulator_device_info.py)
 

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -622,19 +622,19 @@ stages:
           --ios_deployment_target 13.0 \
           -- \
           --enable_cxx_tests
-      displayName: Build xcframework for iphonesimulator x86_64
+      displayName: "Build xcframework for iphonesimulator x86_64"
 
     - script: |
         python ./tools/ios/assemble_pod_package.py \
           --staging-dir $(Build.BinariesDirectory)/pod_staging \
           --xcframework-output-dir $(Build.BinariesDirectory)/xcframework_out \
           --pod-version ${ORT_EXTENSIONS_POD_VERSION}
-      displayName: Assemble pod
+      displayName: "Assemble pod"
 
     - script: |
         ORT_EXTENSIONS_LOCAL_POD_PATH=$(Build.BinariesDirectory)/pod_staging \
           pod install
-      displayName: Install pods for OrtExtensionsUsage
+      displayName: "Install pods for OrtExtensionsUsage"
       workingDirectory: $(Build.SourcesDirectory)/test/ios/OrtExtensionsUsage
 
     - script: |
@@ -650,11 +650,11 @@ stages:
         # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
         set +x
         echo "##vso[task.setvariable variable=ORT_EXTENSIONS_SIMULATOR_DEVICE_ID]${SIMULATOR_DEVICE_ID}"
-      displayName: Get simulator device info
+      displayName: "Get simulator device info"
 
     - script: |
         xcrun simctl bootstatus ${ORT_EXTENSIONS_SIMULATOR_DEVICE_ID} -b
-      displayName: Wait for simulator device to boot
+      displayName: "Wait for simulator device to boot"
 
     - script: |
         xcrun xcodebuild \
@@ -665,4 +665,4 @@ stages:
           -scheme OrtExtensionsUsage \
           -destination "platform=iOS Simulator,id=${ORT_EXTENSIONS_SIMULATOR_DEVICE_ID}" \
           test CODE_SIGNING_ALLOWED=NO
-      displayName: Build and test OrtExtensionsUsage
+      displayName: "Build and test OrtExtensionsUsage"

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -638,19 +638,30 @@ stages:
       workingDirectory: $(Build.SourcesDirectory)/test/ios/OrtExtensionsUsage
 
     - script: |
-        set -e
+        set -e -x
 
-        SIMULATOR_DEVICE_INFO=$(python tools/ios/get_simulator_device_info.py)
+        SIMULATOR_DEVICE_INFO=$(python ./tools/ios/get_simulator_device_info.py)
+
         echo "Simulator device info:"
         echo "${SIMULATOR_DEVICE_INFO}"
 
         SIMULATOR_DEVICE_ID=$(jq --raw-output '.device_udid' <<< "${SIMULATOR_DEVICE_INFO}")
 
+        # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
+        set +x
+        echo "##vso[task.setvariable variable=ORT_EXTENSIONS_SIMULATOR_DEVICE_ID]${SIMULATOR_DEVICE_ID}"
+      displayName: Get simulator device info
+
+    - script: |
+        xcrun simctl bootstatus ${ORT_EXTENSIONS_SIMULATOR_DEVICE_ID} -b
+      displayName: Wait for simulator device to boot
+
+    - script: |
         xcrun xcodebuild \
           -sdk iphonesimulator \
           -configuration Debug \
           -workspace $(Build.SourcesDirectory)/test/ios/OrtExtensionsUsage/OrtExtensionsUsage.xcworkspace \
           -scheme OrtExtensionsUsage \
-          -destination "platform=iOS Simulator,id=${SIMULATOR_DEVICE_ID}" \
+          -destination "platform=iOS Simulator,id=${ORT_EXTENSIONS_SIMULATOR_DEVICE_ID}" \
           test CODE_SIGNING_ALLOWED=NO
       displayName: Build and test OrtExtensionsUsage

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -660,6 +660,7 @@ stages:
         xcrun xcodebuild \
           -sdk iphonesimulator \
           -configuration Debug \
+          -parallel-testing-enabled NO \
           -workspace $(Build.SourcesDirectory)/test/ios/OrtExtensionsUsage/OrtExtensionsUsage.xcworkspace \
           -scheme OrtExtensionsUsage \
           -destination "platform=iOS Simulator,id=${ORT_EXTENSIONS_SIMULATOR_DEVICE_ID}" \

--- a/.pipelines/ios_packaging.yml
+++ b/.pipelines/ios_packaging.yml
@@ -70,20 +70,32 @@ jobs:
   - script: |
       set -e
 
-      SIMULATOR_DEVICE_INFO=$(python tools/ios/get_simulator_device_info.py)
+      SIMULATOR_DEVICE_INFO=$(python ./tools/ios/get_simulator_device_info.py)
+
       echo "Simulator device info:"
       echo "${SIMULATOR_DEVICE_INFO}"
 
       SIMULATOR_DEVICE_ID=$(jq --raw-output '.device_udid' <<< "${SIMULATOR_DEVICE_INFO}")
 
+      # Do not output ##vso[] commands with `set -x` or they may be parsed again and include a trailing quote.
+      set +x
+      echo "##vso[task.setvariable variable=ORT_EXTENSIONS_SIMULATOR_DEVICE_ID]${SIMULATOR_DEVICE_ID}"
+    displayName: "Get simulator device info"
+
+  - script: |
+      xcrun simctl bootstatus ${ORT_EXTENSIONS_SIMULATOR_DEVICE_ID} -b
+    displayName: "Wait for simulator device to boot"
+
+  - script: |
       xcrun xcodebuild \
         -sdk iphonesimulator \
         -configuration Debug \
+        -parallel-testing-enabled NO \
         -workspace $(Build.SourcesDirectory)/test/ios/OrtExtensionsUsage/OrtExtensionsUsage.xcworkspace \
         -scheme OrtExtensionsUsage \
-        -destination "platform=iOS Simulator,id=${SIMULATOR_DEVICE_ID}" \
+        -destination "platform=iOS Simulator,id=${ORT_EXTENSIONS_SIMULATOR_DEVICE_ID}" \
         test CODE_SIGNING_ALLOWED=NO
-    displayName: Build and test OrtExtensionsUsage
+    displayName: "Build and test OrtExtensionsUsage"
 
   - task: InstallAppleCertificate@2
     inputs:


### PR DESCRIPTION
- Add separate step to wait for simulator to boot.
- Add -parallel-testing-enabled NO xcodebuild option.

Per suggestions from here:
https://github.com/fastlane/fastlane/issues/21025#issuecomment-1435665269
https://heartbeat.comet.ml/the-fast-furious-and-flaky-continuous-integration-with-xcode-10-parallel-tests-2da71fd48cb1