### PR TITLE
Fix batching in fairseq SentencepieceTokenizer

### DIFF
--- a/operators/tokenizer/sentencepiece_tokenizer.cc
+++ b/operators/tokenizer/sentencepiece_tokenizer.cc
@@ -85,6 +85,9 @@ OrtStatusPtr KernelSentencepieceTokenizer::Compute(const ortc::Tensor<std::strin
       }
     }
   }
+  instance_indices.push_back(content.size());
+
+  // Patch fairseq indices
   if (fairseq.has_value() && (*fairseq) && !add_rev) {
     // HF Fairseq Example (XLMRobertaTokenizer) : https://huggingface.co/transformers/v4.6.0/_modules/transformers/models/xlm_roberta/tokenization_xlm_roberta.html#XLMRobertaTokenizer
     //
@@ -106,7 +109,6 @@ OrtStatusPtr KernelSentencepieceTokenizer::Compute(const ortc::Tensor<std::strin
       }
     });
   }
-  instance_indices.push_back(content.size());
 
   // Setup output
   std::vector<int64_t> size_content(1);


### PR DESCRIPTION
This fixes #639 by moving the fairseq id patching out of the loop so it's not applied multiple times to sequences earlier in the batch.

I've added the check to ensure it's not applied when `add_rev` is true mirroring its position in the for loop, but I'm unsure if that's required (presumably there are no HF tokenizers which emit a reversed string and have this fairseq hack?).

I tested it against the example in #639 and both batches and single sequences work correctly now.