### PR TITLE
Change the framework bundle identifier to a valid one (#829)

### DIFF
--- a/cmake/ext_apple_framework.cmake
+++ b/cmake/ext_apple_framework.cmake
@@ -10,7 +10,7 @@ if(NOT _ortcustomops_type STREQUAL "STATIC_LIBRARY")
 endif()
 
 set(APPLE_FRAMEWORK_NAME "onnxruntime_extensions")
-set(APPLE_FRAMEWORK_IDENTIFIER "com.microsoft.onnxruntime_extensions")
+set(APPLE_FRAMEWORK_IDENTIFIER "com.microsoft.onnxruntime-extensions")
 set(APPLE_FRAMEWORK_VERSION "${VERSION}")
 
 # public header files


### PR DESCRIPTION
Cherry pick for release-0.13

Ref: https://github.com/microsoft/onnxruntime-extensions/issues/825

"com.microsoft.onnxruntime_extensions" is not a valid identifier. Update it to "com.microsoft.onnxruntime-extensions"