### PR TITLE
Fix several C5038 warnings

### DIFF
--- a/include/ort_c_to_cpp.h
+++ b/include/ort_c_to_cpp.h
@@ -343,8 +343,8 @@ struct BaseKernel {
   OrtErrorCode GetErrorCodeAndRelease(OrtStatusPtr status) const noexcept;
 
   const OrtApi& api_;
-  OrtW::CustomOpApi ort_;
   const OrtKernelInfo& info_;
+  OrtW::CustomOpApi ort_;
 };
 
 // Deprecated: Use OrtW::CustomOpApi::KernelInfoGetAttribute instead

--- a/shared/api/image_processor.cc
+++ b/shared/api/image_processor.cc
@@ -85,7 +85,7 @@ OrtxStatus ImageProcessor::Init(std::string_view processor_def) {
 }
 
 ImageProcessor::ImageProcessor()
-    : allocator_(&CppAllocator::Instance()), OrtxObjectImpl(kOrtxKindProcessor) {
+    : OrtxObjectImpl(kOrtxKindProcessor), allocator_(&CppAllocator::Instance()) {
 }
 
 template <typename T>

--- a/shared/api/runner.hpp
+++ b/shared/api/runner.hpp
@@ -278,8 +278,8 @@ class OrtxRunner {
   }
 
  private:
-  std::vector<Operation*> ops_;
   ortc::IAllocator* allocator_;
+  std::vector<Operation*> ops_;
 };
 
 }  // namespace ort_extensions


### PR DESCRIPTION
* warning C5038: data member 'ort_extensions::ImageProcessor::allocator_' will be initialized after base class 'OrtxObjectImpl'
* warning C5038: data member 'ort_extensions::OrtxRunner::allocator_' will be initialized after data member 'ort_extensions::OrtxRunner::ops_'