### PR TITLE
Fix component governance issues.

### DIFF
--- a/.pipelines/android_packaging.yml
+++ b/.pipelines/android_packaging.yml
@@ -79,3 +79,7 @@ jobs:
       - publish: "$(Build.ArtifactStagingDirectory)"
         artifact: onnxruntime-extensions-android-aar
         displayName: "Publish artifacts"
+
+      - template: templates/component-governance-component-detection-steps.yml
+        parameters :
+          condition : 'succeeded'

--- a/.pipelines/ios_packaging.yml
+++ b/.pipelines/ios_packaging.yml
@@ -171,3 +171,7 @@ jobs:
   - publish: "$(Build.ArtifactStagingDirectory)"
     artifact: ios_packaging_artifacts
     displayName: "Publish artifacts"
+
+  - template: templates/component-governance-component-detection-steps.yml
+    parameters :
+      condition : 'succeeded'

--- a/.pipelines/templates/android-shared-lib-build.yml
+++ b/.pipelines/templates/android-shared-lib-build.yml
@@ -71,3 +71,7 @@ jobs:
       - publish: "$(Build.ArtifactStagingDirectory)"
         artifact: onnxruntime-extensions-android-${{ parameters.AndroidABI }}
         displayName: "Publish artifacts"
+
+      - template: component-governance-component-detection-steps.yml
+        parameters :
+          condition : 'succeeded'

--- a/.pipelines/templates/build-package-for-linux.yml
+++ b/.pipelines/templates/build-package-for-linux.yml
@@ -96,6 +96,10 @@ jobs:
         targetPath: '$(Build.ArtifactStagingDirectory)'
         artifactName: 'onnxruntime-extensions-linux-${{parameters.OrtExtensionsArch}}'
 
+    - template: component-governance-component-detection-steps.yml
+      parameters :
+        condition : 'succeeded'
+
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'
       condition: always()

--- a/.pipelines/templates/build-package-for-nuget.yml
+++ b/.pipelines/templates/build-package-for-nuget.yml
@@ -275,10 +275,6 @@ stages:
         targetPath: '$(Build.ArtifactStagingDirectory)'
         artifactName: 'drop-signed-nuget-CPU'
 
-    - template: component-governance-component-detection-steps.yml
-      parameters :
-        condition : 'succeeded'
-
     - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
       displayName: 'Clean Agent Directories'
       condition: always()

--- a/.pipelines/templates/build-package-for-windows.yml
+++ b/.pipelines/templates/build-package-for-windows.yml
@@ -106,3 +106,7 @@ jobs:
       inputs:
         targetPath: '$(Build.ArtifactStagingDirectory)'
         artifactName: 'onnxruntime-extensions-win-${{parameters.BuildPlatform}}'
+
+    - template: component-governance-component-detection-steps.yml
+      parameters :
+        condition : 'succeeded'

--- a/.pipelines/templates/component-governance-component-detection-steps.yml
+++ b/.pipelines/templates/component-governance-component-detection-steps.yml
@@ -8,7 +8,21 @@ steps:
 - ${{ if eq(variables['System.TeamProject'], 'Lotus') }}: 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
