### PR TITLE
Update decode_image.hpp: add missing header file

### DIFF
--- a/operators/vision/decode_image.hpp
+++ b/operators/vision/decode_image.hpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <variant>
 #include <unordered_map>
+#include <algorithm>
 
 #if OCOS_ENABLE_VENDOR_IMAGE_CODECS
   #if _WIN32


### PR DESCRIPTION
To fix the following build error with GCC 14:

https://github.com/microsoft/onnxruntime-genai/actions/runs/12696859543/job/35391825241