### PR TITLE
Remove ftfy warning after latest HF transformers update fixes CLIP discrepancy

### DIFF
--- a/test/test_autotokenizer.py
+++ b/test/test_autotokenizer.py
@@ -129,8 +129,4 @@ class TestAutoTokenizer(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    try:
-        dist = pkg_resources.get_distribution('ftfy')
-    except pkg_resources.DistributionNotFound:
-        raise Exception("WARNING: ftfy is not installed - it is required for parity between CLIPTokenizer and CLIPTokenizerFast.")
     unittest.main()


### PR DESCRIPTION
Remove ftfy warning after latest HF Update fixes CLIP discrepancy