### PR TITLE
removes OpenAIAudioToText from config

### DIFF
--- a/tools/android/package_ops.config
+++ b/tools/android/package_ops.config
@@ -1,1 +1,1 @@
-com.microsoft.extensions;1;BertTokenizer,BpeDecoder,CLIPTokenizer,DecodeImage,DrawBoundingBoxes,EncodeImage,OpenAIAudioToText,SentencepieceTokenizer
+com.microsoft.extensions;1;BertTokenizer,BpeDecoder,CLIPTokenizer,DecodeImage,DrawBoundingBoxes,EncodeImage,SentencepieceTokenizer


### PR DESCRIPTION
Fix for extensions.android_packaging pipeline in preparation for ORT 1.19 release.