### PR TITLE
Add Phi-4 Tools Quote Normalization

### DIFF
--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -822,7 +822,10 @@ TEST(OrtxTokenizerTest, Phi4MiniChatTemplateWithMinjaTools) {
   const char* text_ptr = nullptr;
   OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
 
-  std::string expected_output = "<|system|>You are a helpful assistant.<|tool|>[{\"name\": \"get_horoscope\", \"description\": \"Get today's horoscope for an astrological sign.\", \"parameters\": {\"sign\": {\"type\": \"str\", \"description\": \"An astrological sign like Taurus or Aquarius\", \"default\": \"\"}}}]<|/tool|><|end|><|user|>How should I explain the Internet?<|end|><|assistant|>";
+  std::string expected_output = "<|system|>You are a helpful assistant.<|tool|>"
+                                "[{\"name\": \"get_horoscope\", \"description\": \"Get today's horoscope for an astrological sign.\", "
+                                "\"parameters\": {\"sign\": {\"type\": \"str\", \"description\": \"An astrological sign like Taurus or Aquarius\", "
+                                "\"default\": \"\"}}}]<|/tool|><|end|><|user|>How should I explain the Internet?<|end|><|assistant|>";
 
   ASSERT_EQ(std::string(text_ptr), expected_output);
 }
@@ -863,7 +866,10 @@ TEST(OrtxTokenizerTest, Phi4MiniChatTemplateWithOAIToolType) {
   const char* text_ptr = nullptr;
   OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
 
-  std::string expected_output = "<|system|>You are a helpful assistant.<|tool|>[{\"name\": \"get_horoscope\", \"description\": \"Get today's horoscope for an astrological sign.\", \"parameters\": {\"sign\": {\"type\": \"str\", \"description\": \"An astrological sign like Taurus or Aquarius\"}}}]<|/tool|><|end|><|user|>How should I explain the Internet?<|end|><|assistant|>";
+  std::string expected_output = "<|system|>You are a helpful assistant.<|tool|>"
+                                "[{\"name\": \"get_horoscope\", \"description\": \"Get today's horoscope for an astrological sign.\", "
+                                "\"parameters\": {\"sign\": {\"type\": \"str\", \"description\": \"An astrological sign like Taurus or Aquarius\"}}}]"
+                                "<|/tool|><|end|><|user|>How should I explain the Internet?<|end|><|assistant|>";
 
   ASSERT_EQ(std::string(text_ptr), expected_output);
 }
@@ -904,7 +910,12 @@ TEST(OrtxTokenizerTest, Phi4MiniChatTemplateWithOAIFunctionType) {
   const char* text_ptr = nullptr;
   OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
 
-  std::string expected_output = "<|system|>You are a helpful assistant.<|tool|>[{\"name\": \"get_weather\", \"description\": \"Get the current weather for a given location.\", \"parameters\": {\"location\": {\"type\": \"str\", \"description\": \"The name of the city or location.\"}}}, {\"name\": \"get_tourist_attractions\", \"description\": \"Get a list of top tourist attractions for a given city.\", \"parameters\": {\"city\": {\"type\": \"str\", \"description\": \"The name of the city to find attractions for.\"}}}]<|/tool|><|end|><|user|>How should I explain the Internet?<|end|><|assistant|>";
+  std::string expected_output = "<|system|>You are a helpful assistant.<|tool|>"
+                                "[{\"name\": \"get_weather\", \"description\": \"Get the current weather for a given location.\", "
+                                "\"parameters\": {\"location\": {\"type\": \"str\", \"description\": \"The name of the city or location.\"}}}, "
+                                "{\"name\": \"get_tourist_attractions\", \"description\": \"Get a list of top tourist attractions for a given city.\", "
+                                "\"parameters\": {\"city\": {\"type\": \"str\", \"description\": \"The name of the city to find attractions for.\"}}}]"
+                                "<|/tool|><|end|><|user|>How should I explain the Internet?<|end|><|assistant|>";
 
   ASSERT_EQ(std::string(text_ptr), expected_output);
 }


### PR DESCRIPTION
## Description

This PR improves the previously introduced [Tool Normalization features](https://github.com/microsoft/onnxruntime-extensions/pull/1002) by addressing the issue of inconsistent handling of tool quotes in Phi-4 function calling. It introduces the `normalize_tool_quotes` function to maintain consistency in JSON serialization and deserialization, particularly when tools are embedded within the message body as it is in the case of Phi-4, rather than as an additional input like with Qwen 2.5 and most models.

## Validation

- [x] Native C++ unit testing for all three tool formats for Phi-4-mini (Minja/Phi-4, OpenAI `tool`, OpenAI `function`)
- [x] E2E testing in Foundry Local with supported Phi-4 and Qwen 2.5 models
- [x] Verified that chat template rendering produces the expected system/user/assistant block
- [x] Confirmed that existing tests and APIs remain unaffected when tools are not provided/provided in previous standard
