### PR TITLE
Ensure noexcep_operators and ocos_operators get built always

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,6 +493,11 @@ endif()
 # ### make all compile options.
 add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
 add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+
+# Library will not be built if the target src for the lib does not contain any valid *.cc files.
+# Hence the placeholders `noexcep_operators_placeholder.cc` and `ocos_operators_placeholder.cc`
+# are added to the target sources for TARGET_SRC_NOEXCEPTION and TARGET_SRC respectively
+# to ensure the libraries get built.
 add_library(noexcep_operators STATIC ${TARGET_SRC_NOEXCEPTION})
 add_library(ocos_operators STATIC ${TARGET_SRC})
 # TODO: need to address the SDL warnings happens on custom operator code.

--- a/base/noexcep_operators_placeholder.cc
+++ b/base/noexcep_operators_placeholder.cc
@@ -1,0 +1,3 @@
+// Empty file that ensures that the noexcep_operators lib is created.
+// Simplifies the setup when ORT is building with extensions and either
+// ocos_oeprators or noexcp_operators have empty source lists.

--- a/operators/ocos_operators_placeholder.cc
+++ b/operators/ocos_operators_placeholder.cc
@@ -1,0 +1,3 @@
+// Empty file that ensures that the ocos_operators lib is created.
+// Simplifies the setup when ORT is building with extensions and either
+// ocos_oeprators or noexcp_operators have empty source lists.


### PR DESCRIPTION
When ONNX Runtime is built with the flags `--use_extensions` within a minimal build (reduced ops), some of the operators are not built within the `onnxruntime-extensions`.

For example, building onnx runtime with the flag `--cmake_extra_defines=OCOS_ENABLE_TF_STRING=ON` only expects the ocos string operators to be built and included. These operators are currently built inside the `noexcep_operators` and as a result `ocos_operators` library does not get built (as it has no valid sources).

However, onnxruntime takes a dependency on `ocos_operators` library (and now also on `noexcep_operators` library after https://github.com/microsoft/onnxruntime/pull/17850). Since `ocos_operators` library does not get built, it results in ONNX Runtime build failure as well.

This PR introduces placeholder source files that always get included in the target sources (regardless of whether there are other src files or not). Doing this, guarantees that both the libraries get built.