### PR TITLE
Fix newline and apostrophe handling for BPE

### DIFF
--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -150,6 +150,7 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input,
     }
     // remove newlines as CLIP ignores them (treats them as whitespace which is then cleaned)
     str.erase(std::remove(str.begin(), str.end(), '\n'), str.end());
+    str.erase(std::remove(str.begin(), str.end(), '\r'), str.end());
     input = str;
   }
 

--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -198,8 +198,7 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input,
     }
 
     while (static_cast<int64_t>(res.size()) < max_length) {
-      // Skip splitting words with apostrophes for CLIP (e.g., you're, i'm, etc.)
-      auto [b, tok] = regcmp.GetNextToken(ModelName() == BpeModelConf::kModel_CLIP);
+      auto [b, tok] = regcmp.GetNextToken();
       
       if (!b) break;
 

--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -148,6 +148,8 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input,
     if (IsUnicodeSpace(str.back())) {
       str.pop_back();
     }
+    // remove newlines as CLIP ignores them
+    str.erase(std::remove(str.begin(), str.end(), '\n'), str.end());
     input = str;
   }
 
@@ -195,7 +197,9 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input,
     }
 
     while (static_cast<int64_t>(res.size()) < max_length) {
-      auto [b, tok] = regcmp.GetNextToken();
+      // Skip splitting words with apostrophes for CLIP (e.g., you're, i'm, etc.)
+      auto [b, tok] = regcmp.GetNextToken(ModelName() == BpeModelConf::kModel_CLIP);
+      
       if (!b) break;
 
       std::string utf8_token = std::string(ustring(tok));

--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -148,7 +148,7 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input,
     if (IsUnicodeSpace(str.back())) {
       str.pop_back();
     }
-    // remove newlines as CLIP ignores them
+    // remove newlines as CLIP ignores them (treats them as whitespace which is then cleaned)
     str.erase(std::remove(str.begin(), str.end(), '\n'), str.end());
     input = str;
   }

