### PR TITLE
disable azure ops from ci/packaging pipelines

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -121,7 +121,7 @@ stages:
       inputs:
         versionSpec: '3.x'
         disableDownloadFromRegistry: true
-        addToPath: false
+        addToPath: true
         architecture: 'x64'
 
     - script: |
@@ -507,7 +507,7 @@ stages:
       inputs:
         versionSpec: '3.x'
         disableDownloadFromRegistry: true
-        addToPath: false
+        addToPath: true
         architecture: 'x64'
       displayName: Use ADO python task
 
@@ -583,7 +583,7 @@ stages:
         inputs:
           versionSpec: '3.x'
           disableDownloadFromRegistry: true
-          addToPath: false
+          addToPath: true
           architecture: 'x64'
         displayName: Use ADO python task
 

--- a/.pipelines/ci_optional.yml
+++ b/.pipelines/ci_optional.yml
@@ -132,7 +132,7 @@ stages:
       inputs:
         versionSpec: '3.x'
         disableDownloadFromRegistry: true
-        addToPath: false
+        addToPath: true
         architecture: 'x64'
       displayName: Use ADO python task
 
@@ -172,7 +172,7 @@ stages:
         inputs:
           versionSpec: '3.x'
           disableDownloadFromRegistry: true
-          addToPath: false
+          addToPath: true
           architecture: 'x64'
         displayName: Use ADO python task
 

--- a/.pipelines/wheels_linux.yml
+++ b/.pipelines/wheels_linux.yml
@@ -2,7 +2,7 @@ parameters:
 - name: ExtraEnv
   displayName: 'Extra env variable set to CIBW_ENVIRONMENT, in form of "A=1 B=2 C=3"'
   type: string
-  default: 'OCOS_ENABLE_AZURE=1'
+  default: 'OCOS_ENABLE_AZURE=0'
 
 jobs:
 - job: linux_x86_64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,12 @@ set(OCOS_ONNXRUNTIME_PKG_URI "" CACHE STRING
 set(OCOS_BUILD_PRESET "" CACHE STRING
   "Specify the build preset cmake settings file path, like 'token_api_only' which includes ./cmake/presets/token_api_only.cmake")
 
+# AzureOp can be enabled by environment varaible OCOS_ENABLE_AZURE == 1
+if (DEFINED ENV{OCOS_ENABLE_AZURE})
+  set(OCOS_ENABLE_AZURE ON CACHE INTERNAL "" FORCE)
+  message(STATUS "=> AzureOp is enabled env variable.")
+endif()
+
 function(disable_all_operators)
   set(OCOS_ENABLE_RE2_REGEX OFF CACHE INTERNAL "" FORCE)
   set(OCOS_ENABLE_TF_STRING OFF CACHE INTERNAL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,13 +90,6 @@ set(OCOS_ONNXRUNTIME_PKG_URI "" CACHE STRING
   "Specify the onnxruntime C++ shared library zip package path, like ./onnxruntime-win-x64-1.16.0.zip")
 set(OCOS_BUILD_PRESET "" CACHE STRING
   "Specify the build preset cmake settings file path, like 'token_api_only' which includes ./cmake/presets/token_api_only.cmake")
-# TODO: Remove the following statements if AzureOp build is enabled by default.
-# If build_buildid environment varaible is set, which means this is a CI build, then always enable AzureOp.
-# or it is enabled when OCOS_ENABLE_AZURE is set, which means the user explicitly enables it.
-if ((DEFINED ENV{BUILD_BUILDID}) OR (DEFINED ENV{OCOS_ENABLE_AZURE}))
-  set(OCOS_ENABLE_AZURE ON CACHE INTERNAL "" FORCE)
-  message(STATUS "=> AzureOp is enabled by default.")
-endif()
 
 function(disable_all_operators)
   set(OCOS_ENABLE_RE2_REGEX OFF CACHE INTERNAL "" FORCE)

--- a/docs/custom_ops.md
+++ b/docs/custom_ops.md
@@ -1312,7 +1312,7 @@ expect(node, inputs=[text, pattern, rewrite], outputs=[y],
 
 
 ## Azure operators
-
+Starting from onnxruntime-extensions 0.12, these Azure operators will be removed from the official onnxruntime-extensions packages. However, they can still be built from source using `cmake -DOCOS_ENABLE_AZURE=ON ...`.
 ### OpenAIAudioToText
 
 <details>

--- a/tools/test_cibuildwheel.bat
+++ b/tools/test_cibuildwheel.bat
@@ -2,7 +2,7 @@
 if "%OCOS_ENABLE_AZURE%"=="1" (
     pushd %1\test
     python -m pip install coloredlogs flatbuffers numpy packaging protobuf sympy
-    python -m pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ ort-nightly==1.16.0.dev20230820005
+    python -m pip install onnxruntime==1.18
     python test_azure_ops.py
     popd
 )

--- a/tools/test_cibuildwheel.sh
+++ b/tools/test_cibuildwheel.sh
@@ -4,7 +4,7 @@ if [[ "$OCOS_ENABLE_AZURE" == "1" ]]
 then
     pushd $1/test
     python -m pip install coloredlogs flatbuffers numpy packaging protobuf sympy
-    python -m pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT-Nightly/pypi/simple/ ort-nightly==1.16.0.dev20230820005
+    python -m pip install onnxruntime==1.18
     python ./test_azure_ops.py
     popd
 fi


### PR DESCRIPTION
The current Triton dependency introduced by these operations does not meet Microsoft's latest security requirements. Therefore, these operators will be removed from all pipelines.