### PR TITLE
Sign dlls with the correct key code

### DIFF
--- a/.pipelines/templates/win-esrp-dll.yml
+++ b/.pipelines/templates/win-esrp-dll.yml
@@ -26,7 +26,38 @@ steps:
     AuthAKVName: 'buildkeyvault'
     AuthCertName: '53d54d02-SSL-AutoRotate'
     AuthSignCertName: '53d54d02-978d-4305-8572-583cf6711c4f'
-
+    signConfigType: inlineSignParams
+    inlineOperation: |
+      [
+        {
+          "keyCode": "CP-230012",
+          "operationSetCode": "SigntoolSign",
+          "parameters": [
+            {
+              "parameterName": "OpusName",
+              "parameterValue": "Microsoft"
+            },
+            {
+              "parameterName": "OpusInfo",
+              "parameterValue": "http://www.microsoft.com"
+            },
+            {
+              "parameterName": "PageHash",
+              "parameterValue": "/NPH"
+            },
+            {
+              "parameterName": "FileDigest",
+              "parameterValue": "/fd sha256"
+            },
+            {
+              "parameterName": "TimeStamp",
+              "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            }
+          ],
+          "toolName": "signtool.exe",
+          "toolVersion": "6.2.9304.0"
+        }
+      ]
     FolderPath: ${{ parameters.FolderPath }}
     Pattern: ${{ parameters.Pattern }}
     SessionTimeout: 90


### PR DESCRIPTION
same as https://github.com/microsoft/onnxruntime/pull/21854.

The default keycode is test code sign.
KeyCode must be specified explicitly.