### PR TITLE
Remove comma in cmake argument list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,7 +444,7 @@ set(_HAS_TOKENIZER OFF)
 if(OCOS_ENABLE_GPT2_TOKENIZER)
   # GPT2
   set(_HAS_TOKENIZER ON)
-  file(GLOB tok_TARGET_SRC "operators/tokenizer/bpe_*.*" "operators/tokenizer/unicode*.*", "operators/tokenizer/case_*.*")
+  file(GLOB tok_TARGET_SRC "operators/tokenizer/bpe_*.*" "operators/tokenizer/unicode*.*" "operators/tokenizer/case_*.*")
   list(APPEND TARGET_SRC ${tok_TARGET_SRC})
 endif()
 


### PR DESCRIPTION
Addressing warning:

```
CMake Warning (dev) at onnxruntime_extensions-src/CMakeLists.txt:447:
  Syntax Warning in cmake code at column 90

  Argument not separated from preceding token by whitespace.
```