### PR TITLE
Fix: Added check the type of  tokenizer.json's model_merges

### DIFF
--- a/onnxruntime_extensions/_hf_cvt.py
+++ b/onnxruntime_extensions/_hf_cvt.py
@@ -54,8 +54,15 @@ class HFTokenizerConverter(CustomOpConverter):
         # get vocab object from json file
         vocab = tokenizer_json.get("model", {}).get("vocab", {})
         sorted_merges = tokenizer_json.get("model", {}).get("merges", [])
-        sorted_merges = [v_.replace("\n", "<0x0A>") for v_ in sorted_merges]
+        
         attrs = {"vocab": json.dumps(vocab, separators=(",", ":"))}
+
+        # merges data can be a list of string or list of list of string
+        if (all(isinstance(v_,(list,tuple)))  for v_ in sorted_merges) :
+            sorted_merges = [ " ".join(v if v != "\n" else "<0x0A>" for v in v_ ) for v_ in sorted_merges]
+        else : 
+            sorted_merges = [v_.replace("\n", "<0x0A>") for v_ in sorted_merges]
+
         attrs["merges"] = "\n".join(sorted_merges)
         if hf_tokenizer.added_tokens_encoder:
             token_map = [f"{_k}={_v}" for _k,


### PR DESCRIPTION
In Tokenizer like gpt-2 or gemma-2 merges stored as list of string  while in modern Tokenizer store merges as list of list of string .
Ex [Mistral](https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Base-2503/resolve/main/tokenizer.json)