### PR TITLE
Make ort extensions build successfully on Linux GPU 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -814,6 +814,7 @@ if(_BUILD_SHARED_LIBRARY)
 endif()
 
 if(OCOS_USE_CUDA)
+  target_include_directories(ocos_operators PUBLIC ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
   target_include_directories(ortcustomops PUBLIC ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
   target_link_libraries(extensions_shared PUBLIC cudart cublas cufft)
 endif()

--- a/cmake/ext_tests.cmake
+++ b/cmake/ext_tests.cmake
@@ -59,6 +59,10 @@ function(add_test_target)
                           ${ARG_LIBRARIES}
                           gtest gmock)
 
+    if(OCOS_USE_CUDA)
+      target_link_directories(${ARG_TARGET} PRIVATE $ENV{CUDA_PATH}/lib64)
+    endif()
+
     set(test_data_destination_root_directory ${onnxruntime_extensions_BINARY_DIR})
 
   else()
@@ -126,10 +130,6 @@ file(GLOB static_TEST_SRC "${TEST_SRC_DIR}/static_test/*.cc")
 add_test_target(TARGET ocos_test
                 TEST_SOURCES ${static_TEST_SRC}
                 LIBRARIES ortcustomops ${ocos_libraries})
-
-if(OCOS_USE_CUDA)
-  target_link_libraries(ocos_test PUBLIC cudart cublas cufft)
-endif()
 
 # -- shared test (needs onnxruntime) --
 SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)

--- a/cmake/ext_tests.cmake
+++ b/cmake/ext_tests.cmake
@@ -127,6 +127,10 @@ add_test_target(TARGET ocos_test
                 TEST_SOURCES ${static_TEST_SRC}
                 LIBRARIES ortcustomops ${ocos_libraries})
 
+if(OCOS_USE_CUDA)
+  target_link_libraries(ocos_test PUBLIC cudart cublas cufft)
+endif()
+
 # -- shared test (needs onnxruntime) --
 SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
 find_library(ONNXRUNTIME onnxruntime HINTS "${ONNXRUNTIME_LIB_DIR}")


### PR DESCRIPTION
How to test locally:
export CUDA_PATH=/usr/local/cuda-11.8
sh ./build.sh -DOCOS_ENABLE_CTEST=ON -DOCOS_ONNXRUNTIME_VERSION={ORT_VERSION} -DOCOS_USE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=86 -DONNXRUNTIME_PKG_DIR={ORT_RELEASE_DIR} 

Note:
1. Since std::filesystem is used in unit test, gcc version should be bigger than 9.0
2. CI pipeline will be enabled in next PR.