### PR TITLE
Fix unreferenced variable warning in chat_template.cc

### DIFF
--- a/shared/api/chat_template.cc
+++ b/shared/api/chat_template.cc
@@ -10,7 +10,7 @@ OrtxStatus TokenizerImpl::LoadChatTemplate() {
   if (chat_template.size()) {
     try {
       chat_template_root_ = minja::Parser::parse(chat_template, {});
-    } catch (const std::runtime_error& e) {
+    } catch (const std::runtime_error&) {
       return OrtxStatus(kOrtxOK, "Warning: The chat template for this model is not yet supported, trying to apply chat template will cause an error.");
     }
   }


### PR DESCRIPTION
Fix warning:
shared\api\chat_template.cc(13,40): warning C4101: 'e': unreferenced local variable