### PR TITLE
Fix spm converted FastTokenizer issue on non-ascii char

### DIFF
--- a/operators/tokenizer/bpe_streaming.hpp
+++ b/operators/tokenizer/bpe_streaming.hpp
@@ -53,25 +53,7 @@ class BpeStreamingDecoder : public KernelBpeDecoder {
     return {};
   }
 
-  static std::string ReplaceAll(std::string_view s, const std::string& search, const std::string& replace) {
-    std::string result;
-    for (size_t pos = 0;; pos += search.length()) {
-      auto new_pos = s.find(search, pos);
-      if (new_pos == std::string::npos) {
-        result += s.substr(pos, s.size() - pos);
-        break;
-      }
-      result += s.substr(pos, new_pos - pos);
-      result += replace;
-      pos = new_pos;
-    }
 
-    return result;
-  }
-
-  static bool IsSpmByteWord(std::string_view word) {
-    return word.size() == 6 && word[0] == '<' && word[1] == '0' && word[2] == 'x' && word[5] == '>';
-  }
 
   OrtxStatus Id2Token(extTokenId_t id,
                       std::string& token,
@@ -119,7 +101,6 @@ class BpeStreamingDecoder : public KernelBpeDecoder {
   }
 
   OrtxStatus SpmId2Token(extTokenId_t id, std::string& token, bool& f_special_last) const {
-    const char spm_underscore[] = "\xe2\x96\x81";
 
     std::string piece = id < arr_vocab_.size() ? arr_vocab_[id] : "";
     bool f_special = false;

--- a/test/test_cliptok.py
+++ b/test/test_cliptok.py
@@ -1,7 +1,6 @@
 ﻿import unittest
 import numpy as np
 import onnxruntime as _ort
-import pkg_resources
 
 from pathlib import Path
 from onnx import helper, onnx_pb as onnx_proto
@@ -150,8 +149,4 @@ class TestCLIPTokenizer(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    try:
-        dist = pkg_resources.get_distribution('ftfy')
-    except pkg_resources.DistributionNotFound:
-        raise Exception("WARNING: ftfy is not installed - it is required for parity between CLIPTokenizer and CLIPTokenizerFast.")
     unittest.main()

--- a/test/test_fast_tokenizer.py
+++ b/test/test_fast_tokenizer.py
@@ -21,13 +21,24 @@ class TestAutoTokenizer(unittest.TestCase):
         np.testing.assert_array_equal(ids[0], actual_ids[0])
 
     def test_mistral(self):
-        tokenizer = AutoTokenizer.from_pretrained("mistral-community/Mistral-7B-v0.2", use_fast=True)
+        tokenizer = AutoTokenizer.from_pretrained(
+            "mistral-community/Mistral-7B-v0.2", use_fast=True)
         text = "\nOnce upon a time, I was really into monochromatic makeup looks. I have a lot of coppery and bronze "
         ids = tokenizer.encode(text, return_tensors="np")
 
         ort_tok, _ = gen_processing_models(tokenizer, pre_kwargs={})
         actual_ids, *_ = ort_inference(ort_tok, [text])
         np.testing.assert_array_equal(ids[0], actual_ids[0])
+
+    def test_phi_3_mini(self):
+        tokenizer = AutoTokenizer.from_pretrained(
+            "microsoft/Phi-3-mini-128k-instruct", use_fast=True)
+        text = "what are you? \n 给 weiss ich, über was los ist \n"
+        ids = tokenizer.encode(text, return_tensors="np")
+
+        ort_tok, _ = gen_processing_models(tokenizer, pre_kwargs={})
+        actual_ids, *_ = ort_inference(ort_tok, [text])
+        np.testing.assert_array_equal(ids[0], actual_ids[0][1:])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Missing the special handling on SentencePiece converted tokenizer in BPEDecoder.