+    continueOnError: true
     condition:
       or(or(and(eq('${{parameters.condition}}', 'ci_only'), and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI', 'Scheduled'))),
           and(eq('${{parameters.condition}}', 'always'), always())),
           and(eq('${{parameters.condition}}', 'succeeded'), succeeded()))
+    inputs:
+      # ignore unused language bindings from 3rd party dependencies.
+      # skip the multi-build directories used for the Android and iOS packages. the contents of _deps is covered
+      # by the other builds where we explicitly exclude a subset of _deps
+      ignoreDirectories:
+        '$(Build.BinariesDirectory)/out/RelWithDebInfo/_deps/triton-src/src/grpc_generated,
+        $(Build.BinariesDirectory)/out/RelWithDebInfo/_deps/protobuf-src/benchmarks,
+        $(Build.BinariesDirectory)/out/RelWithDebInfo/_deps/protobuf-src/examples,
+        $(Build.BinariesDirectory)/out/RelWithDebInfo/_deps/protobuf-src/java,
+        $(Build.BinariesDirectory)/out/RelWithDebInfo/_deps/protobuf-src/js,
+        $(Build.BinariesDirectory)/out/RelWithDebInfo/_deps/protobuf-src/ruby,
+        $(Build.BinariesDirectory)/xcframework_out,
+        $(Build.BinariesDirectory)/android_aar'

--- a/.pipelines/templates/ios-framework-build.yml
+++ b/.pipelines/templates/ios-framework-build.yml
@@ -72,3 +72,7 @@ jobs:
       - publish: "$(Build.ArtifactStagingDirectory)"
         artifact: onnxruntime-extensions-ios-${{ parameters.Platform }}-${{ parameters.IosArch }}-lib
         displayName: "Publish artifacts"
+
+      - template: component-governance-component-detection-steps.yml
+        parameters :
+          condition : 'succeeded'

--- a/.pipelines/templates/mac-shared-lib-build.yml
+++ b/.pipelines/templates/mac-shared-lib-build.yml
@@ -70,3 +70,7 @@ jobs:
 
   - publish: '$(Build.ArtifactStagingDirectory)'
     artifact: 'onnxruntime-extensions-osx-${{ parameters.MacosArch }}'
+
+  - template: component-governance-component-detection-steps.yml
+    parameters :
+      condition : 'succeeded'

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -5,18 +5,20 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "v1.14.1",
+          "commitHash": "8f5c79cb63f09ef1302e85081093a3fe4da1bc7d",
           "repositoryUrl": "https://github.com/microsoft/onnxruntime.git"
-        }
+        },
+        "comments": "v1.17.1"
       }
     },
     {
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "6e511679de8ab0feefc1cdac1505b2fac5548e42",
+          "commitHash": "fe271ab76f2ad2b2b28c10443865d2af21e27e0e",
           "repositoryUrl": "https://github.com/protocolbuffers/protobuf.git"
-        }
+        },
+        "comments": "v3.20.3"
       }
     },
     {
@@ -50,16 +52,17 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "2021-06-01",
+          "commitHash": "4244cd1cb492fa1d10986ec67f862964c073f844",
           "repositoryUrl": "https://github.com/google/re2.git"
-        }
+        },
+        "comments": "2021-06-01"
       }
     },
     {
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "release-1.11.0",
+          "commitHash": "9406a60c7839052e4944ea4dbc8344762a89f9bd",
           "repositoryUrl": "https://github.com/google/googletest.git"
         }
       }
@@ -68,85 +71,93 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "3.24.0",
+          "commitHash": "a3534567187d2edc428efd3f13466ff75fe5805c",
           "repositoryUrl": "https://github.com/microsoft/GSL.git"
