### PR TITLE
Pipeline - Publish whl Files to ORT-Nightly Feed

### DIFF
--- a/tools/ci_build/github/azure-pipeline/templates/windows-build-stage.yml
+++ b/tools/ci_build/github/azure-pipeline/templates/windows-build-stage.yml
@@ -20,7 +20,7 @@ stages:
       os: windows
 
     variables:
-      CIBW_BUILD: cp3{9,10,11,12,13}-*amd64
+      CIBW_BUILD: cp3{10,11,12,13}-*amd64
       CIBW_ARCHS: AMD64
       CIBW_ENVIRONMENT: "${{ parameters.CibwEnv }}"
       CIBW_BUILD_VERBOSITY: 1

--- a/tools/ci_build/github/azure-pipeline/templates/windows-build-stage.yml
+++ b/tools/ci_build/github/azure-pipeline/templates/windows-build-stage.yml
@@ -20,7 +20,7 @@ stages:
       os: windows
 
     variables:
-      CIBW_BUILD: cp3{8,9,10,11,12}-*amd64
+      CIBW_BUILD: cp3{9,10,11,12,13}-*amd64
       CIBW_ARCHS: AMD64
       CIBW_ENVIRONMENT: "${{ parameters.CibwEnv }}"
       CIBW_BUILD_VERBOSITY: 1
@@ -60,7 +60,7 @@ stages:
 
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.12'
+        versionSpec: '3.13'
         addToPath: true
 
     - script: |

--- a/tools/ci_build/github/azure-pipeline/templates/windows-build-stage.yml
+++ b/tools/ci_build/github/azure-pipeline/templates/windows-build-stage.yml
@@ -4,6 +4,11 @@ parameters:
   type: string
   default: ''
 
+- name: artifact_feed
+  displayName: 'Artifact feed'
+  type: string
+  default: 'ORT-Nightly'
+
 stages:
 - stage: Windows_Build
   dependsOn: []
@@ -98,3 +103,18 @@ stages:
           )
       workingDirectory: '$(REPOROOT)'
       displayName: zip package
+
+    - script: 'pip install twine==3.4.2'
+      displayName: 'Install Twine'
+
+    - task: TwineAuthenticate@1
+      displayName: 'Twine Authenticate '
+      inputs:
+        artifactFeed: PublicPackages/${{ parameters.artifact_feed }}
+
+    - script: 'python -m twine upload -r ${{ parameters.artifact_feed }} --config-file $(PYPIRC_PATH) --non-interactive --skip-existing *.whl'
+      workingDirectory: '$(REPOROOT)\out'
+      displayName: 'Uploading wheels to ${{ parameters.artifact_feed }}'
+      retryCountOnTaskFailure: 3
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/tools/ci_build/github/azure-pipeline/wheels_linux.yml
+++ b/tools/ci_build/github/azure-pipeline/wheels_linux.yml
@@ -29,7 +29,7 @@ extends:
       - job: linux_x86_64
         timeoutInMinutes: 180
         variables:
-          CIBW_BUILD: "cp3{9,10,11,12,13}-*"
+          CIBW_BUILD: "cp3{10,11,12,13}-*"
           CIBW_SKIP: "*musllinux*"
           CIBW_ENVIRONMENT: "${{ parameters.ExtraEnv }}"
         templateContext:
@@ -52,7 +52,7 @@ extends:
       - job: manylinux_aarch64
         timeoutInMinutes: 180
         variables:
-          CIBW_BUILD: "cp3{9,10,11,12,13}-*"
+          CIBW_BUILD: "cp3{10,11,12,13}-*"
           CIBW_SKIP: "*musllinux_*"
           # AzureOp doesn't support aaarch64 yet.
           # CIBW_ENVIRONMENT: "${{ parameters.ExtraEnv }}"

--- a/tools/ci_build/github/azure-pipeline/wheels_linux.yml
+++ b/tools/ci_build/github/azure-pipeline/wheels_linux.yml
@@ -29,7 +29,7 @@ extends:
       - job: linux_x86_64
         timeoutInMinutes: 180
         variables:
-          CIBW_BUILD: "cp3{8,9,10,11,12}-*"
+          CIBW_BUILD: "cp3{9,10,11,12,13}-*"
           CIBW_SKIP: "*musllinux*"
           CIBW_ENVIRONMENT: "${{ parameters.ExtraEnv }}"
         templateContext:
@@ -52,7 +52,7 @@ extends:
       - job: manylinux_aarch64
         timeoutInMinutes: 180
         variables:
-          CIBW_BUILD: "cp3{8,9,10,11,12}-*"
+          CIBW_BUILD: "cp3{9,10,11,12,13}-*"
           CIBW_SKIP: "*musllinux_*"
           # AzureOp doesn't support aaarch64 yet.
           # CIBW_ENVIRONMENT: "${{ parameters.ExtraEnv }}"

--- a/tools/ci_build/github/azure-pipeline/wheels_macos.yml
+++ b/tools/ci_build/github/azure-pipeline/wheels_macos.yml
@@ -24,7 +24,7 @@ extends:
       - job: macos
         timeoutInMinutes: 180
         variables:
-          CIBW_BUILD: "cp3{8,9,10,11,12}-*"
+          CIBW_BUILD: "cp3{9,10,11,12,13}-*"
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=11.0"
           # Skip trying to test arm64 builds on Intel Macs

--- a/tools/ci_build/github/azure-pipeline/wheels_macos.yml
+++ b/tools/ci_build/github/azure-pipeline/wheels_macos.yml
@@ -24,7 +24,7 @@ extends:
       - job: macos
         timeoutInMinutes: 180
         variables:
-          CIBW_BUILD: "cp3{9,10,11,12,13}-*"
+          CIBW_BUILD: "cp3{10,11,12,13}-*"
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=11.0"
           # Skip trying to test arm64 builds on Intel Macs


### PR DESCRIPTION
1 Publish whl Files to ORT-Nightly Feed:

2 For these 3 pipelines, official, linux wheel and macro wheel, upgrade Python version to 9,10,11,12,13 instead of 8,9,10,11,12. 