### PR TITLE
upgrade pybind11 2.12 to support both numpy 1.x and 2.x

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -144,7 +144,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "80dc998efced8ceb2be59756668a7e90e8bef917",
+          "commitHash": "3e9dfa2866941655c56877882565e7577de6fc7b",
           "repositoryUrl": "https://github.com/pybind/pybind11.git"
         },
         "comments": "v2.10.1"

--- a/cmake/externals/pybind11.cmake
+++ b/cmake/externals/pybind11.cmake
@@ -1,7 +1,7 @@
 FetchContent_Declare(
   pybind11
-  URL       https://github.com/pybind/pybind11/archive/refs/tags/v2.10.1.zip
-  URL_HASH  SHA1=769b6aa67a77f17a770960f604b727645b6f6a13
+  URL       https://github.com/pybind/pybind11/archive/refs/tags/v2.12.0.zip
+  URL_HASH  SHA1=8482f57ed55c7b100672815a311d5450858723fb
 )
 
 FetchContent_GetProperties(pybind11)


### PR DESCRIPTION
v2.12 is the latest and it claims support both version of numpy.