### PR TITLE
Don't disable vision operators in a catalyst build.

### DIFF
--- a/cmake/externals/opencv-no-rtti.patch
+++ b/cmake/externals/opencv-no-rtti.patch
@@ -93,6 +93,41 @@ index a217979a1..0ba30d024 100644
  /* static */ Context Context::fromHandle(void* context) { OCL_NOT_AVAILABLE(); }
  /* static */ Context Context::fromDevice(const ocl::Device& device) { OCL_NOT_AVAILABLE(); }
  /* static */ Context Context::create(const std::string& configuration) { OCL_NOT_AVAILABLE(); }
+diff --git a/modules/imgcodecs/src/macosx_conversions.mm b/modules/imgcodecs/src/macosx_conversions.mm
+index 0023e06260..8a4bc0b211 100644
+--- a/modules/imgcodecs/src/macosx_conversions.mm
++++ b/modules/imgcodecs/src/macosx_conversions.mm
+@@ -9,6 +9,7 @@ CV_EXPORTS NSImage* MatToNSImage(const cv::Mat& image);
+ CV_EXPORTS void NSImageToMat(const NSImage* image, cv::Mat& m, bool alphaExist);
+ 
+ NSImage* MatToNSImage(const cv::Mat& image) {
++#if !NSIMAGE_UNAVAILABLE_MACCATALYST
+     // Creating CGImage from cv::Mat
+     CGImageRef imageRef = MatToCGImage(image);
+ 
+@@ -17,9 +18,22 @@ NSImage* MatToNSImage(const cv::Mat& image) {
+     CGImageRelease(imageRef);
+ 
+     return nsImage;
++#else
++    @throw [NSException 
++            exceptionWithName:@"NSGenericException" 
++            reason:@"NSImage is not supported on Mac Catalyst"
++            userInfo:nil];
++#endif
+ }
+ 
+ void NSImageToMat(const NSImage* image, cv::Mat& m, bool alphaExist) {
++#if !NSIMAGE_UNAVAILABLE_MACCATALYST
+     CGImageRef imageRef = [image CGImageForProposedRect:NULL context:NULL hints:NULL];
+     CGImageToMat(imageRef, m, alphaExist);
++#else
++    @throw [NSException 
++            exceptionWithName:@"NSGenericException" 
++            reason:@"NSImage is not supported on Mac Catalyst"
++            userInfo:nil];
++#endif
+ }
 diff --git a/samples/dnn/dnn_model_runner/dnn_conversion/requirements.txt b/samples/dnn/dnn_model_runner/dnn_conversion/requirements.txt
 deleted file mode 100644
 index 6887c2ab2..000000000

--- a/tools/build.py
+++ b/tools/build.py
@@ -534,7 +534,6 @@ def _generate_build_tree(
                     f"-DCMAKE_CC_FLAGS=--target={macabi_target}",
                     f"-DCMAKE_CC_FLAGS_RELEASE=-O3 -DNDEBUG --target={macabi_target}",
                     "-DOCOS_ENABLE_CV2=OFF",
-                    "-DOCOS_ENABLE_VISION=OFF",
                     "-DOCOS_ENABLE_CTESTS=OFF",
                     "-DMAC_CATALYST=1",
                 ]


### PR DESCRIPTION
We need the image decode/encode operators in the nuget package. 