### PR TITLE
Return added_tokens_ by reference

### DIFF
--- a/operators/tokenizer/bpe_kernels.h
+++ b/operators/tokenizer/bpe_kernels.h
@@ -115,7 +115,7 @@ class JsonFastTokenizer : KernelBpeTokenizer {
                      std::optional<ortc::Tensor<int64_t>*> offset_mapping) const;
 
  public:
-  auto& GetAddedTokens() const { return added_tokens_; }
+  const auto& GetAddedTokens() const { return added_tokens_; }
   const ort_extensions::BpeModel& GetEncoder() const { return *bbpe_tokenizer_; }
 
  private:

--- a/operators/tokenizer/bpe_kernels.h
+++ b/operators/tokenizer/bpe_kernels.h
@@ -115,7 +115,7 @@ class JsonFastTokenizer : KernelBpeTokenizer {
                      std::optional<ortc::Tensor<int64_t>*> offset_mapping) const;
 
  public:
-  auto GetAddedTokens() const { return added_tokens_; }
+  auto& GetAddedTokens() const { return added_tokens_; }
   const ort_extensions::BpeModel& GetEncoder() const { return *bbpe_tokenizer_; }
 
  private:

--- a/operators/tokenizer/bpe_streaming.hpp
+++ b/operators/tokenizer/bpe_streaming.hpp
@@ -31,7 +31,7 @@ class BpeStreamingDecoder : public KernelBpeDecoder {
     eos_token_ = tok_config.eos_token_;
     unk_token_ = tok_config.unk_token_;
 
-    auto& a_toks = encoder.GetAddedTokens();
+    const auto& a_toks = encoder.GetAddedTokens();
     for (const auto& tok : a_toks) {
       added_tokens_[tok.id_] = tok.content_;
       if (tok.special_) {


### PR DESCRIPTION
https://github.com/microsoft/onnxruntime-extensions/blob/c58c930739ffa481744d59a3e170895e1461b9b4/operators/tokenizer/bpe_streaming.hpp#L34 is expecting a reference, but the function does not return a reference resulting in a compiler error.

This PR addresses this issue.