### PR TITLE
Ensure ONNX model generation considers opset version

### DIFF
--- a/onnxruntime_extensions/cvt.py
+++ b/onnxruntime_extensions/cvt.py
@@ -90,7 +90,7 @@ def gen_processing_models(processor: Union[str, object],
             **pre_kwargs) if pre_kwargs is not None else None
         post_g = _converter.post_processing(
             **post_kwargs) if post_kwargs is not None else None
-        return make_onnx_model(pre_g) if pre_g else None, \
-            make_onnx_model(post_g) if post_g else None
+        return make_onnx_model(pre_g, opset_version=opset) if pre_g else None, \
+            make_onnx_model(post_g, opset_version=opset) if post_g else None
     else:
         raise ValueError(f"Unsupported processor/tokenizer: {cls_name}")


### PR DESCRIPTION
This commit modifies the `gen_processing_models` function in `onnxruntime_extensions/cvt.py` to explicitly include the `opset_version` argument when calling `make_onnx_model` for both pre-processing and post-processing graphs.

Previously, the function only generated models if `pre_g` or `post_g` existed, without specifying the opset version. This update ensures that generated ONNX models adhere to the desired opset level, improving compatibility and deployment options.