### PR TITLE
Update NuGet Pipeline for AzureLinux

### DIFF
--- a/.pipelines/templates/build-package-for-linux.yml
+++ b/.pipelines/templates/build-package-for-linux.yml
@@ -54,8 +54,12 @@ jobs:
         displayName: 'build onnxruntime-extensions and run tests'
     - ${{ else }}:
       - bash: |
-          sudo dnf remove cmake
-          pip install cmake --upgrade
+          if ! dnf list installed cmake &>/dev/null; then
+            echo "CMake is not installed. Installing/upgrading cmake."
+            pip install cmake --upgrade
+          else
+            echo "CMake is already installed."
+          fi
           export PATH=~/.local/bin:$PATH
           cmake --version
           export CFLAGS="${{parameters.OrtExtensionsCFlags}}"

--- a/tools/ci_build/github/azure-pipeline/templates/build-package-for-linux.yml
+++ b/tools/ci_build/github/azure-pipeline/templates/build-package-for-linux.yml
@@ -64,8 +64,12 @@ jobs:
         displayName: 'build onnxruntime-extensions and run tests'
     - ${{ else }}:
       - bash: |
-          sudo dnf remove cmake
-          pip install cmake --upgrade
+          if ! dnf list installed cmake &>/dev/null; then
+            echo "CMake is not installed. Installing/upgrading cmake."
+            pip install cmake --upgrade
+          else
+            echo "CMake is already installed."
+          fi
           export PATH=~/.local/bin:$PATH
           cmake --version
           export CFLAGS="${{parameters.OrtExtensionsCFlags}}"


### PR DESCRIPTION
## Description

This PR updates the **Linux NuGet build pipeline** to support the switch from **ARM64 Linux** to **AzureLinux** VMs.

Key updates:

- **Switch to AzureLinux for ARM (aarch64) Builds**  
  - Replaces `apt-get` with `dnf` for package installation and CMake management on **AzureLinux VMs** for ARM64 architecture.
  - Ensures proper installation of dependencies like `libssh-devel` and `cmake` in the ARM64 environment.

- **CMake Upgrade for ARM (aarch64)**  
  - Adds logic to check if CMake is already installed on ARM builds and upgrade it using `pip` if necessary, ensuring the correct version for the build due to long build times (2+ hours).

This update ensures compatibility with **AzureLinux VMs** and improves the cross-platform support for both `x64` and `aarch64` architectures, optimizing the build process for ARM-based environments.

## Validation

- [x] **Successful builds** for both `x64` and `aarch64` architectures for ORT Extensions NuGet Packaging pipeline
- [x] **Package installation** and CMake upgrade correctly handled for ARM64 (AzureLinux) VMs
