### PR TITLE
Add C++ regex support for Llama3, Standard Library, and Custom Cases

### DIFF
--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -276,7 +276,9 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input,
     }
 
     while (static_cast<int64_t>(res.size()) < max_length) {
-      auto [b, tok] = regcmp.GetNextToken();
+      // TODO: Change regex based on tokenizer type. Currently using GPT2 regex.
+      std::string regex_expr = "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)";
+      auto [b, tok] = regcmp.GetNextToken(regex_expr);
 
       if (!b) break;
 

--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -278,10 +278,10 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input,
     while (static_cast<int64_t>(res.size()) < max_length) {
       std::string regex_expr = "";
       if (ModelName() == kModel_Llama){
-        regex_expr = "(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
+        regex_expr = regcmp.LLAMA_REGEX_PATTERN_1;
       } else {
         // default to GPT2 regex
-        regex_expr = "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)";
+        regex_expr = regcmp.GPT2_REGEX_PATTERN;
       }
       auto [b, tok] = regcmp.GetNextToken(regex_expr);
 

--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -276,8 +276,13 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input,
     }
 
     while (static_cast<int64_t>(res.size()) < max_length) {
-      // TODO: Change regex based on tokenizer type. Currently using GPT2 regex.
-      std::string regex_expr = "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)";
+      std::string regex_expr = "";
+      if (ModelName() == kModel_Llama){
+        regex_expr = "(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
+      } else {
+        // default to GPT2 regex
+        regex_expr = "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)";
+      }
       auto [b, tok] = regcmp.GetNextToken(regex_expr);
 
       if (!b) break;

--- a/operators/tokenizer/bpe_utils.hpp
+++ b/operators/tokenizer/bpe_utils.hpp
@@ -202,23 +202,33 @@ class TokenWithRegularExp {
   }
 
   std::u32string_view RegexMatchGPT2() {
-    // GPT2 python regex pattern:
+    // python pattern:
     // 's|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+
 
-    // s|'t|'re|'ve|'m|'ll|'d
+    // 's|'t|'re|'ve|'m|'ll|'d|
+    // Note: the sequencial of the following if should not be switched, which follows the python regex's syntax
 
     // Standard Library Search might be too compute intensive here due to conversions to and fro ustring and wstring
     // std::u32string_view std_regex = RegexMatchSTD(U"'s|'t|'re|'ve|'m|'ll|'d");
     // if (std_regex.size() != 0){
     //   return std_regex;
     // }
-    // Note: the sequencial of the following if should not be switched, which follows the python regex's syntax
     if ((m_text[0] == U'\'') && (m_text.size() > 1)) {
       if ((m_text[1] == U's') || (m_text[1] == U't') ||
           (m_text[1] == U'm') || (m_text[1] == U'd')) {
         std::u32string_view res = m_text.substr(0, 2);
         m_text = m_text.substr(2);
         return res;
+      }
+
+      if (m_text.size() > 2) {
+        if (((m_text[1] == U'r') && (m_text[2] == U'e')) ||
+            ((m_text[1] == U'v') && (m_text[2] == U'e')) ||
+            ((m_text[1] == U'l') && (m_text[2] == U'l'))) {
+          std::u32string_view res = m_text.substr(0, 3);
+          m_text = m_text.substr(3);
+          return res;
+        }
       }
     }
 

--- a/operators/tokenizer/bpe_utils.hpp
+++ b/operators/tokenizer/bpe_utils.hpp
@@ -115,6 +115,10 @@ class TokenWithRegularExp {
     return {false, {}};
   }
 
+  const std::string GPT2_REGEX_PATTERN = "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)";
+  const std::string LLAMA_REGEX_PATTERN_1 = "(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
+  const std::string LLAMA_REGEX_PATTERN_2 = "(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
+
  private:
 
   /*
@@ -517,10 +521,10 @@ class TokenWithRegularExp {
   std::u32string_view RegexMatchCustom(const std::string & regex_expr) {
     std::vector<size_t> bpe_offsets;
 
-    if (regex_expr == "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)") {
+    if (regex_expr == GPT2_REGEX_PATTERN) {
         return RegexMatchGPT2();
-    } else if (regex_expr == "(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+" ||
-               regex_expr == "(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+") {
+    } else if (regex_expr == LLAMA_REGEX_PATTERN_1 ||
+               regex_expr == LLAMA_REGEX_PATTERN_2) {
 
         return RegexMatchLlama3();
     }

--- a/operators/tokenizer/bpe_utils.hpp
+++ b/operators/tokenizer/bpe_utils.hpp
@@ -205,6 +205,12 @@ class TokenWithRegularExp {
     // GPT2 python regex pattern:
     // 's|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+
 
+    // s|'t|'re|'ve|'m|'ll|'d
+    std::u32string_view std_regex = RegexMatchSTD(U"'s|'t|'re|'ve|'m|'ll|'d");
+    if (std_regex.size() != 0){
+      return std_regex;
+    }
+
     // ?\p{L}+
     if ((m_text[0] == U' ') && (m_text.size() > 1) && (ufal::unilib::unicode::category(m_text[1]) & ufal::unilib::unicode::L)) {
       size_t i = 2;
@@ -289,8 +295,7 @@ class TokenWithRegularExp {
       return res;
     }
 
-    // s|'t|'re|'ve|'m|'ll|'d
-    return RegexMatchSTD(U"'s|'t|'re|'ve|'m|'ll|'d");
+    return std::u32string_view{};
   }
 
   // TODO: Add Llama3 regex support for python regex:

--- a/operators/tokenizer/bpe_utils.hpp
+++ b/operators/tokenizer/bpe_utils.hpp
@@ -103,9 +103,9 @@ class TokenWithRegularExp {
     m_text = val;
   }
 
-  std::pair<bool, std::u32string_view> GetNextToken() {
+  std::pair<bool, std::u32string_view> GetNextToken(std::string & regex_expr) {
     while (!m_text.empty()) {
-      auto res = RegexMatchLlama3();
+      auto res = RegexMatchCustom(regex_expr);
       if (res.empty()) {
         m_text = m_text.substr(1);
         continue;
@@ -454,6 +454,28 @@ class TokenWithRegularExp {
 
     return std::u32string_view{};
   }
+
+  std::u32string_view RegexMatchCustom(const std::string & regex_expr) {
+    std::vector<size_t> bpe_offsets;
+
+    if (regex_expr == "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)") {
+        return RegexMatchGPT2();
+    } else if (regex_expr == "(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+" ||
+               regex_expr == "(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+") {
+
+        return RegexMatchLlama3();
+    }
+
+    try {
+      return RegexMatchSTD(ustring(regex_expr));
+    } catch (const std::exception& ex) {
+      std::string part1 = "Regex '";
+      std::string part2 = "' not supported!";
+      throw std::runtime_error(part1 + regex_expr + part2);
+    }
+
+    return std::u32string_view{};
+}
 
   static bool IsRN(char32_t ch) {
     return ch == U'\r' || ch == U'\n';

--- a/operators/tokenizer/bpe_utils.hpp
+++ b/operators/tokenizer/bpe_utils.hpp
@@ -206,9 +206,20 @@ class TokenWithRegularExp {
     // 's|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+
 
     // s|'t|'re|'ve|'m|'ll|'d
-    std::u32string_view std_regex = RegexMatchSTD(U"'s|'t|'re|'ve|'m|'ll|'d");
-    if (std_regex.size() != 0){
-      return std_regex;
+
+    // Standard Library Search might be too compute intensive here due to conversions to and fro ustring and wstring
+    // std::u32string_view std_regex = RegexMatchSTD(U"'s|'t|'re|'ve|'m|'ll|'d");
+    // if (std_regex.size() != 0){
+    //   return std_regex;
+    // }
+    // Note: the sequencial of the following if should not be switched, which follows the python regex's syntax
+    if ((m_text[0] == U'\'') && (m_text.size() > 1)) {
+      if ((m_text[1] == U's') || (m_text[1] == U't') ||
+          (m_text[1] == U'm') || (m_text[1] == U'd')) {
+        std::u32string_view res = m_text.substr(0, 2);
+        m_text = m_text.substr(2);
+        return res;
+      }
     }
 
     // ?\p{L}+

--- a/test/pp_api_test/test_tokenizer.cc
+++ b/test/pp_api_test/test_tokenizer.cc
@@ -133,7 +133,7 @@ TEST(OrtxTokenizerTest, Phi3_S_Tokenizer) {
   EXPECT_NE(tokenizer, nullptr);
 
   std::vector<extTokenId_t> EXPECTED_IDS_0 = {2028, 374, 264, 1296, 13};
-  std::vector<std::string_view> input = {"This is a test.", "the second one",
+  std::vector<std::string_view> input = {"This is a test.", "Ich liebe München",
                                          "I like walking my cute dog\n and\x17 then",
                                          "Hey<|endoftext|>. \t\t \n\nyou  é  @#😈  🤗!       , 1234 15 5,61"};
   std::vector<std::vector<extTokenId_t>> token_ids;
@@ -346,7 +346,7 @@ TEST(OrtxTokenizerStreamTest, Llama2Tokenizer) {
   // validate tokenizer is not null
   EXPECT_TRUE(tokenizer != nullptr);
 
-  std::vector<std::string_view> input = {"This is a test and the second one. "};
+  std::vector<std::string_view> input = {"This is a test and the second one is in German. Ich liebe München!"};
   std::vector<std::vector<extTokenId_t>> token_ids;
   status = tokenizer->Tokenize(input, token_ids);
   EXPECT_TRUE(status.IsOk());

--- a/test/pp_api_test/test_tokenizer.cc
+++ b/test/pp_api_test/test_tokenizer.cc
@@ -65,6 +65,24 @@ TEST(CApiTest, StreamApiTest) {
   OrtxDispose(&tokenizer);
 }
 
+TEST(OrtxTokenizerTest, RegexTest) {
+  std::u32string str = U"CAN'T \r\n 2413m";
+  auto regcmp = std::make_unique<ort_extensions::bpe::TokenWithRegularExp>();
+
+  std::vector<std::u32string> res;
+  std::vector<std::u32string> out_tokens = {U"CAN", U"'T", U" \r\n", U" ", U"241", U"3", U"m"};
+
+  int64_t max_length = out_tokens.size();
+  regcmp->Set(str.c_str());
+  std::string regex_expr = regcmp->LLAMA_REGEX_PATTERN_1;
+
+  while (static_cast<int64_t>(res.size()) < max_length) {
+    auto [b, tok] = regcmp->GetNextToken(regex_expr);
+    res.push_back(ustring(tok));
+  }
+  EXPECT_EQ(res, out_tokens);
+}
+
 TEST(OrtxTokenizerTest, ClipTokenizer) {
   auto tokenizer = std::make_unique<ort_extensions::TokenizerImpl>();
   auto status = tokenizer->Load("data/clip");


### PR DESCRIPTION
Currently, our regular expression pattern matching for BPE tokenization only supports the GPT2 regex.

This PR adds the following functionality:
1. Standard library regex support.
2. Llama3 regex support.
3. Custom regex implementation that will use appropriate regex given a model.
