### PR TITLE
Fix nuget pipeline for onnxruntime-extensions

### DIFF
--- a/.pipelines/templates/build-package-for-nuget.yml
+++ b/.pipelines/templates/build-package-for-nuget.yml
@@ -77,14 +77,6 @@ stages:
     parameters:
       DoCompliance: ${{ parameters.DoCompliance }}
       DoEsrp: ${{ parameters.DoEsrp }}
-      StageNameSuffix: CPU_arm
-      BuildPlatform: arm
-      AdditionalBuildFlags: ${{parameters.OperatorSelectionFlags}} ${{parameters.AdditionalBuildFlags}}
-
-  - template: build-package-for-windows.yml
-    parameters:
-      DoCompliance: ${{ parameters.DoCompliance }}
-      DoEsrp: ${{ parameters.DoEsrp }}
       StageNameSuffix: CPU_arm64
       BuildPlatform: arm64
       AdditionalBuildFlags: ${{parameters.OperatorSelectionFlags}} ${{parameters.AdditionalBuildFlags}}
@@ -159,11 +151,6 @@ stages:
         artifactName: 'onnxruntime-extensions-win-arm64'
         targetPath: '$(Build.BinariesDirectory)/artifact-downloads'
 
-    - task: DownloadPipelineArtifact@0
-      displayName: 'Download win-arm Pipeline Artifact'
-      inputs:
-        artifactName: 'onnxruntime-extensions-win-arm'
-        targetPath: '$(Build.BinariesDirectory)/artifact-downloads'
     - task: DownloadPipelineArtifact@0
       displayName: 'Download osx-all Pipeline Artifact'
       inputs:

--- a/.pipelines/templates/build-package-for-windows.yml
+++ b/.pipelines/templates/build-package-for-windows.yml
@@ -15,7 +15,6 @@ parameters:
   - 'x86'
   - 'x64'
   - 'arm64'
-  - 'arm'
 
 - name: StageNameSuffix
   displayName: job name for nuget
@@ -43,7 +42,7 @@ jobs:
       clean: true
       submodules: none
 
-    # Currently we can only run tests on x64. x86 tests faile. arm/arm64 tests can't be run as the build machine is amd64
+    # Currently we can only run tests on x64. x86 tests faile. arm64 tests can't be run as the build machine is amd64
     # TODO: Fix these issues so the nuget build is properly tested.
     - ${{ if eq(parameters.BuildPlatform, 'x64') }}:
       - task: BatchScript@1


### PR DESCRIPTION
Onnxruntime dropped support for ARM32 in 1.17.1. Make corresponding changes here to keep the nuget pipeline happy.