### PR TITLE
Fix re2 link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -629,7 +629,7 @@ if(OCOS_ENABLE_TF_STRING)
 
   if(OCOS_ENABLE_RE2_REGEX)
     target_include_directories(noexcep_operators PUBLIC ${googlere2_SOURCE_DIR})
-    target_link_libraries(noexcep_operators PRIVATE re2)
+    target_link_libraries(noexcep_operators PRIVATE re2::re2)
   endif()
 endif()
 


### PR DESCRIPTION
CMake's [target_link_libraries](https://cmake.org/cmake/help/latest/command/target_link_libraries.html#id2) function accepts plain library name(like re2) or target name(like re2::re2) or some other kinds of names. "plain library names" are old-fashioned, for compatibility only. We should use target names.

Similar to https://github.com/microsoft/onnxruntime/pull/23173
