### PR TITLE
Fix LinuxPyDbg in CI Pipeline

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -122,7 +122,6 @@ stages:
     - task: UsePythonVersion@0
       inputs:
         versionSpec: '3.10'
-        disableDownloadFromRegistry: true
         addToPath: true
         architecture: 'x64'
 

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -121,7 +121,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.x'
+        versionSpec: '3.10'
         disableDownloadFromRegistry: true
         addToPath: true
         architecture: 'x64'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+pyreadline3
 pytest
 numpy            < 2.0.0
 onnx             >=1.9.0


### PR DESCRIPTION
1. Makes python version explicit for LinuxPyDbg
2. Enables download from registry
3. Adds pyreadline3 to requirements-dev.txt