### PR TITLE
Remove 10.14 suffix from osx nuget package

### DIFF
--- a/nuget/DummyNativeNuget.nuspec
+++ b/nuget/DummyNativeNuget.nuspec
@@ -60,8 +60,8 @@
     <file src="targets\net6.0-ios\Microsoft.ML.OnnxRuntime.Extensions.Dummy.targets" target="build\net6.0-ios15.4" />
     <file src="targets\net6.0-ios\Microsoft.ML.OnnxRuntime.Extensions.Dummy.targets" target="buildTransitive\net6.0-ios15.4" />
     <!-- .net 6 macOS -->
-    <file src="..\nuget-artifacts\onnxruntime-extensions-osx-x86_64\lib\libortextensions.dylib" target="runtimes\osx.10.14-x64\native" />
-    <file src="..\nuget-artifacts\onnxruntime-extensions-osx-arm64\lib\libortextensions.dylib" target="runtimes\osx.10.14-arm64\native"/>
+    <file src="..\nuget-artifacts\onnxruntime-extensions-osx-x86_64\lib\libortextensions.dylib" target="runtimes\osx-x64\native" />
+    <file src="..\nuget-artifacts\onnxruntime-extensions-osx-arm64\lib\libortextensions.dylib" target="runtimes\osx-arm64\native"/>
 
     <file src="targets\net6.0-macos\Microsoft.ML.OnnxRuntime.Extensions.Dummy.targets" target="build\net6.0-macos12.3" />
     <file src="targets\net6.0-macos\Microsoft.ML.OnnxRuntime.Extensions.Dummy.targets" target="buildTransitive\net6.0-macos12.3" />

--- a/nuget/NativeNuget.nuspec
+++ b/nuget/NativeNuget.nuspec
@@ -57,8 +57,8 @@
     <file src="targets\net6.0-ios\Microsoft.ML.OnnxRuntime.Extensions.targets" target="build\net6.0-ios15.4" />
     <file src="targets\net6.0-ios\Microsoft.ML.OnnxRuntime.Extensions.targets" target="buildTransitive\net6.0-ios15.4" />
     <!-- .net 6 macOS -->
-    <file src="..\nuget-artifacts\onnxruntime-extensions-osx-x86_64\lib\libortextensions.dylib" target="runtimes\osx.10.14-x64\native" />
-    <file src="..\nuget-artifacts\onnxruntime-extensions-osx-arm64\lib\libortextensions.dylib" target="runtimes\osx.10.14-arm64\native"/>
+    <file src="..\nuget-artifacts\onnxruntime-extensions-osx-x86_64\lib\libortextensions.dylib" target="runtimes\osx-x64\native" />
+    <file src="..\nuget-artifacts\onnxruntime-extensions-osx-arm64\lib\libortextensions.dylib" target="runtimes\osx-arm64\native"/>
     
     <file src="targets\net6.0-macos\Microsoft.ML.OnnxRuntime.Extensions.targets" target="build\net6.0-macos12.3" />
     <file src="targets\net6.0-macos\Microsoft.ML.OnnxRuntime.Extensions.targets" target="buildTransitive\net6.0-macos12.3" />

--- a/nuget/targets/net6.0-macos/Microsoft.ML.OnnxRuntime.Extensions.targets
+++ b/nuget/targets/net6.0-macos/Microsoft.ML.OnnxRuntime.Extensions.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
-    <NativeReference Condition="'$(Platform)' == 'arm64'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx.10.14-arm64\native\libonnxruntime_extensions.dylib">
+    <NativeReference Condition="'$(Platform)' == 'arm64'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-arm64\native\libonnxruntime_extensions.dylib">
       <Kind>Framework</Kind>
       <IsCxx>True</IsCxx>
       <SmartLink>True</SmartLink>
@@ -9,7 +9,7 @@
       <LinkerFlags>-lc++</LinkerFlags>
       <WeakFrameworks>CoreML</WeakFrameworks>
     </NativeReference>
-    <NativeReference Condition="'$(Platform)' == 'x64'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx.10.14-x64\native\libonnxruntime_extensions.dylib">
+    <NativeReference Condition="'$(Platform)' == 'x64'" Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-x64\native\libonnxruntime_extensions.dylib">
       <Kind>Framework</Kind>
       <IsCxx>True</IsCxx>
       <SmartLink>True</SmartLink>


### PR DESCRIPTION
Updates the specified runtime for osx to remove the OS specific RID. This is no longer supported since .NET 8 and generates the following warning as well as runtime errors.

Matches the same changes made in `microsoft/onnxruntime` with https://github.com/microsoft/onnxruntime/pull/17277

Build Warning

```
/usr/local/share/dotnet/sdk/9.0.101/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(322,5): warning NETSDK1206: Found version-specific or distribution-specific runtime identifier(s): osx.10.14-arm64, osx.10.14-x64. Affected libraries: Microsoft.ML.OnnxRuntime.Extensions. In .NET 8.0 and higher, assets for version-specific and distribution-specific runtime identifiers will not be found by default. See https://aka.ms/dotnet/rid-usage for details.
```

Runtime Error

```
Error Message
      : Microsoft.ML.OnnxRuntime.OnnxRuntimeException : [ErrorCode:NoSuchFile] The ONNX Runtime extensions library
       was not found. The Microsoft.ML.OnnxRuntime.Extensions NuGet package must be referenced by the project to u
      se 'OrtExtensions.RegisterCustomOps.
      Stack Trace:
         at Microsoft.ML.OnnxRuntime.SessionOptions.RegisterOrtExtensions()
```