### PR TITLE
Fix prefast issue in image transforms

### DIFF
--- a/shared/api/image_transforms.hpp
+++ b/shared/api/image_transforms.hpp
@@ -54,12 +54,14 @@ inline OrtxStatus convert_to_rgb(const ortc::Tensor<uint8_t>& input, ortc::Tenso
 
 struct Resize {
   static const std::unordered_map<std::string, int>& InterpolationMethods() {
-    return {
+    static std::unordered_map<std::string, int> methods = {
       {"NEAREST", IMAGING_TRANSFORM_NEAREST},
       {"LINEAR", IMAGING_TRANSFORM_BILINEAR},
       {"CUBIC", IMAGING_TRANSFORM_BICUBIC},
       {"LANCZOS", IMAGING_TRANSFORM_LANCZOS}
     };
+    
+    return methods;
   }
 
   OrtxStatus Compute(const ortc::Tensor<uint8_t>& input, ortc::Tensor<uint8_t>& output) {

--- a/shared/api/image_transforms.hpp
+++ b/shared/api/image_transforms.hpp
@@ -53,7 +53,7 @@ inline OrtxStatus convert_to_rgb(const ortc::Tensor<uint8_t>& input, ortc::Tenso
 }
 
 struct Resize {
-  static const std::unordered_map<std::string, int> InterpolationMethods() {
+  static const std::unordered_map<std::string, int>& InterpolationMethods() {
     return {
       {"NEAREST", IMAGING_TRANSFORM_NEAREST},
       {"LINEAR", IMAGING_TRANSFORM_BILINEAR},
@@ -121,8 +121,7 @@ struct Resize {
         keep_aspect_ratio_ = std::get<int64_t>(value) != 0;
       } else if (key == "interpolation") {
         interpolation_ = std::get<std::string>(value);
-        std::unordered_map<std::string, int> interpolation_methods_ = InterpolationMethods();
-        if (interpolation_methods_.find(interpolation_) == interpolation_methods_.end()) {
+        if (InterpolationMethods().find(interpolation_) == InterpolationMethods().end()) {
           return {kOrtxErrorInvalidArgument, "[Resize]: Invalid interpolation method"};
         }
       } else {

--- a/shared/api/image_transforms.hpp
+++ b/shared/api/image_transforms.hpp
@@ -121,7 +121,8 @@ struct Resize {
         keep_aspect_ratio_ = std::get<int64_t>(value) != 0;
       } else if (key == "interpolation") {
         interpolation_ = std::get<std::string>(value);
-        if (InterpolationMethods().find(interpolation_) == InterpolationMethods().end()) {
+        std::unordered_map<std::string, int> interpolation_methods_ = InterpolationMethods();
+        if (interpolation_methods_.find(interpolation_) == interpolation_methods_.end()) {
           return {kOrtxErrorInvalidArgument, "[Resize]: Invalid interpolation method"};
         }
       } else {


### PR DESCRIPTION
This PR fixes a prefast issue in image transforms that caused the following error on certain machines due to list iterators for temporary objects: `C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.41.34120\include\list(194) : Assertion failed: list iterators incompatible`, specifically for transforms using interpolation.