### PR TITLE
Add `skip_special_tokens` to Decoder API

### DIFF
--- a/include/ortx_tokenizer.h
+++ b/include/ortx_tokenizer.h
@@ -141,6 +141,20 @@ extError_t ORTX_API_CALL OrtxDetokenize(const OrtxTokenizer* tokenizer, const Or
 extError_t ORTX_API_CALL OrtxDetokenize1D(const OrtxTokenizer* tokenizer, const extTokenId_t* input, size_t len,
                                           OrtxStringArray** output);
 
+/** \brief Detokenize the input using the specified tokenizer and options such as the skip_special_tokens flag (1D version).
+ * 
+ * Separate from OrtxDetokenize1D for backward compatibility. Can be used to specify other options in the future.
+ *
+ * \param tokenizer Pointer to the tokenizer object
+ * \param input Pointer to the input token IDs
+ * \param len Length of the input token IDs array
+ * \param output Pointer to store the detokenized result
+ * \param skip_special_tokens Boolean to determine whether to add or omit special tokens
+ * \return Error code indicating the success or failure of the operation
+ */
+extError_t ORTX_API_CALL OrtxDetokenize1DWithOptions(const OrtxTokenizer* tokenizer, const extTokenId_t* input, size_t len,
+                                          OrtxStringArray** output, bool skip_special_tokens);
+
 /** \brief Detokenize the input using the specified tokenizer with caching
  *
  * \param tokenizer Pointer to the tokenizer object

--- a/operators/tokenizer/bpe_streaming.hpp
+++ b/operators/tokenizer/bpe_streaming.hpp
@@ -177,7 +177,8 @@ class BpeStreamingDecoder : public KernelBpeDecoder {
   }
 
   OrtxStatus Compute(const ortc::Tensor<int64_t>& ids,
-                     ortc::Tensor<std::string>& output) const {
+                     ortc::Tensor<std::string>& output,
+                     bool skip_special_tokens) const {
     const int64_t* p_ids = ids.Data();
     const auto& ids_dim = ids.Shape();
     std::vector<int64_t> output_dim = {1};
@@ -201,7 +202,7 @@ class BpeStreamingDecoder : public KernelBpeDecoder {
 
         auto status = spm_model_
                       ? SpmId2Token(id, decoded_token, f_special_last)
-                      : Id2Token(id, decoded_token, true, f_special_last);
+                      : Id2Token(id, decoded_token, skip_special_tokens, f_special_last);
 
         if (!status.IsOk()) {
           return status;

--- a/operators/tokenizer/ugm_kernels.hpp
+++ b/operators/tokenizer/ugm_kernels.hpp
@@ -724,7 +724,7 @@ class SpmUgmDecoder {
     return {};
   }
 
-  OrtxStatus Compute(const ortc::Tensor<int64_t>& ids, ortc::Tensor<std::string>& output) const {
+  OrtxStatus Compute(const ortc::Tensor<int64_t>& ids, ortc::Tensor<std::string>& output, std::optional<bool> add_special_tokens) const {
     const int64_t* p_ids = ids.Data();
     const auto& ids_dim = ids.Shape();
     std::vector<int64_t> output_dim = {1};

--- a/shared/api/tokenizer_impl.cc
+++ b/shared/api/tokenizer_impl.cc
@@ -114,17 +114,15 @@ OrtxStatus TokenizerImpl::BatchEncode(const std::vector<std::string_view>& input
 }
 
 OrtxStatus TokenizerImpl::BatchDecode(const std::vector<span<extTokenId_t const>>& t_ids,
-                                      std::vector<std::string>& t_text) const {
+                                      std::vector<std::string>& t_text, bool skip_special_tokens) const {
   for (const auto& s : t_ids) {
     std::vector<int64_t> ids(s.size());
     std::transform(s.begin(), s.end(), ids.begin(), [](extTokenId_t v) { return static_cast<int64_t>(v); });
     ortc::Tensor<int64_t> ts_input(std::vector<int64_t>{1, static_cast<int64_t>(ids.size())}, (void*)ids.data());
     ortc::Tensor<std::string> ts_output;
 
-    // Note: currently the detokenizer Compute is called with skip_special_tokens = true
-    // by default, but this parameter should be exposed to GenAI in the future.
     OrtxStatus status = std::visit([&](auto& detokenizer) {
-      return detokenizer->Compute(ts_input, ts_output); }, detokenizer_);
+      return detokenizer->Compute(ts_input, ts_output, skip_special_tokens); }, detokenizer_);
 
     if (!status.IsOk()) {
       return status;

--- a/shared/api/tokenizer_impl.h
+++ b/shared/api/tokenizer_impl.h
@@ -27,8 +27,8 @@ class TokenizerImpl : public OrtxObjectImpl {
     return BatchEncode(input, t_ids, add_special_tokens);
   }
 
-  OrtxStatus Detokenize(const std::vector<span<extTokenId_t const>>& t_ids, std::vector<std::string>& t_text) const {
-    return BatchDecode(t_ids, t_text);
+  OrtxStatus Detokenize(const std::vector<span<extTokenId_t const>>& t_ids, std::vector<std::string>& t_text, bool skip_special_tokens = true) const {
+    return BatchDecode(t_ids, t_text, skip_special_tokens);
   }
 
   OrtxStatus Token2Id(const std::string& token, extTokenId_t& id) const {
@@ -52,7 +52,9 @@ class TokenizerImpl : public OrtxObjectImpl {
                          std::vector<std::vector<extTokenId_t>>& t_ids,
                          bool add_special_tokens) const;
 
-  OrtxStatus BatchDecode(const std::vector<span<extTokenId_t const>>& t_ids, std::vector<std::string>& t_text) const;
+  OrtxStatus BatchDecode(const std::vector<span<extTokenId_t const>>& t_ids,
+                         std::vector<std::string>& t_text,
+                         bool skip_special_tokens) const;
 
   using MessageList = std::vector<std::unordered_map<std::string, std::string>>;
   std::string chat_template;

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -603,6 +603,24 @@ TEST(OrtxTokenizerTest, Gemma3SpecialChatTemplate) {
   ASSERT_EQ(std::string(special_text), expected_special_decoder_output);
 }
 
+/*
+
+Neither OpenAI nor HuggingFace have explicit Whisper chat template functionality.
+
+OpenAI does not expose Whisper via a chat interface like ChatCompletion.
+Instead, their Whisper API uses raw audio uploads. For finetuning or embedding Whisper
+in pipelines, they rely on pre-tokenized sequences. They don’t use Jinja2 or chat templates
+for Whisper at all — it is purely sequence input with prepended tokens like
+<|startoftranscript|> manually inserted.
+
+In HuggingFace transformers, for Whisper, you are expected to pass in the template manually
+or have it defined in tokenizer_config.json.
+
+However, the expected logic (same for HF and OAI) should emulate concatenating
+message['content'], with no roles, separators, etc. We thereby automatically handle this
+in ORT Extensions as well.
+
+*/
 
 TEST(OrtxTokenizerTest, WhisperChatTemplate) {
   OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/tokenizer/whisper.tiny");


### PR DESCRIPTION
### Updates

Inside the foundry catalog for [Foundry Local](https://github.com/[microsoft/Foundry-Local](https://github.com/microsoft/Foundry-Local)), all tool call tokens are marked as special such that we can use them with guidance inside [GenAI](https://github.com/microsoft/onnxruntime-genai). Now, in order for decoding to work with these tokens, we need to expose using special tokens as an option in our Decoder API in Extensions. Hence, this API adds `skip_special_tokens` to `OrtxDetokenize1DWithOptions`, used in the GenAI `OgaDecoder`.

Note that we leave `OrtxDetokenize1D` as is for backward compatibility. In the future, we shall be adding an extensible options map API that will reduce the need for messy parameter additions to our Encoder/Decoder APIs, and can be easily consumed by GenAI and other partners.

### Validation
- [x] Native C++ testing against HuggingFace benchmark.