### PR TITLE
Enhance error message on audio file processing

### DIFF
--- a/operators/audio/audio_decoder.cc
+++ b/operators/audio/audio_decoder.cc
@@ -106,7 +106,7 @@ OrtxStatus AudioDecoder::ComputeInternal(const ortc::Tensor<uint8_t>& input, con
     str_format = *format;
   }
   auto stream_format = ReadStreamFormat(p_data, str_format, status);
-  if (status) {
+  if (!status.IsOk()) {
     return status;
   }
 

--- a/shared/api/c_api_feature_extraction.cc
+++ b/shared/api/c_api_feature_extraction.cc
@@ -42,6 +42,10 @@ extError_t ORTX_API_CALL OrtxLoadAudios(OrtxRawAudios** raw_audios, const char* 
   auto audios_obj = std::make_unique<RawAudiosObject>();
   auto [audios, num] =
       ort_extensions::LoadRawData<char const* const*, AudioRawData>(audio_paths, audio_paths + num_audios);
+  if (num == 0) {
+    ReturnableStatus::last_error_message_ = "No audio data loaded";
+    return kOrtxErrorInvalidArgument;
+  }
   audios_obj->audios_ = std::move(audios);
   audios_obj->num_audios_ = num;
 


### PR DESCRIPTION
1. report explicit error if file format not recognizing.
2. report explicit error if the audio file not loaded.

related issue #900 