### PR TITLE
Fix Marian Decoding

### DIFF
--- a/operators/tokenizer/ugm_kernels.hpp
+++ b/operators/tokenizer/ugm_kernels.hpp
@@ -719,11 +719,6 @@ class SpmUgmDecoder {
     special_token_ids_ = tokenizer.special_token_ids_;
     tokenizer_add_space_prefix_ = tokenizer.tokenizer_add_space_prefix_;
     case_encoding_ = tokenizer.case_encoder_ != nullptr;
-
-    if (config.tokenizer_class_ == "MarianTokenizer") {
-      is_marian = true;
-    }
-
     return {};
   }
 
@@ -731,7 +726,6 @@ class SpmUgmDecoder {
     const int64_t* p_ids = ids.Data();
     const auto& ids_dim = ids.Shape();
     std::vector<int64_t> output_dim = {1};
-
     if (ids_dim.size() > 1) {
       output_dim.resize(ids_dim.size() - 1);
       std::copy(ids_dim.begin(), ids_dim.begin() + ids_dim.size() - 1, output_dim.begin());
@@ -743,62 +737,24 @@ class SpmUgmDecoder {
     std::vector<std::string> decoded_strings;
     decoded_strings.reserve(string_batch);
     TokenizerDecodingState* state{};
-
-    for (size_t n = 0; n < string_batch; ++n) {
-      std::vector<std::string> words;
-      std::string current_word;
-
+    for (auto n = string_batch; n > 0; n--) {
+      std::string text;
       for (int64_t i = 0; i < seq_len; ++i) {
-        int64_t id = p_ids[n * seq_len + i];
-
         std::string token;
-        Id2Token(ort_extensions::narrow<extTokenId_t>(id), token, &state);
-        if (token.empty() || token == "</s>") continue;
-
-        if (is_marian) {
-          // Check if token ends with ▁ (U+2581), UTF-8: E2 96 81
-          const std::string marker = "\u2581";
-          if (token.size() >= 3 &&
-              token.compare(token.size() - 3, 3, marker) == 0) {
-            current_word += token.substr(0, token.size() - 3);
-            words.push_back(std::move(current_word));
-            current_word.clear();
-          } else {
-            current_word += token;
-          }
-        } else {
-          current_word += token;
-        }
+        Id2Token(ort_extensions::narrow<extTokenId_t>(p_ids[i]), token, &state);
+        text += token;
       }
 
-      if (is_marian) {
-        if (!current_word.empty()) {
-          words.push_back(std::move(current_word));
-        }
-
-        // Join words with space
-        std::string text;
-        for (size_t i = 0; i < words.size(); ++i) {
-          if (i > 0) text += " ";
-          text += words[i];
-        }
-
-        // Capitalize first letter if needed
-        if (!text.empty() && std::islower(static_cast<unsigned char>(text[0]))) {
-          text[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(text[0])));
-        }
-
-        decoded_strings.push_back(std::move(text));
-      } else {
-        std::string text = current_word;
-        if (tokenizer_add_space_prefix_ && !text.empty() && text[0] == ' ') {
+      if (tokenizer_add_space_prefix_) {
+        if (text.length() > 0 && text[0] == ' ') {
           text = text.substr(1);
         }
-        if (case_encoding_ && !text.empty() && text.back() == ' ') {
-          text.pop_back();
-        }
-        decoded_strings.push_back(std::move(text));
       }
+
+      if (case_encoding_ && text.back() == ' ') {
+        text.pop_back();
+      }
+      decoded_strings.push_back(text);
     }
 
     std::unique_ptr<TokenizerDecodingState> decoding_state(state);
@@ -836,11 +792,14 @@ class SpmUgmDecoder {
 
     const std::string ws = " ";
     auto pos = token.find(spm_escaped_space);
-    if (pos == 0) {
-      token = ws + token.substr(spm_escaped_space.length());
-    } else if (pos + 3 == token.length()) {
-      token = token.substr(0, pos) + ws;
+    if (pos != std::string::npos) {
+      if (pos == 0) {
+        token = ws + token.substr(spm_escaped_space.length());
+      } else if (pos + 3 == token.length()) {
+        token = token.substr(0, pos) + ws;
+      }
     }
+    
     if (!case_encoding_) {
       return {};
     }
@@ -900,7 +859,6 @@ class SpmUgmDecoder {
   std::vector<std::string> vocab_;
   std::string unknown_token_ = "<unk>";
   std::set<extTokenId_t> special_token_ids_;
-  bool is_marian = false;
 };
 
 }  // namespace ort_extensions


### PR DESCRIPTION


### Updates

This PR fixes a couple issues in UGM Kernels (used for our Marian tokenizer for the Marian translation model)
1. **Incorrect Spacing from Wrongful Comparisons due to Overflow**: In certain instances Id2Token may have run into an index for an escape sequence which was a very large number (`size_t(-1)`) and a unchecked comparison such as `pos + 3 == token.length()` which should end up being false in intention, was resulting in true due to overflow (i.e., `npos + 3` wraps around and accidentally equals `token.length()` for some short strings like "г").
2. **Titlecase Logic**: basic `toupper` does not work for a lot of languages, such as Russian, due to characters such as the Cyrillic ones. We hence refactor titlecase logic completely. Note that we use `std::towupper`, and although it would lead to a simpler implementation we do not use `std::wstring_convert` because of efficiency concerns and the following reasons:
      - **Slow**: `std::wstring_convert` (and `std::codecvt_utf8`) is notoriously slow, because:
            - It allocates memory.
            - It does full string conversions even when we only need the first character.
      - **Deprecated**: It is deprecated in C++17 and removed in C++20.
      - **Overkill**: We're only trying to titlecase the first character — so converting the entire string just to uppercase one character is inefficient.

### Validation
- [x] Native C++ testing against baseline output. Since the test data required for the tokenizer is from a currently private model, these files and respective tests are not checked in.