### PR TITLE
Switch aiinfra-Linux-CPU machine pool to onnxruntime-Ubuntu2204-AMD-CPU

### DIFF
--- a/.pipelines/templates/build-package-for-linux.yml
+++ b/.pipelines/templates/build-package-for-linux.yml
@@ -10,7 +10,7 @@ parameters:
 
 - name: PoolName
   type: string
-  default: 'aiinfra-Linux-CPU'
+  default: 'onnxruntime-Ubuntu2204-AMD-CPU'
 
 - name: OrtExtensionsCFlags
   type: string

--- a/.pipelines/templates/build-package-for-nuget.yml
+++ b/.pipelines/templates/build-package-for-nuget.yml
@@ -46,7 +46,7 @@ stages:
   - template: build-package-for-linux.yml
     parameters:
       OrtExtensionsArch: 'x64'
-      PoolName: 'aiinfra-Linux-CPU'
+      PoolName: 'onnxruntime-Ubuntu2204-AMD-CPU'
       IsReleaseBuild: ${{parameters.IsReleaseBuild}}
       OrtExtensionsCFlags: ''
       OrtExtensionsCXXFlags: ''


### PR DESCRIPTION
The old pool uses Ubuntu 20.04.
The new pool uses Ubuntu 22.04.
We are retiring the old one.