### PR TITLE
fix the win32 macro usage

### DIFF
--- a/operators/vision/decode_image.hpp
+++ b/operators/vision/decode_image.hpp
@@ -11,7 +11,7 @@
 #include "op_def_struct.h"
 
 #if OCOS_ENABLE_VENDOR_IMAGE_CODECS
-  #if WIN32
+  #if _WIN32
     #include "image_decoder_win32.hpp"
   #elif __APPLE__
     #include "image_decoder_darwin.hpp"

--- a/shared/api/image_transforms.hpp
+++ b/shared/api/image_transforms.hpp
@@ -9,7 +9,7 @@
 
 template <typename T>
 void DumpTensorToFile(const ortc::Tensor<T>& tensor, const char* name) {
-#if WIN32
+#if _WIN32
   auto tic = GetTickCount();
   std::string dtype;
   if constexpr (std::is_same_v<T, uint8_t> || std::is_same_v<T, std::byte>) {

--- a/test/pp_api_test/test_imgcodec.cc
+++ b/test/pp_api_test/test_imgcodec.cc
@@ -74,7 +74,7 @@ TEST(ImageDecoderTest, TestJpegDecoder) {
             std::vector<uint8_t>({48, 14, 5, 48, 14, 5, 48, 14, 5, 48, 14, 5}));
 
 #if OCOS_ENABLE_VENDOR_IMAGE_CODECS
-  #if WIN32
+  #if _WIN32
   out_range = out_tensor.Data() + 1296 * 3;
   ASSERT_EQ(std::vector<uint8_t>(out_range, out_range + 12),
             std::vector<uint8_t>({228, 234, 222, 228, 235, 219, 219, 221, 200, 203, 201, 178}));
@@ -128,7 +128,7 @@ TEST(ImageDecoderTest, TestJpegDecoder) {
 }
 
 #if OCOS_ENABLE_VENDOR_IMAGE_CODECS
-#if defined(WIN32) || defined(__APPLE__)
+#if defined(_WIN32) || defined(__APPLE__)
 TEST(ImageDecoderTest, TestTiffDecoder) {
   ort_extensions::DecodeImage image_decoder;
   image_decoder.Init(std::unordered_map<std::string, std::variant<std::string>>());


### PR DESCRIPTION
_"WIN32 is a name that you could use and even define in your own code and so might clash with Microsoft's usage. _WIN32 is a name that is reserved for the implementor (in this case Microsoft) because it begins with an underscore and an uppercase letter - you are not allowed to define reserved names in your own code, so there can be no clash."_