### PR TITLE
Add InternLM2Tokenizer support (BPE tokenizer)

### DIFF
--- a/operators/tokenizer/tokenizer_jsconfig.hpp
+++ b/operators/tokenizer/tokenizer_jsconfig.hpp
@@ -21,6 +21,7 @@ constexpr std::pair<const char*, TokenType> kTokenizerDict[] = {
   {"CLIPTokenizer", TokenType::kBPE},
   {"WhisperTokenizer", TokenType::kBPE},
   {"GemmaTokenizer", TokenType::kBPE},
+  {"InternLM2Tokenizer", TokenType::kBPE},  // InternLM2 uses BPE (same as Llama)
   {"LlamaTokenizer", TokenType::kBPE},
   {"Phi3Tokenizer", TokenType::kBPE},
   {"CodeLlamaTokenizer", TokenType::kBPE},


### PR DESCRIPTION
## Summary
InternLM2 models use the same BPE/LLaMA tokenizer format as Llama. This registers `InternLM2Tokenizer` so that models exported with `tokenizer_class: InternLM2Tokenizer` in `tokenizer_config.json` are recognized at runtime.

## Changes
- Added `{"InternLM2Tokenizer", TokenType::kBPE}` to the tokenizer type map in `operators/tokenizer/tokenizer_jsconfig.hpp`

## Reference
- Model: https://huggingface.co/internlm/internlm2-1_8b
- Related onnxruntime-genai PR: [link to your PR if available]

## Testing
Tested with InternLM2-1.8B model export and inference in onnxruntime-genai.