### PR TITLE
Reverse Chat Template Fallback Order

### DIFF
--- a/shared/api/chat_template.cc
+++ b/shared/api/chat_template.cc
@@ -809,7 +809,8 @@ OrtxStatus TokenizerImpl::ApplyChatTemplate(const char* template_str, const char
       root = minja::Parser::parse(template_str, {});
     }
     if (root == nullptr) {
-      return {kOrtxErrorInvalidArgument, "Invalid chat template."};
+      // Note that this will get caught in the "catch" and then we try the native implementation.
+      throw std::runtime_error("Invalid chat template.");
     }
 
     auto context = minja::Context::make(json({


### PR DESCRIPTION
This change now ensures we try to parse the chat template with Minja first, and then falls back on the native implementation.