--- a/operators/tokenizer/bpe_utils.hpp
+++ b/operators/tokenizer/bpe_utils.hpp
@@ -101,6 +101,13 @@ class TokenWithRegularExp {
 
  private:
   std::u32string_view TryMatch(bool skipApostrophes) {
+    // HF Python implementation for CLIP has same regex
+    // (https://github.com/huggingface/transformers/blob/v4.34.0/src/transformers/models/clip/tokenization_clip.py#L337)
+    // as below but from manual testing it works differently: for example "you're" splits as ["you", "'re"] with C++ regex
+    // compiling but Python regex compiling gives the tokens ["you", "'", "re"].
+    // 
+    // skipApostrophes is intended to bring parity with the regex compiling for Python.
+
     if (!skipApostrophes) {
       // python pattern:
       // 's|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+

--- a/operators/tokenizer/bpe_utils.hpp
+++ b/operators/tokenizer/bpe_utils.hpp
@@ -87,9 +87,9 @@ class TokenWithRegularExp {
     m_text = val;
   }
 
-  std::pair<bool, std::u32string_view> GetNextToken(bool skipApostrophes) {
+  std::pair<bool, std::u32string_view> GetNextToken() {
     while (!m_text.empty()) {
-      auto res = TryMatch(skipApostrophes);
+      auto res = TryMatch();
       if (res.empty()) {
         m_text = m_text.substr(1);
         continue;
@@ -100,36 +100,28 @@ class TokenWithRegularExp {
   }
 
  private:
-  std::u32string_view TryMatch(bool skipApostrophes) {
-    // HF Python implementation for CLIP has same regex
-    // (https://github.com/huggingface/transformers/blob/v4.34.0/src/transformers/models/clip/tokenization_clip.py#L337)
-    // as below but from manual testing it works differently: for example "you're" splits as ["you", "'re"] with C++ regex
-    // compiling but Python regex compiling gives the tokens ["you", "'", "re"].
-    // 
-    // skipApostrophes is intended to bring parity with the regex compiling for Python.
+  std::u32string_view TryMatch() {
 
-    if (!skipApostrophes) {
-      // python pattern:
-      // 's|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+
+    // python pattern:
+    // 's|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+
 
-      // 's|'t|'re|'ve|'m|'ll|'d|
-      // Note: the sequencial of the following if should not be switched, which follows the python regex's syntax
-      if ((m_text[0] == U'\'') && (m_text.size() > 1)) {
-        if ((m_text[1] == U's') || (m_text[1] == U't') ||
-            (m_text[1] == U'm') || (m_text[1] == U'd')) {
-          std::u32string_view res = m_text.substr(0, 2);
-          m_text = m_text.substr(2);
+    // 's|'t|'re|'ve|'m|'ll|'d|
+    // Note: the sequencial of the following if should not be switched, which follows the python regex's syntax
+    if ((m_text[0] == U'\'') && (m_text.size() > 1)) {
+      if ((m_text[1] == U's') || (m_text[1] == U't') ||
+          (m_text[1] == U'm') || (m_text[1] == U'd')) {
+        std::u32string_view res = m_text.substr(0, 2);
+        m_text = m_text.substr(2);
+        return res;
+      }
+
+      if (m_text.size() > 2) {
+        if (((m_text[1] == U'r') && (m_text[2] == U'e')) ||
+            ((m_text[1] == U'v') && (m_text[2] == U'e')) ||
+            ((m_text[1] == U'l') && (m_text[2] == U'l'))) {
+          std::u32string_view res = m_text.substr(0, 3);
+          m_text = m_text.substr(3);
           return res;
-        }
-
-        if (m_text.size() > 2) {
-          if (((m_text[1] == U'r') && (m_text[2] == U'e')) ||
-              ((m_text[1] == U'v') && (m_text[2] == U'e')) ||
-              ((m_text[1] == U'l') && (m_text[2] == U'l'))) {
-            std::u32string_view res = m_text.substr(0, 3);
-            m_text = m_text.substr(3);
-            return res;
-          }
         }
       }
     }

--- a/operators/tokenizer/bpe_utils.hpp
+++ b/operators/tokenizer/bpe_utils.hpp
@@ -87,9 +87,9 @@ class TokenWithRegularExp {
     m_text = val;
   }
 
-  std::pair<bool, std::u32string_view> GetNextToken() {
+  std::pair<bool, std::u32string_view> GetNextToken(bool skipApostrophes) {
     while (!m_text.empty()) {
-      auto res = TryMatch();
+      auto res = TryMatch(skipApostrophes);
       if (res.empty()) {
         m_text = m_text.substr(1);
         continue;
@@ -100,27 +100,29 @@ class TokenWithRegularExp {
   }
 
  private:
-  std::u32string_view TryMatch() {
-    // python pattern:
-    // 's|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+
+  std::u32string_view TryMatch(bool skipApostrophes) {
+    if (!skipApostrophes) {
+      // python pattern:
+      // 's|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+
 
-    // 's|'t|'re|'ve|'m|'ll|'d|
-    // Note: the sequencial of the following if should not be switched, which follows the python regex's syntax
-    if ((m_text[0] == U'\'') && (m_text.size() > 1)) {
-      if ((m_text[1] == U's') || (m_text[1] == U't') ||
-          (m_text[1] == U'm') || (m_text[1] == U'd')) {
-        std::u32string_view res = m_text.substr(0, 2);
-        m_text = m_text.substr(2);
-        return res;
-      }
-
-      if (m_text.size() > 2) {
-        if (((m_text[1] == U'r') && (m_text[2] == U'e')) ||
-            ((m_text[1] == U'v') && (m_text[2] == U'e')) ||
-            ((m_text[1] == U'l') && (m_text[2] == U'l'))) {
-          std::u32string_view res = m_text.substr(0, 3);
-          m_text = m_text.substr(3);
+      // 's|'t|'re|'ve|'m|'ll|'d|
+      // Note: the sequencial of the following if should not be switched, which follows the python regex's syntax
+      if ((m_text[0] == U'\'') && (m_text.size() > 1)) {
+        if ((m_text[1] == U's') || (m_text[1] == U't') ||
+            (m_text[1] == U'm') || (m_text[1] == U'd')) {
+          std::u32string_view res = m_text.substr(0, 2);
+          m_text = m_text.substr(2);
           return res;
+        }
+
+        if (m_text.size() > 2) {
+          if (((m_text[1] == U'r') && (m_text[2] == U'e')) ||
+              ((m_text[1] == U'v') && (m_text[2] == U'e')) ||
+              ((m_text[1] == U'l') && (m_text[2] == U'l'))) {
+            std::u32string_view res = m_text.substr(0, 3);
+            m_text = m_text.substr(3);
+            return res;
+          }
         }
       }
     }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # include requirements.txt so pip has context to avoid installing incompatible dependencies
 -r requirements.txt
 pytest
+ftfy
 # multiple versions of onnxruntime are supported, but only one can be installed at a time
 protobuf         < 4.0.0
 onnxruntime      >=1.12.0

--- a/test/test_autotokenizer.py
+++ b/test/test_autotokenizer.py
@@ -60,7 +60,10 @@ class TestAutoTokenizer(unittest.TestCase):
 
     def test_clip_tokenizer(self):
         tokenizer = AutoTokenizer.from_pretrained("openai/clip-vit-base-patch32", use_fast=False)
-        text = "you're i'm don't"
+        text = """
+               1. Testing long text with multiple lines to check newline handling
+               2. And weird characters such as . , ~ ? ( ) " [ ] ! : - .
+               """
         ids = tokenizer.encode(text, return_tensors="np")
 
         ort_tok = OrtPyFunction.from_model(gen_processing_models(

--- a/test/test_autotokenizer.py
+++ b/test/test_autotokenizer.py
@@ -3,6 +3,7 @@
 import unittest
 
 import numpy as np
+import ftfy
 from transformers import AutoTokenizer, GPT2Tokenizer
 from onnxruntime_extensions import OrtPyFunction, gen_processing_models, ort_inference, util
 
@@ -49,7 +50,10 @@ class TestAutoTokenizer(unittest.TestCase):
 
     def test_roberta_base(self):
         tokenizer = AutoTokenizer.from_pretrained("SamLowe/roberta-base-go_emotions", use_fast=False)
-        text = "Agree. Keep trying, then if your rejected every time. I'm sorry your done."
+        text = """
+               Agree. Keep trying, then if your rejected every time. I'm sorry your done.
+               Testing words with apostrophes such as you're, i'm, don't, etc.
+               """
         ids = tokenizer.encode(text, return_tensors="np")
         m_tok, m_detok = gen_processing_models(tokenizer, pre_kwargs={}, post_kwargs={})
 
@@ -62,7 +66,8 @@ class TestAutoTokenizer(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained("openai/clip-vit-base-patch32", use_fast=False)
         text = """
                1. Testing long text with multiple lines to check newline handling
-               2. And weird characters such as . , ~ ? ( ) " [ ] ! : - .
+               2. As well as words with apostrophes such as you're, i'm, don't, etc.
+               3. And weird characters such as . , ~ ? ( ) " [ ] ! : - .
                """
         ids = tokenizer.encode(text, return_tensors="np")
 
@@ -74,7 +79,7 @@ class TestAutoTokenizer(unittest.TestCase):
         
     def test_gpt2_tokenizer(self):
         tokenizer = GPT2Tokenizer.from_pretrained("Xenova/gpt-4", use_fast=False)
-        text = "Deep learning has come a long way, no?"
+        text = "Testing words with apostrophes such as you're, i'm, don't, etc."
         ids = tokenizer.encode(text, return_tensors="np")
 
         ort_tok = OrtPyFunction.from_model(gen_processing_models(

--- a/test/test_autotokenizer.py
+++ b/test/test_autotokenizer.py
@@ -63,7 +63,6 @@ class TestAutoTokenizer(unittest.TestCase):
         text = """
                1. Testing long text with multiple lines to check newline handling
                2. As well as words with apostrophes such as you're, i'm, don't, etc.
-               3. And weird characters such as . , ~ ? ( ) " [ ] ! : - .
                """
         ids = tokenizer.encode(text, return_tensors="np")
 

--- a/test/test_autotokenizer.py
+++ b/test/test_autotokenizer.py
@@ -60,10 +60,7 @@ class TestAutoTokenizer(unittest.TestCase):
 
     def test_clip_tokenizer(self):
         tokenizer = AutoTokenizer.from_pretrained("openai/clip-vit-base-patch32", use_fast=False)
-        text = """
-               1. Testing long text with multiple lines to check newline handling
-               2. As well as words with apostrophes such as you're, i'm, don't, etc.
-               """
+        text = "you're i'm don't"
         ids = tokenizer.encode(text, return_tensors="np")
 
         ort_tok = OrtPyFunction.from_model(gen_processing_models(

--- a/test/test_autotokenizer.py
+++ b/test/test_autotokenizer.py
@@ -60,7 +60,11 @@ class TestAutoTokenizer(unittest.TestCase):
 
     def test_clip_tokenizer(self):
         tokenizer = AutoTokenizer.from_pretrained("openai/clip-vit-base-patch32", use_fast=False)
-        text = "Wow, these models are getting popular."
+        text = """
+               1. Testing long text with multiple lines to check newline handling
+               2. As well as words with apostrophes such as you're, i'm, don't, etc.
+               3. And weird characters such as . , ~ ? ( ) " [ ] ! : - .
+               """
         ids = tokenizer.encode(text, return_tensors="np")
 
         ort_tok = OrtPyFunction.from_model(gen_processing_models(

--- a/test/test_cliptok.py
+++ b/test/test_cliptok.py
@@ -73,7 +73,7 @@ class TestCLIPTokenizer(unittest.TestCase):
         cls.slow_tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-base-patch32")
         cls.tokenizer_cvt = HFTokenizerConverter(cls.slow_tokenizer)
 
-    def _run_tokenizer(self, test_sentence, padding_length=-1):
+    def _run_tokenizer(self, test_sentence, padding_length=-1, use_slow=False):
         model = _create_test_model(vocab_file=self.tokjson, merges_file=self.merges,
                                    max_length=padding_length, attention_mask=True, offset_map=True)
         so = _ort.SessionOptions()
@@ -81,7 +81,7 @@ class TestCLIPTokenizer(unittest.TestCase):
         sess = _ort.InferenceSession(model.SerializeToString(), so, providers=["CPUExecutionProvider"])
         input_text = np.array(test_sentence)
         input_ids, attention_mask, _ = sess.run(None, {'string_input': input_text})
-        clip_out = self.tokenizer(test_sentence, return_offsets_mapping=True)
+        clip_out = self.slow_tokenizer(test_sentence) if use_slow else self.tokenizer(test_sentence, return_offsets_mapping=True)
         expect_input_ids = clip_out['input_ids']
         expect_attention_mask = clip_out['attention_mask']
         np.testing.assert_array_equal(expect_input_ids, input_ids)
@@ -105,6 +105,10 @@ class TestCLIPTokenizer(unittest.TestCase):
         self._run_tokenizer(["Testing multiple      sequences       of spaces"])
         self._run_tokenizer(["      in the beginning and the end.      "])
         self._run_tokenizer([" "])
+        
+        # Currently, HF CLIPTokenizer and CLIPTokenizerFast implementations are not consistent with apostrophe handling
+        # so we test aposrophe handling against the regular HF CLIPTokenizer Python implementation.
+        self._run_tokenizer(["Testing words with apostrophes such as you're, i'm, don't, etc."], use_slow=True)
 
     def test_converter(self):
         fn_tokenizer = PyOrtFunction.from_customop("CLIPTokenizer",

--- a/test/test_cliptok.py
+++ b/test/test_cliptok.py
@@ -1,6 +1,7 @@
 ﻿import unittest
 import numpy as np
 import onnxruntime as _ort
+import ftfy
 
 from pathlib import Path
 from onnx import helper, onnx_pb as onnx_proto
@@ -107,8 +108,9 @@ class TestCLIPTokenizer(unittest.TestCase):
         self._run_tokenizer([" "])
         
         # Currently, HF CLIPTokenizer and CLIPTokenizerFast implementations are not consistent with apostrophe handling
-        # so we test aposrophe handling against the regular HF CLIPTokenizer Python implementation.
+        # until ftfy is installed so we test aposrophe handling for both slow and fast Python implementations.
         self._run_tokenizer(["Testing words with apostrophes such as you're, i'm, don't, etc."], use_slow=True)
+        self._run_tokenizer(["Testing words with apostrophes such as you're, i'm, don't, etc."])
 
     def test_converter(self):
         fn_tokenizer = PyOrtFunction.from_customop("CLIPTokenizer",


### PR DESCRIPTION
fixes newline and apostrophe handling for issues discovered by long text testing.

**Update**: CLIPTokenizer tokenizes apostrophes separately (['you', ''', 're']) but CLIPTokenizerFast tokenizes together (['you', ''re']), **unless ftfy is installed**: https://github.com/huggingface/transformers/issues/22166.