### PR TITLE
Add check for audio sampling rate other than 8k or 16k Hz

### DIFF
--- a/shared/api/speech_features.hpp
+++ b/shared/api/speech_features.hpp
@@ -626,7 +626,7 @@ class Phi4AudioEmbed {
     
     // Currently we only support 8k and 16k Hz sampling rate.
     if (sr_val != 8000 && sr_val != 16000){
-      ORTX_CXX_API_THROW("ort-extensions internal error: currently only 8k and 16k Hz sampling rate is supported. Please resample your audio file to either 8k or 16k.", ORT_RUNTIME_EXCEPTION);
+      return OrtxStatus(kOrtxErrorNotImplemented, "Currently only 8k and 16k Hz sampling rate is supported. Please resample your audio file with unsupported audio sampling rate: " + sr_val);
     }
 
     logmel.Init(sr_val == 8000 ? logmel_8k_attrs_: logmel_attrs_);

--- a/shared/api/speech_features.hpp
+++ b/shared/api/speech_features.hpp
@@ -626,7 +626,7 @@ class Phi4AudioEmbed {
     
     // Currently we only support 8k and 16k Hz sampling rate.
     if (sr_val != 8000 && sr_val != 16000){
-      ORTX_CXX_API_THROW("ort-extensions internal error: currently only 8k and 16k Hz sampling rate is supported", ORT_RUNTIME_EXCEPTION);
+      ORTX_CXX_API_THROW("ort-extensions internal error: currently only 8k and 16k Hz sampling rate is supported. Please resample your audio file to either 8k or 16k.", ORT_RUNTIME_EXCEPTION);
     }
 
     logmel.Init(sr_val == 8000 ? logmel_8k_attrs_: logmel_attrs_);

--- a/shared/api/speech_features.hpp
+++ b/shared/api/speech_features.hpp
@@ -623,7 +623,13 @@ class Phi4AudioEmbed {
 
     SpeechLibLogMel logmel;
     // already checked in Init
-    logmel.Init(sr_val == 8000? logmel_8k_attrs_: logmel_attrs_);
+    
+    // Currently we only support 8k and 16k Hz sampling rate.
+    if (sr_val != 8000 && sr_val != 16000){
+      ORTX_CXX_API_THROW("ort-extensions internal error: currently only 8k and 16k Hz sampling rate is supported", ORT_RUNTIME_EXCEPTION);
+    }
+
+    logmel.Init(sr_val == 8000 ? logmel_8k_attrs_: logmel_attrs_);
     status = logmel.Compute(stft_norm, ts_logmel);
     if (!status.IsOk()) {
       return status;


### PR DESCRIPTION
Fixes issue where user was getting vague error when using audio file with 48k Hz sampling rate: https://github.com/microsoft/onnxruntime-extensions/blob/0d5aefa9b2e3c0be57ba3ae2d872b920d6d494a6/include/ort_c_to_cpp.h#L109