### PR TITLE
Add compatibility with v17 API

### DIFF
--- a/includes/custom_op_lite.h
+++ b/includes/custom_op_lite.h
@@ -845,6 +845,12 @@ struct OrtLiteCustomOp : public OrtCustomOp {
     OrtCustomOp::CreateKernelV2 = nullptr;
     OrtCustomOp::KernelComputeV2 = nullptr;
 #endif
+
+#if ORT_API_VERSION >= 17
+    OrtCustomOp::InferOutputShapeFn = nullptr;
+    OrtCustomOp::GetStartVersion = nullptr;
+    OrtCustomOp::GetEndVersion = nullptr;
+#endif
   }
 
   const std::string op_name_;


### PR DESCRIPTION
This follows the existing pattern but I wonder if a better fix would be for ops to report their supported version as 16? The code would then work as-is with v18 etc. whereas the current pattern requires updates each time the API is extended. Fixes #572