### PR TITLE
Add BPE cache to improve efficiency of BPE Tokenizers

### DIFF
--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -132,6 +132,13 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input,
                                                   std::list<OffsetMappingType>& offset_map) const {
   std::vector<int64_t> res;
   std::list<std::pair<uint32_t, uint32_t>> byte_list;
+
+  // HF implements a cache for BPE:
+  // https://github.com/huggingface/transformers/blob/6f316016877197014193b9463b2fd39fa8f0c8e4/src/transformers/models/gpt2/tokenization_gpt2.py#L216C6-L216C6
+
+  // We use a LRU cache algorithm for the same in C++ in order to save compute.
+
+  // Current cache capacity is set to a relatively small 500 in order to support mobile platforms.
   LRUCache bpe_cache = LRUCache(500);
 
   bool clean_up_spaces = false;

--- a/operators/tokenizer/bpe_utils.hpp
+++ b/operators/tokenizer/bpe_utils.hpp
@@ -249,7 +249,7 @@ class LRUCache {
   LRUCache(int n) { capacity = n; }
 
   // Add tok to the LRU cache
-  void add(std::string tok, std::list<std::pair<uint32_t, uint32_t>> output) {
+  void Add(const std::string& tok, std::list<std::pair<uint32_t, uint32_t>> output) {
     // token not present in cache
     if (references.find(tok) == references.end()) {
       // cache is full
@@ -281,7 +281,7 @@ class LRUCache {
   }
 
   // Check if token is already tokenized
-  bool already_tokenized(std::string tok) {
+  bool AlreadyTokenized(std::string tok) {
     bool tokenized = input_ids_and_offsets.find(tok) != input_ids_and_offsets.end();
     if (tokenized) {
       // update keys and references since tok is now recently used
@@ -293,7 +293,7 @@ class LRUCache {
   }
 
   // Return output for token that is already tokenized
-  std::list<std::pair<uint32_t, uint32_t>> get_output(std::string tok) {
+  std::list<std::pair<uint32_t, uint32_t>> GetOutput(std::string tok) {
     return input_ids_and_offsets[tok];
   }
 };


### PR DESCRIPTION
HF also implements a cache for BPE: https://github.com/huggingface/transformers/blob/6f316016877197014193b9463b2fd39fa8f0c8e4/src/transformers/models/gpt2/tokenization_gpt2.py#L216C6-L216C6

We use a LRU cache algorithm for the same in C++.