### PR TITLE
Fix Phi-3-Vision Issue

### DIFF
--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -521,22 +521,6 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
           }
         }
 
-        // Handle leading '▁' if in vocab
-        if (mutable_tok.front() == 0x2581) {
-          // Convert the full token to UTF-8 for vocab check
-          std::string full_utf8_token = std::string(ustring(mutable_tok));
-          auto full_id = bbpe_tokenizer_->GetTokenId(full_utf8_token);
-
-          // Convert just the '▁' prefix to UTF-8 and get its ID
-          std::string prefix_utf8 = "\xE2\x96\x81";  // U+2581 in UTF-8
-          auto prefix_id = bbpe_tokenizer_->GetTokenId(prefix_utf8);
-
-          if (full_id == bpe::kInvalidTokenId && prefix_id != bpe::kInvalidTokenId) {
-            byte_list.emplace_back(prefix_id, 1);
-            mutable_tok.erase(mutable_tok.begin());  // Remove '▁' from token
-          }
-        }
-
         std::string utf8_token = std::string(ustring(mutable_tok));
 
         auto id = bbpe_tokenizer_->GetTokenId(utf8_token);

--- a/test/pp_api_test/test_tokenizer_impl.cc
+++ b/test/pp_api_test/test_tokenizer_impl.cc
@@ -143,6 +143,28 @@ TEST(OrtxTokenizerTest, Phi3_Small_Tokenizer) {
   EXPECT_EQ(token_ids[0], EXPECTED_IDS_0);
 }
 
+TEST(OrtxTokenizerTest, Phi3_Vision_Tokenizer) {
+  auto tokenizer = std::make_unique<ort_extensions::TokenizerImpl>();
+  auto status = tokenizer->Load("data/phi-3-vision");
+  if (!status.IsOk()) {
+    std::cout << status.ToString() << std::endl;
+    tokenizer.reset();
+  }
+
+  // validate tokenizer is not null
+  ASSERT_NE(tokenizer.get(), nullptr) << "Tokenizer is null, stopping the test.";
+
+  std::vector<extTokenId_t> EXPECTED_IDS_0 = {1, 3750, 338, 512, 2325, 16459, 17587, 29973};
+  std::vector<std::string_view> input = {"Why is Include handled differently?"};
+  std::vector<std::vector<extTokenId_t>> token_ids;
+  status = tokenizer->Tokenize(input, token_ids);
+  EXPECT_TRUE(status.IsOk());
+  DumpTokenIds(token_ids);
+
+  EXPECT_EQ(token_ids.size(), input.size());
+  EXPECT_EQ(token_ids[0], EXPECTED_IDS_0);
+}
+
 TEST(OrtxTokenizerTest, GemmaTokenizer) {
   auto tokenizer = std::make_unique<ort_extensions::TokenizerImpl>();
   auto status = tokenizer->Load("data/gemma");


### PR DESCRIPTION
### Updates
This PR fixes a tokenization issue in our BPE tokenizer for Phi-3-Vision, caused by unnecessary edge-case handling of leading '▁' in tokens.

### Validation
- [x] Native C++ testing against expected HuggingFace output.