-        }
+        },
+        "comments": "v4.0.0"
       }
     },
     {
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "v3.10.5",
+          "commitHash": "4f8fba14066156b73f1189a2b8bd568bde5284c5",
           "repositoryUrl": "https://github.com/nlohmann/json.git"
-        }
+        },
+        "comments": "v3.10.5"
       }
     },
     {
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "4.5.4",
+          "commitHash": "4223495e6cd67011f86b8ecd9be1fa105018f3b1",
           "repositoryUrl": "https://github.com/opencv/opencv.git"
-        }
+        },
+        "comments": "4.5.4"
       }
     },
     {
       "component": {
-        "type": "git",
-        "git": {
-          "commitHash": "364702b1c98943e4e306e745389d3f464010f069",
-          "repositoryUrl": "https://github.com/opencv/opencv/tree/4.x/3rdparty/libjpeg"
+        "type": "other",
+        "other": {
+          "name": "libjpeg",
+          "version": "9d  12-Jan-2020",
+          "downloadUrl": "https://github.com/opencv/opencv/tree/4.5.4/3rdparty/libjpeg"
         },
         "comments": "Used by OpenCV"
       }
     },
     {
       "component": {
-        "type": "git",
-        "git": {
-          "commitHash": "a2fc479c0b36d1786a9570ddb76f2ab72626994b",
-          "repositoryUrl": "https://github.com/opencv/opencv/tree/4.x/3rdparty/openjpeg"
+        "type": "other",
+        "other": {
+          "name": "openjpg",
+          "version": "v2.4.0",
+          "downloadUrl": "https://github.com/opencv/opencv/tree/4.5.4/3rdparty/openjpg"
         },
         "comments": "Used by OpenCV"
       }
     },
     {
       "component": {
-        "type": "git",
-        "git": {
-          "commitHash": "d9bf522b271ed026813cbe35399b5aead3c9b670",
-          "repositoryUrl": "https://github.com/opencv/opencv/tree/4.x/3rdparty/libpng"
+        "type": "other",
+        "other": {
+          "name": "libjpeg",
+          "version": "1.6.37",
+          "downloadUrl": "https://github.com/opencv/opencv/tree/4.5.4/3rdparty/libpng"
         },
         "comments": "Used by OpenCV"
       }
     },
     {
       "component": {
+        "other": {
+          "name": "zlib",
+          "version": "1.2.11",
+          "downloadUrl": "https://github.com/opencv/opencv/tree/4.5.4/3rdparty/zlib"
+        },
+        "comments": "Used by OpenCV. https://github.com/madler/zlib.git"
+      }
+    },
+    {
+      "component": {
         "type": "git",
         "git": {
-          "commitHash": "v2.6.2",
+          "commitHash": "80dc998efced8ceb2be59756668a7e90e8bef917",
           "repositoryUrl": "https://github.com/pybind/pybind11.git"
-        }
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "commitHash": "v0.1.96",
-          "repositoryUrl": "https://github.com/google/sentencepiece.git"
-        }
-      }
-    },
-    {
-      "component": {
-        "type": "git",
-        "git": {
-          "commitHash": "v1.2.13",
-          "repositoryUrl": "https://github.com/madler/zlib.git"
         },
-        "comments": "Used by OpenCV"
+        "comments": "v2.10.1"
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "commitHash": "d8711f55d9b2cb9c77a00adcc18108482b29b675",
+          "repositoryUrl": "https://github.com/google/sentencepiece.git"
+        },
+        "comments": "v0.1.96"
       }
     },
     {

--- a/cmake/externals/sentencepieceproject.cmake
+++ b/cmake/externals/sentencepieceproject.cmake
@@ -9,7 +9,7 @@ if(NOT _ONNXRUNTIME_EMBEDDED)
   FetchContent_Declare(
     protobuf
     GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git
-    GIT_TAG v3.20.2
+    GIT_TAG v3.20.3
     PATCH_COMMAND git checkout . && git apply --ignore-space-change --ignore-whitespace ${PROJECT_SOURCE_DIR}/cmake/externals/protobuf_cmake.patch
   )
   set(protobuf_BUILD_TESTS OFF CACHE BOOL "Build tests")

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -148,7 +148,7 @@ if (cmakeBuildDir != null) {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
-    testImplementation 'com.google.protobuf:protobuf-java:3.20.1'
+    testImplementation 'com.google.protobuf:protobuf-java:3.21.7'
 }
 
 processTestResources {


### PR DESCRIPTION
Fix component governance warnings:
- update protobuf version being used by sentencepiece and the java tests
- ignore unused language bindings from protobuf and triton
- specify the CG config file with ignored directories where required

Fix cgmanifest.json:
- 'git' entries require a commit hash not version
- use 'other' for opencv third party code that is included directly in the opencv repo
  - the path isn't a valid repositoryUrl value to be provided as a 'git' entry
- update version numbers/commit hashes to match the latest code