### PR TITLE
Fix Win x86 build

### DIFF
--- a/shared/api/c_api_utils.cc
+++ b/shared/api/c_api_utils.cc
@@ -25,7 +25,7 @@ OrtxStatus OrtxObjectImpl::IsInstanceOf(extObjectKind_t kind) const {
 
 int ORTX_API_CALL OrtxGetAPIVersion() { return API_VERSION; }
 
-const char* OrtxGetLastErrorMessage() { return ReturnableStatus::last_error_message_.c_str(); }
+const char* ORTX_API_CALL OrtxGetLastErrorMessage() { return ReturnableStatus::last_error_message_.c_str(); }
 
 extError_t ORTX_API_CALL OrtxCreate(extObjectKind_t kind, OrtxObject** object, ...) {
   if (object == nullptr) {


### PR DESCRIPTION
OrtxGetLastErrorMessage was missing the ORTX_API_CALL calling convention specifier in its definition as the header file declared it.