### PR TITLE
[java] Setting Java module name to com.microsoft.onnxruntime.extensions

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -113,7 +113,7 @@ if (cmakeBuildDir != null) {
     // Overwrite jar location
     task allJar(type: Jar) {
         manifest {
-            attributes('Automatic-Module-Name': project.group,
+            attributes('Automatic-Module-Name': "com.microsoft.onnxruntime.extensions",
                     'Implementation-Title': 'onnxruntime-extensions',
                     'Implementation-Version': project.version)
         }


### PR DESCRIPTION
The Java module system (introduced in Java 9) requires that all modules on the module path have unique names, and the current name for ORT-extensions collides with ORT as both use `com.microsoft.onnxruntime`. This PR changes the ORT-extensions module name to `com.microsoft.onnxruntime.extensions` to remove the collision.

If they are colliding then work needs to be done in the user's build system to pull ORT-extensions off from the module path and put it on the classpath which can be irritating to do particularly if it's consumed by a third party dependency which might not be doing a module aware build.