### PR TITLE
Add Gemma 4 Preprocessing Support (Image, Audio, Text)

### DIFF
--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -812,11 +812,15 @@ void JsonFastTokenizer::UpdateTokenizer(const TokenJsonConfig& config, const jso
   // tokenizer_config.json. When these flags were not explicitly set, try to
   // infer BOS/EOS behavior from the post_processor in tokenizer.json, or fall
   // back to per-class defaults for known tokenizer families.
-  // Track BOS and EOS inference separately so that finding only one in the
-  // post_processor doesn't suppress the per-class default for the other.
+  //
+  // Note: EOS inference is intentionally scoped inside the BOS-not-explicit
+  // block rather than being fully independent. In pre-v5 tokenizers (e.g.
+  // Mistral), add_bos_token is explicit but add_eos_token is simply absent
+  // (meaning "default false", not "infer from post_processor"). Making EOS
+  // inference independent would incorrectly enable EOS for those models.
+  // In v5, both flags are absent, so this block correctly handles both.
   if (!config.add_bos_token_explicit_ && !config.bos_token_.empty()) {
     bool bos_inferred = false;
-    bool eos_inferred = false;
     auto post_processor = tok_json.find("post_processor");
     if (post_processor != tok_json.end()) {
       std::string text = post_processor->dump();
@@ -827,7 +831,6 @@ void JsonFastTokenizer::UpdateTokenizer(const TokenJsonConfig& config, const jso
       if (!config.add_eos_token_explicit_ &&
           text.find(config.eos_token_) != std::string::npos) {
         add_eos_token_ = true;
-        eos_inferred = true;
       }
     }
 

--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -813,17 +813,22 @@ void JsonFastTokenizer::UpdateTokenizer(const TokenJsonConfig& config, const jso
   // infer BOS/EOS behavior from the post_processor in tokenizer.json, or fall
   // back to per-class defaults for known tokenizer families.
   if (!config.add_bos_token_explicit_ && !config.bos_token_.empty()) {
+    bool inferred_from_post_processor = false;
     auto post_processor = tok_json.find("post_processor");
     if (post_processor != tok_json.end()) {
       std::string text = post_processor->dump();
       if (text.find(config.bos_token_) != std::string::npos) {
         add_bos_token_ = true;
+        inferred_from_post_processor = true;
       }
       if (text.find(config.eos_token_) != std::string::npos) {
         add_eos_token_ = true;
+        inferred_from_post_processor = true;
       }
-    } else {
-      // No post_processor in tokenizer.json and no explicit config flags:
+    }
+
+    if (!inferred_from_post_processor) {
+      // post_processor is absent or doesn't mention BOS/EOS:
       // apply per-class defaults for known tokenizer families.
       // Note: GPT2-family models (Phi-4, Qwen2, DeepSeek, etc.) correctly
       // default to add_bos_token_=false so they don't need to be listed here.

--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -812,23 +812,27 @@ void JsonFastTokenizer::UpdateTokenizer(const TokenJsonConfig& config, const jso
   // tokenizer_config.json. When these flags were not explicitly set, try to
   // infer BOS/EOS behavior from the post_processor in tokenizer.json, or fall
   // back to per-class defaults for known tokenizer families.
+  // Track BOS and EOS inference separately so that finding only one in the
+  // post_processor doesn't suppress the per-class default for the other.
   if (!config.add_bos_token_explicit_ && !config.bos_token_.empty()) {
-    bool inferred_from_post_processor = false;
+    bool bos_inferred = false;
+    bool eos_inferred = false;
     auto post_processor = tok_json.find("post_processor");
     if (post_processor != tok_json.end()) {
       std::string text = post_processor->dump();
       if (text.find(config.bos_token_) != std::string::npos) {
         add_bos_token_ = true;
-        inferred_from_post_processor = true;
+        bos_inferred = true;
       }
-      if (text.find(config.eos_token_) != std::string::npos) {
+      if (!config.add_eos_token_explicit_ &&
+          text.find(config.eos_token_) != std::string::npos) {
         add_eos_token_ = true;
-        inferred_from_post_processor = true;
+        eos_inferred = true;
       }
     }
 
-    if (!inferred_from_post_processor) {
-      // post_processor is absent or doesn't mention BOS/EOS:
+    if (!bos_inferred) {
+      // post_processor is absent or doesn't mention BOS:
       // apply per-class defaults for known tokenizer families.
       // Note: GPT2-family models (Phi-4, Qwen2, DeepSeek, etc.) correctly
       // default to add_bos_token_=false so they don't need to be listed here.

--- a/shared/api/gemma4_audio_features.hpp
+++ b/shared/api/gemma4_audio_features.hpp
@@ -259,7 +259,9 @@ class Gemma4LogMel {
       for (int64_t fi = 0; fi < num_frames; ++fi) {
         float* mel_row = logmel_data.data() + fi * feature_size_;
         for (int64_t m = 0; m < feature_size_; ++m) {
-          mel_row[m] /= per_bin_stddev_[m];
+          if (per_bin_stddev_[m] != 0.0f) {
+            mel_row[m] /= per_bin_stddev_[m];
+          }
         }
       }
     }

--- a/shared/api/gemma4_audio_features.hpp
+++ b/shared/api/gemma4_audio_features.hpp
@@ -1,0 +1,346 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cmath>
+#include <vector>
+#include <complex>
+#include <algorithm>
+#include <numeric>
+
+#include "ext_status.h"
+#include "op_def_struct.h"
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace ort_extensions {
+
+// Gemma 4 audio feature extraction: USM-style log-mel spectrogram that matches
+// the HuggingFace Gemma4AudioFeatureExtractor exactly.
+//
+// Pipeline:  AudioDecoder  ->  Gemma4LogMel
+//
+// Inputs:   float (1, num_samples)  — mono PCM at `sampling_rate` Hz
+// Outputs:  float (num_frames, feature_size) — log-mel features
+//           bool  (num_frames,)              — frame-level attention mask
+class Gemma4LogMel {
+ public:
+  Gemma4LogMel() = default;
+
+  // ---------- HTK mel-frequency conversions --------------------------------
+  static double HzToMel(double hz) { return 2595.0 * std::log10(1.0 + hz / 700.0); }
+  static double MelToHz(double mel) { return 700.0 * (std::pow(10.0, mel / 2595.0) - 1.0); }
+
+  // Build an HTK-scale mel filterbank  (num_freq_bins x num_mel_filters).
+  static std::vector<float> MelFilterBank(int num_freq_bins, int num_mel_filters,
+                                          int sampling_rate,
+                                          double min_freq, double max_freq) {
+    const double mel_min = HzToMel(min_freq);
+    const double mel_max = HzToMel(max_freq);
+    const int n_points = num_mel_filters + 2;
+    std::vector<double> mel_points(n_points);
+    for (int i = 0; i < n_points; ++i) {
+      mel_points[i] = mel_min + (mel_max - mel_min) * i / (n_points - 1);
+    }
+
+    // Convert mel points back to Hz, then to FFT bin indices.
+    std::vector<double> freq_points(n_points);
+    for (int i = 0; i < n_points; ++i) {
+      freq_points[i] = MelToHz(mel_points[i]);
+    }
+
+    // Filterbank: shape (num_freq_bins, num_mel_filters), stored row-major.
+    std::vector<float> fb(static_cast<size_t>(num_freq_bins) * num_mel_filters, 0.0f);
+
+    auto hz_to_bin = [&](double hz) -> double {
+      return hz * (num_freq_bins - 1) * 2.0 / sampling_rate;
+    };
+
+    for (int m = 0; m < num_mel_filters; ++m) {
+      const double left = hz_to_bin(freq_points[m]);
+      const double center = hz_to_bin(freq_points[m + 1]);
+      const double right = hz_to_bin(freq_points[m + 2]);
+
+      for (int k = 0; k < num_freq_bins; ++k) {
+        double kd = static_cast<double>(k);
+        float w = 0.0f;
+        if (kd > left && kd <= center && center > left) {
+          w = static_cast<float>((kd - left) / (center - left));
+        } else if (kd > center && kd < right && right > center) {
+          w = static_cast<float>((right - kd) / (right - center));
+        }
+        fb[static_cast<size_t>(k) * num_mel_filters + m] = w;
+      }
+    }
+    return fb;
+  }
+
+  // ---------- Periodic Hann window -----------------------------------------
+  static std::vector<float> PeriodicHannWindow(int N) {
+    // w[n] = 0.5 - 0.5 * cos(2*pi*n / N)   for n = 0 .. N-1
+    std::vector<float> w(N);
+    for (int n = 0; n < N; ++n) {
+      double s = std::sin(M_PI * n / N);
+      w[n] = static_cast<float>(s * s);
+    }
+    return w;
+  }
+
+  // ---------- Real FFT (magnitude only) ------------------------------------
+  // Cooley-Tukey radix-2 DIT FFT, returns only non-negative frequency magnitudes.
+  static void RealFFTMagnitude(const float* data, int n_fft, std::vector<float>& mag) {
+    const int n_out = n_fft / 2 + 1;
+    mag.resize(n_out);
+
+    // Build complex input (zero-padded if data is shorter than n_fft).
+    std::vector<std::complex<double>> x(n_fft, {0.0, 0.0});
+    // Caller must ensure the data pointer has at least n_fft valid elements
+    // (it may have been zero-padded externally).
+    for (int i = 0; i < n_fft; ++i) {
+      x[i] = {static_cast<double>(data[i]), 0.0};
+    }
+
+    // Bit-reversal permutation.
+    int log2n = 0;
+    for (int tmp = n_fft; tmp > 1; tmp >>= 1) ++log2n;
+    for (int i = 1, j = 0; i < n_fft; ++i) {
+      int bit = n_fft >> 1;
+      for (; j & bit; bit >>= 1) j ^= bit;
+      j ^= bit;
+      if (i < j) std::swap(x[i], x[j]);
+    }
+
+    // Butterfly stages.
+    for (int len = 2; len <= n_fft; len <<= 1) {
+      double ang = -2.0 * M_PI / len;
+      std::complex<double> wlen(std::cos(ang), std::sin(ang));
+      for (int i = 0; i < n_fft; i += len) {
+        std::complex<double> w(1.0, 0.0);
+        for (int j = 0; j < len / 2; ++j) {
+          auto u = x[i + j];
+          auto v = x[i + j + len / 2] * w;
+          x[i + j] = u + v;
+          x[i + j + len / 2] = u - v;
+          w *= wlen;
+        }
+      }
+    }
+
+    for (int i = 0; i < n_out; ++i) {
+      mag[i] = static_cast<float>(std::abs(x[i]));
+    }
+  }
+
+  // ---------- Main Compute -------------------------------------------------
+  OrtxStatus Compute(const ortc::Tensor<float>& pcm_input,
+                     ortc::Tensor<float>& logmel_out,
+                     ortc::Tensor<bool>& mask_out) {
+    const auto& pcm_shape = pcm_input.Shape();
+    if (pcm_shape.size() != 2 || pcm_shape[0] != 1) {
+      return {kOrtxErrorInvalidArgument,
+              "[Gemma4LogMel]: expected (1, num_samples) float input"};
+    }
+
+    const int64_t num_samples = pcm_shape[1];
+    const float* pcm = pcm_input.Data();
+
+    // --- build window & filterbank on first call ---------------------------
+    if (window_.empty()) {
+      window_ = PeriodicHannWindow(static_cast<int>(frame_length_));
+      int fft_len = 1;
+      while (fft_len < frame_length_) fft_len <<= 1;
+      if (fft_overdrive_) fft_len <<= 1;
+      fft_length_ = fft_len;
+
+      mel_filters_ = MelFilterBank(
+          fft_len / 2 + 1, static_cast<int>(feature_size_),
+          static_cast<int>(sampling_rate_), min_frequency_, max_frequency_);
+    }
+
+    // --- semicausal padding ------------------------------------------------
+    const int64_t pad_left = frame_length_ / 2;
+    const int64_t padded_len = num_samples + pad_left;
+    std::vector<float> padded(static_cast<size_t>(padded_len), 0.0f);
+    std::copy(pcm, pcm + num_samples, padded.begin() + pad_left);
+
+    // Build a per-sample attention mask (1 = real audio, 0 = padding).
+    std::vector<uint8_t> sample_mask(static_cast<size_t>(padded_len), 0);
+    std::fill(sample_mask.begin() + pad_left,
+              sample_mask.begin() + pad_left + num_samples, 1);
+
+    // --- unfold into overlapping frames ------------------------------------
+    const int64_t frame_size_unfold = frame_length_ + 1;  // 321 @ 16 kHz
+    if (padded_len < frame_size_unfold) {
+      // Audio too short to form even one frame — return empty tensors.
+      logmel_out.Allocate({0, feature_size_});
+      mask_out.Allocate({0});
+      return {};
+    }
+    const int64_t num_frames = (padded_len - frame_size_unfold) / hop_length_ + 1;
+
+    // --- per-frame processing ----------------------------------------------
+    const int n_freq = fft_length_ / 2 + 1;
+    std::vector<float> logmel_data(static_cast<size_t>(num_frames * feature_size_));
+    std::vector<bool> frame_mask(static_cast<size_t>(num_frames));
+
+    std::vector<float> frame_buf(fft_length_, 0.0f);
+    std::vector<float> mag;
+
+    for (int64_t fi = 0; fi < num_frames; ++fi) {
+      const int64_t offset = fi * hop_length_;
+      const float* frame_start = padded.data() + offset;
+
+      // --- pre-emphasis (HTK flavour) or simple truncation -----------------
+      std::vector<float> processed(static_cast<size_t>(frame_length_));
+      if (preemphasis_ > 0.0f) {
+        if (preemphasis_htk_flavor_) {
+          processed[0] = frame_start[0] * (1.0f - preemphasis_);
+          for (int64_t i = 1; i < frame_length_; ++i) {
+            processed[i] = frame_start[i] - preemphasis_ * frame_start[i - 1];
+          }
+        } else {
+          for (int64_t i = 0; i < frame_length_; ++i) {
+            processed[i] = frame_start[i + 1] - preemphasis_ * frame_start[i];
+          }
+        }
+      } else {
+        // No preemphasis — drop the last sample of the unfolded frame.
+        std::copy(frame_start, frame_start + frame_length_, processed.begin());
+      }
+
+      // --- window ----------------------------------------------------------
+      for (int64_t i = 0; i < frame_length_; ++i) {
+        processed[i] *= window_[i];
+      }
+
+      // --- zero-pad to fft_length and compute magnitude FFT ----------------
+      std::fill(frame_buf.begin(), frame_buf.end(), 0.0f);
+      std::copy(processed.begin(), processed.end(), frame_buf.begin());
+      RealFFTMagnitude(frame_buf.data(), fft_length_, mag);
+
+      // --- mel filterbank + log --------------------------------------------
+      float* mel_row = logmel_data.data() + fi * feature_size_;
+      for (int64_t m = 0; m < feature_size_; ++m) {
+        double sum = 0.0;
+        for (int k = 0; k < n_freq; ++k) {
+          sum += static_cast<double>(mag[k]) *
+                 mel_filters_[static_cast<size_t>(k) * feature_size_ + m];
+        }
+        mel_row[m] = std::log(static_cast<float>(sum) + mel_floor_);
+      }
+
+      // --- frame-level attention mask --------------------------------------
+      // A frame is valid when the last sample of its window is real audio.
+      const int64_t frame_end_idx = offset + frame_size_unfold - 1;
+      frame_mask[fi] = (frame_end_idx < padded_len) && sample_mask[frame_end_idx];
+    }
+
+    // --- zero out padding frames -------------------------------------------
+    for (int64_t fi = 0; fi < num_frames; ++fi) {
+      if (!frame_mask[fi]) {
+        float* mel_row = logmel_data.data() + fi * feature_size_;
+        std::fill(mel_row, mel_row + feature_size_, 0.0f);
+      }
+    }
+
+    // --- per-bin normalization (optional) -----------------------------------
+    if (!per_bin_mean_.empty()) {
+      for (int64_t fi = 0; fi < num_frames; ++fi) {
+        float* mel_row = logmel_data.data() + fi * feature_size_;
+        for (int64_t m = 0; m < feature_size_; ++m) {
+          mel_row[m] -= per_bin_mean_[m];
+        }
+      }
+    }
+    if (!per_bin_stddev_.empty()) {
+      for (int64_t fi = 0; fi < num_frames; ++fi) {
+        float* mel_row = logmel_data.data() + fi * feature_size_;
+        for (int64_t m = 0; m < feature_size_; ++m) {
+          mel_row[m] /= per_bin_stddev_[m];
+        }
+      }
+    }
+
+    // --- write outputs -----------------------------------------------------
+    float* out_mel = logmel_out.Allocate({num_frames, feature_size_});
+    std::copy(logmel_data.begin(), logmel_data.end(), out_mel);
+
+    bool* out_mask = mask_out.Allocate({num_frames});
+    for (int64_t i = 0; i < num_frames; ++i) {
+      out_mask[i] = frame_mask[i];
+    }
+
+    return {};
+  }
+
+  template <typename DictT>
+  OrtxStatus Init(const DictT& attrs) {
+    for (const auto& [key, value] : attrs) {
+      if (key == "feature_size") {
+        feature_size_ = std::get<int64_t>(value);
+      } else if (key == "sampling_rate") {
+        sampling_rate_ = std::get<int64_t>(value);
+      } else if (key == "frame_length_ms") {
+        frame_length_ms_ = std::get<double>(value);
+      } else if (key == "hop_length_ms") {
+        hop_length_ms_ = std::get<double>(value);
+      } else if (key == "min_frequency") {
+        min_frequency_ = std::get<double>(value);
+      } else if (key == "max_frequency") {
+        max_frequency_ = std::get<double>(value);
+      } else if (key == "preemphasis") {
+        preemphasis_ = static_cast<float>(std::get<double>(value));
+      } else if (key == "preemphasis_htk_flavor") {
+        preemphasis_htk_flavor_ = std::get<int64_t>(value) != 0;
+      } else if (key == "fft_overdrive") {
+        fft_overdrive_ = std::get<int64_t>(value) != 0;
+      } else if (key == "mel_floor") {
+        mel_floor_ = static_cast<float>(std::get<double>(value));
+      } else if (key == "per_bin_mean") {
+        auto& v = std::get<std::vector<double>>(value);
+        per_bin_mean_.assign(v.begin(), v.end());
+      } else if (key == "per_bin_stddev") {
+        auto& v = std::get<std::vector<double>>(value);
+        per_bin_stddev_.assign(v.begin(), v.end());
+      } else {
+        return {kOrtxErrorInvalidArgument,
+                "[Gemma4LogMel]: unknown attribute '" + key + "'"};
+      }
+    }
+
+    // Derive sample-domain lengths from millisecond config.
+    frame_length_ = static_cast<int64_t>(
+        std::round(sampling_rate_ * frame_length_ms_ / 1000.0));
+    hop_length_ = static_cast<int64_t>(
+        std::round(sampling_rate_ * hop_length_ms_ / 1000.0));
+
+    return {};
+  }
+
+ private:
+  // Configuration (matching Gemma4AudioFeatureExtractor defaults).
+  int64_t feature_size_ = 128;
+  int64_t sampling_rate_ = 16000;
+  double frame_length_ms_ = 20.0;
+  double hop_length_ms_ = 10.0;
+  double min_frequency_ = 0.0;
+  double max_frequency_ = 8000.0;
+  float preemphasis_ = 0.0f;
+  bool preemphasis_htk_flavor_ = true;
+  bool fft_overdrive_ = false;
+  float mel_floor_ = 0.001f;
+  std::vector<float> per_bin_mean_;
+  std::vector<float> per_bin_stddev_;
+
+  // Derived / cached state (computed on first Compute call).
+  int64_t frame_length_ = 320;   // samples
+  int64_t hop_length_ = 160;     // samples
+  int fft_length_ = 512;
+  std::vector<float> window_;
+  std::vector<float> mel_filters_;  // (n_freq x feature_size), row-major
+};
+
+}  // namespace ort_extensions

--- a/shared/api/gemma4_audio_features.hpp
+++ b/shared/api/gemma4_audio_features.hpp
@@ -147,19 +147,6 @@ class Gemma4LogMel {
     const int64_t num_samples = pcm_shape[1];
     const float* pcm = pcm_input.Data();
 
-    // --- build window & filterbank on first call ---------------------------
-    if (window_.empty()) {
-      window_ = PeriodicHannWindow(static_cast<int>(frame_length_));
-      int fft_len = 1;
-      while (fft_len < frame_length_) fft_len <<= 1;
-      if (fft_overdrive_) fft_len <<= 1;
-      fft_length_ = fft_len;
-
-      mel_filters_ = MelFilterBank(
-          fft_len / 2 + 1, static_cast<int>(feature_size_),
-          static_cast<int>(sampling_rate_), min_frequency_, max_frequency_);
-    }
-
     // --- semicausal padding ------------------------------------------------
     const int64_t pad_left = frame_length_ / 2;
     const int64_t padded_len = num_samples + pad_left;
@@ -188,13 +175,13 @@ class Gemma4LogMel {
 
     std::vector<float> frame_buf(fft_length_, 0.0f);
     std::vector<float> mag;
+    std::vector<float> processed(static_cast<size_t>(frame_length_));
 
     for (int64_t fi = 0; fi < num_frames; ++fi) {
       const int64_t offset = fi * hop_length_;
       const float* frame_start = padded.data() + offset;
 
       // --- pre-emphasis (HTK flavour) or simple truncation -----------------
-      std::vector<float> processed(static_cast<size_t>(frame_length_));
       if (preemphasis_ > 0.0f) {
         if (preemphasis_htk_flavor_) {
           processed[0] = frame_start[0] * (1.0f - preemphasis_);
@@ -319,6 +306,18 @@ class Gemma4LogMel {
     hop_length_ = static_cast<int64_t>(
         std::round(sampling_rate_ * hop_length_ms_ / 1000.0));
 
+    // Pre-compute window, FFT length, and mel filterbank so Compute() is
+    // allocation-free for these (avoids lazy-init races if reused concurrently).
+    window_ = PeriodicHannWindow(static_cast<int>(frame_length_));
+    int fft_len = 1;
+    while (fft_len < frame_length_) fft_len <<= 1;
+    if (fft_overdrive_) fft_len <<= 1;
+    fft_length_ = fft_len;
+
+    mel_filters_ = MelFilterBank(
+        fft_len / 2 + 1, static_cast<int>(feature_size_),
+        static_cast<int>(sampling_rate_), min_frequency_, max_frequency_);
+
     return {};
   }
 
@@ -337,7 +336,7 @@ class Gemma4LogMel {
   std::vector<float> per_bin_mean_;
   std::vector<float> per_bin_stddev_;
 
-  // Derived / cached state (computed on first Compute call).
+  // Derived / cached state (computed in Init()).
   int64_t frame_length_ = 320;   // samples
   int64_t hop_length_ = 160;     // samples
   int fft_length_ = 512;

--- a/shared/api/image_processor.cc
+++ b/shared/api/image_processor.cc
@@ -15,6 +15,7 @@
 #include "image_transforms_mllama.hpp"
 #include "image_transforms_phi_4.hpp"
 #include "image_transforms_qwen2_5.hpp"
+#include "image_transforms_gemma4.hpp"
 
 namespace ort_extensions {
 std::tuple<std::unique_ptr<ImageRawData[]>, size_t> LoadRawImages(
@@ -42,7 +43,8 @@ Operation::KernelRegistry ImageProcessor::kernel_registry_ = {
     {"Llama3ImageTransform", []() { return CreateKernelInstance(&Llama3ImageTransform::Compute); }},
     {"Phi4VisionDynamicPreprocess", []() { return CreateKernelInstance(&Phi4VisionDynamicPreprocess::Compute); }},
     {"Phi4VisionProcessor", []() { return CreateKernelInstance(&Phi4VisionProcessor::Compute); }},
-    {"PatchImage", []() { return CreateKernelInstance(&PatchImage::Compute); }}};  // NOLINT
+    {"PatchImage", []() { return CreateKernelInstance(&PatchImage::Compute); }},
+    {"Gemma4ImageTransform", []() { return CreateKernelInstance(&Gemma4ImageTransform::Compute); }}};  // NOLINT
 
 OrtxStatus ImageProcessor::Init(std::string_view processor_def) {
   std::string processor_def_str;

--- a/shared/api/image_transforms_gemma4.hpp
+++ b/shared/api/image_transforms_gemma4.hpp
@@ -125,7 +125,7 @@ class Gemma4ImageTransform {
     const int64_t patch_dim = patch_size_ * patch_size_ * C;   // 16*16*3 = 768
     const float rescale = 1.0f / 255.0f;
 
-    // Output 1: pixel_values  (max_patches, patch_dim), zero-padded
+    // Output 0: pixel_values  (max_patches, patch_dim), zero-padded
     float* pv = pixel_values_out.Allocate({max_patches, patch_dim});
     std::memset(pv, 0, static_cast<size_t>(max_patches * patch_dim) * sizeof(float));
 
@@ -152,7 +152,7 @@ class Gemma4ImageTransform {
     }
     ImagingDelete(rgb_dst);
 
-    // Output 2: position_ids  (max_patches, 2)
+    // Output 1: position_ids  (max_patches, 2)
     // Real patches get (x=col, y=row); padding gets (-1, -1).
     int64_t* pos = position_ids_out.Allocate({max_patches, 2});
     for (int64_t py = 0; py < ph; ++py) {
@@ -168,7 +168,7 @@ class Gemma4ImageTransform {
       pos[i * 2 + 1] = -1;
     }
 
-    // Output 3: num_soft_tokens  (1,) — the number of vision tokens after pooling
+    // Output 2: num_soft_tokens  (1,) — the number of vision tokens after pooling
     int64_t* nst = num_soft_tokens_out.Allocate({1});
     nst[0] = num_patches / (pooling_kernel_size_ * pooling_kernel_size_);
 

--- a/shared/api/image_transforms_gemma4.hpp
+++ b/shared/api/image_transforms_gemma4.hpp
@@ -43,22 +43,10 @@ class Gemma4ImageTransform {
 
     const int64_t max_side = (max_patches / (pooling_kernel_size * pooling_kernel_size)) * side_mult;
 
-    if (tgt_h == 0 && tgt_w == 0) {
-      // Both rounded to zero — fall back to the smallest possible square.
-      tgt_h = side_mult;
-      tgt_w = side_mult;
-    } else if (tgt_h == 0) {
-      tgt_h = side_mult;
-      tgt_w = std::min(
-          static_cast<int64_t>(std::floor(static_cast<double>(src_w) / src_h)) * side_mult,
-          max_side);
-      if (tgt_w == 0) tgt_w = side_mult;
-    } else if (tgt_w == 0) {
-      tgt_w = side_mult;
-      tgt_h = std::min(
-          static_cast<int64_t>(std::floor(static_cast<double>(src_h) / src_w)) * side_mult,
-          max_side);
-      if (tgt_h == 0) tgt_h = side_mult;
+    // Match HuggingFace behavior: reject extreme aspect ratios that round
+    // a dimension to zero.  See image_processing_gemma4.py L61.
+    if (tgt_h == 0 || tgt_w == 0) {
+      return {0, 0};  // caller checks and returns an error
     }
 
     return {tgt_h, tgt_w};
@@ -83,6 +71,13 @@ class Gemma4ImageTransform {
     const int64_t max_patches = max_soft_tokens_ * pooling_kernel_size_ * pooling_kernel_size_;
     auto [tgt_h, tgt_w] = GetAspectRatioPreservingSize(
         src_h, src_w, patch_size_, max_patches, pooling_kernel_size_);
+
+    if (tgt_h == 0 || tgt_w == 0) {
+      return {kOrtxErrorInvalidArgument,
+          "[Gemma4ImageTransform]: image has extreme aspect ratio ("
+          + std::to_string(src_h) + ", " + std::to_string(src_w)
+          + ") and cannot be resized to fit the patch constraints"};
+    }
 
     // Use Pillow-style bicubic resampling (same as existing Resize kernel).
     Imaging rgb_src = ImagingNew("RGB", static_cast<int>(src_w), static_cast<int>(src_h));
@@ -126,17 +121,18 @@ class Gemma4ImageTransform {
       for (int64_t px = 0; px < pw; ++px) {
         const int64_t patch_idx = py * pw + px;
         float* dst = pv + patch_idx * patch_dim;
-        // Copy patch pixels in raster order: for each (dy, dx) in patch, for
-        // each channel.  Layout: C contiguous blocks of (patch_size * patch_size).
-        for (int64_t ch = 0; ch < C; ++ch) {
-          for (int64_t dy = 0; dy < patch_size_; ++dy) {
-            const int64_t row = py * patch_size_ + dy;
-            for (int64_t dx = 0; dx < patch_size_; ++dx) {
-              const int64_t col = px * patch_size_ + dx;
-              uint8_t* pixel = reinterpret_cast<uint8_t*>(
-                  rgb_dst->image[row] + col * 4);
-              dst[ch * patch_size_ * patch_size_ + dy * patch_size_ + dx] =
-                  static_cast<float>(pixel[ch]) * rescale;
+        // Copy patch pixels in HWC raster order to match HuggingFace:
+        // permute(1, 3, 2, 4, 0) in convert_image_to_patches() yields
+        // (patch_height, patch_width, num_channels) within each patch.
+        for (int64_t dy = 0; dy < patch_size_; ++dy) {
+          const int64_t row = py * patch_size_ + dy;
+          for (int64_t dx = 0; dx < patch_size_; ++dx) {
+            const int64_t col = px * patch_size_ + dx;
+            uint8_t* pixel = reinterpret_cast<uint8_t*>(
+                rgb_dst->image[row] + col * 4);
+            const int64_t base = (dy * patch_size_ + dx) * C;
+            for (int64_t ch = 0; ch < C; ++ch) {
+              dst[base + ch] = static_cast<float>(pixel[ch]) * rescale;
             }
           }
         }

--- a/shared/api/image_transforms_gemma4.hpp
+++ b/shared/api/image_transforms_gemma4.hpp
@@ -43,10 +43,22 @@ class Gemma4ImageTransform {
 
     const int64_t max_side = (max_patches / (pooling_kernel_size * pooling_kernel_size)) * side_mult;
 
-    // Match HuggingFace behavior: reject extreme aspect ratios that round
-    // a dimension to zero.  See image_processing_gemma4.py L61.
-    if (tgt_h == 0 || tgt_w == 0) {
+    // Match HuggingFace behavior: reject images where both dimensions round
+    // to zero (extreme aspect ratio).  See image_processing_gemma4.py L61.
+    if (tgt_h == 0 && tgt_w == 0) {
       return {0, 0};  // caller checks and returns an error
+    } else if (tgt_h == 0) {
+      tgt_h = side_mult;
+      tgt_w = std::min(
+          static_cast<int64_t>(std::floor(static_cast<double>(src_w) / src_h)) * side_mult,
+          max_side);
+      if (tgt_w == 0) tgt_w = side_mult;
+    } else if (tgt_w == 0) {
+      tgt_w = side_mult;
+      tgt_h = std::min(
+          static_cast<int64_t>(std::floor(static_cast<double>(src_h) / src_w)) * side_mult,
+          max_side);
+      if (tgt_h == 0) tgt_h = side_mult;
     }
 
     return {tgt_h, tgt_w};

--- a/shared/api/image_transforms_gemma4.hpp
+++ b/shared/api/image_transforms_gemma4.hpp
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cmath>
+#include <vector>
+#include <algorithm>
+
+#include "ext_status.h"
+#include "op_def_struct.h"
+#include "image_resample.h"
+
+namespace ort_extensions {
+
+// Gemma 4 vision preprocessing: aspect-ratio-preserving resize, patchification,
+// and 2-D position-ID computation that matches the HuggingFace
+// Gemma4ImageProcessor exactly.
+//
+// Pipeline:  DecodeImage  ->  Gemma4ImageTransform
+//
+// Inputs:   uint8  (H, W, 3)   — decoded RGB image
+// Outputs:  float  (max_patches, patch_size*patch_size*3) — patchified pixel values in [0, 1]
+//           int64  (max_patches, 2)                        — 2-D position IDs  (x=col, y=row)
+//           int64  (1,)                                    — number of soft tokens for this image
+class Gemma4ImageTransform {
+ public:
+  Gemma4ImageTransform() = default;
+
+  // Compute the target (height, width) that preserves the source aspect ratio
+  // while fitting within the patch budget.  Both dimensions are rounded DOWN to
+  // the nearest multiple of `side_mult = pooling_kernel_size * patch_size`.
+  static std::pair<int64_t, int64_t> GetAspectRatioPreservingSize(
+      int64_t src_h, int64_t src_w,
+      int64_t patch_size, int64_t max_patches, int64_t pooling_kernel_size) {
+    const int64_t side_mult = pooling_kernel_size * patch_size;
+    const double target_px = static_cast<double>(max_patches) * patch_size * patch_size;
+    const double total_px = static_cast<double>(src_h) * src_w;
+    const double factor = std::sqrt(target_px / total_px);
+
+    int64_t tgt_h = static_cast<int64_t>(std::floor(factor * src_h / side_mult)) * side_mult;
+    int64_t tgt_w = static_cast<int64_t>(std::floor(factor * src_w / side_mult)) * side_mult;
+
+    const int64_t max_side = (max_patches / (pooling_kernel_size * pooling_kernel_size)) * side_mult;
+
+    if (tgt_h == 0 && tgt_w == 0) {
+      // Both rounded to zero — fall back to the smallest possible square.
+      tgt_h = side_mult;
+      tgt_w = side_mult;
+    } else if (tgt_h == 0) {
+      tgt_h = side_mult;
+      tgt_w = std::min(
+          static_cast<int64_t>(std::floor(static_cast<double>(src_w) / src_h)) * side_mult,
+          max_side);
+      if (tgt_w == 0) tgt_w = side_mult;
+    } else if (tgt_w == 0) {
+      tgt_w = side_mult;
+      tgt_h = std::min(
+          static_cast<int64_t>(std::floor(static_cast<double>(src_h) / src_w)) * side_mult,
+          max_side);
+      if (tgt_h == 0) tgt_h = side_mult;
+    }
+
+    return {tgt_h, tgt_w};
+  }
+
+  OrtxStatus Compute(const ortc::Tensor<uint8_t>& input,
+                     ortc::Tensor<float>& pixel_values_out,
+                     ortc::Tensor<int64_t>& position_ids_out,
+                     ortc::Tensor<int64_t>& num_soft_tokens_out) {
+    // --- validate input --------------------------------------------------
+    const auto& dims = input.Shape();
+    if (dims.size() != 3ULL || dims[2] != 3) {
+      return {kOrtxErrorInvalidArgument,
+              "[Gemma4ImageTransform]: expected (H, W, 3) uint8 input"};
+    }
+
+    const int64_t src_h = dims[0];
+    const int64_t src_w = dims[1];
+    constexpr int64_t C = 3;
+
+    // --- aspect-ratio-preserving resize ----------------------------------
+    const int64_t max_patches = max_soft_tokens_ * pooling_kernel_size_ * pooling_kernel_size_;
+    auto [tgt_h, tgt_w] = GetAspectRatioPreservingSize(
+        src_h, src_w, patch_size_, max_patches, pooling_kernel_size_);
+
+    // Use Pillow-style bicubic resampling (same as existing Resize kernel).
+    Imaging rgb_src = ImagingNew("RGB", static_cast<int>(src_w), static_cast<int>(src_h));
+    if (!rgb_src) {
+      return {kOrtxErrorInternal, "[Gemma4ImageTransform]: ImagingNew failed"};
+    }
+
+    const uint8_t* src_data = input.Data();
+    for (int64_t r = 0; r < src_h; ++r) {
+      for (int64_t c = 0; c < src_w; ++c) {
+        uint8_t* pixel = reinterpret_cast<uint8_t*>(rgb_src->image[r] + c * 4);
+        const auto idx = (r * src_w + c) * C;
+        pixel[0] = src_data[idx];
+        pixel[1] = src_data[idx + 1];
+        pixel[2] = src_data[idx + 2];
+        pixel[3] = 0;
+      }
+    }
+
+    float box[4] = {0.0f, 0.0f, static_cast<float>(src_w), static_cast<float>(src_h)};
+    Imaging rgb_dst = ImagingResample(rgb_src, static_cast<int>(tgt_w),
+                                      static_cast<int>(tgt_h),
+                                      IMAGING_TRANSFORM_BICUBIC, box);
+    ImagingDelete(rgb_src);
+    if (!rgb_dst) {
+      return {kOrtxErrorInternal, "[Gemma4ImageTransform]: ImagingResample failed"};
+    }
+
+    // --- patchify ---------------------------------------------------------
+    const int64_t ph = tgt_h / patch_size_;   // patches along height
+    const int64_t pw = tgt_w / patch_size_;   // patches along width
+    const int64_t num_patches = ph * pw;
+    const int64_t patch_dim = patch_size_ * patch_size_ * C;   // 16*16*3 = 768
+    const float rescale = 1.0f / 255.0f;
+
+    // Output 1: pixel_values  (max_patches, patch_dim), zero-padded
+    float* pv = pixel_values_out.Allocate({max_patches, patch_dim});
+    std::memset(pv, 0, static_cast<size_t>(max_patches * patch_dim) * sizeof(float));
+
+    for (int64_t py = 0; py < ph; ++py) {
+      for (int64_t px = 0; px < pw; ++px) {
+        const int64_t patch_idx = py * pw + px;
+        float* dst = pv + patch_idx * patch_dim;
+        // Copy patch pixels in raster order: for each (dy, dx) in patch, for
+        // each channel.  Layout: C contiguous blocks of (patch_size * patch_size).
+        for (int64_t ch = 0; ch < C; ++ch) {
+          for (int64_t dy = 0; dy < patch_size_; ++dy) {
+            const int64_t row = py * patch_size_ + dy;
+            for (int64_t dx = 0; dx < patch_size_; ++dx) {
+              const int64_t col = px * patch_size_ + dx;
+              uint8_t* pixel = reinterpret_cast<uint8_t*>(
+                  rgb_dst->image[row] + col * 4);
+              dst[ch * patch_size_ * patch_size_ + dy * patch_size_ + dx] =
+                  static_cast<float>(pixel[ch]) * rescale;
+            }
+          }
+        }
+      }
+    }
+    ImagingDelete(rgb_dst);
+
+    // Output 2: position_ids  (max_patches, 2)
+    // Real patches get (x=col, y=row); padding gets (-1, -1).
+    int64_t* pos = position_ids_out.Allocate({max_patches, 2});
+    for (int64_t py = 0; py < ph; ++py) {
+      for (int64_t px = 0; px < pw; ++px) {
+        const int64_t idx = (py * pw + px) * 2;
+        pos[idx]     = px;   // x = column
+        pos[idx + 1] = py;   // y = row
+      }
+    }
+    // Padding positions
+    for (int64_t i = num_patches; i < max_patches; ++i) {
+      pos[i * 2]     = -1;
+      pos[i * 2 + 1] = -1;
+    }
+
+    // Output 3: num_soft_tokens  (1,) — the number of vision tokens after pooling
+    int64_t* nst = num_soft_tokens_out.Allocate({1});
+    nst[0] = num_patches / (pooling_kernel_size_ * pooling_kernel_size_);
+
+    return {};
+  }
+
+  template <typename DictT>
+  OrtxStatus Init(const DictT& attrs) {
+    for (const auto& [key, value] : attrs) {
+      if (key == "patch_size") {
+        patch_size_ = std::get<int64_t>(value);
+      } else if (key == "max_soft_tokens") {
+        max_soft_tokens_ = std::get<int64_t>(value);
+      } else if (key == "pooling_kernel_size") {
+        pooling_kernel_size_ = std::get<int64_t>(value);
+      } else {
+        return {kOrtxErrorInvalidArgument,
+                "[Gemma4ImageTransform]: unknown attribute '" + key + "'"};
+      }
+    }
+    return {};
+  }
+
+ private:
+  int64_t patch_size_ = 16;
+  int64_t max_soft_tokens_ = 280;
+  int64_t pooling_kernel_size_ = 3;
+};
+
+}  // namespace ort_extensions

--- a/shared/api/speech_extractor.cc
+++ b/shared/api/speech_extractor.cc
@@ -5,6 +5,7 @@
 
 #include "audio/audio_decoder.h"
 #include "speech_features.hpp"
+#include "gemma4_audio_features.hpp"
 
 using namespace ort_extensions;
 
@@ -13,7 +14,8 @@ Operation::KernelRegistry SpeechFeatureExtractor::kernel_registry_ = {
     {"AudioDecoderEx", []() { return CreateKernelInstance(&AudioDecoder::ComputeNoOpt2); }},
     {"STFTNorm", []() { return CreateKernelInstance(&SpeechFeatures::STFTNorm); }},
     {"LogMelSpectrum", []() { return CreateKernelInstance(&LogMel::Compute); }},
-    {"Phi4AudioEmbed", []() { return CreateKernelInstance(&Phi4AudioEmbed::Compute); }}};
+    {"Phi4AudioEmbed", []() { return CreateKernelInstance(&Phi4AudioEmbed::Compute); }},
+    {"Gemma4LogMel", []() { return CreateKernelInstance(&Gemma4LogMel::Compute); }}};
 
 SpeechFeatureExtractor::SpeechFeatureExtractor() : OrtxObjectImpl(extObjectKind_t::kOrtxKindFeatureExtractor) {}
 

--- a/test/data/models/gemma-4/audio_feature_extraction.json
+++ b/test/data/models/gemma-4/audio_feature_extraction.json
@@ -1,0 +1,30 @@
+{
+  "feature_extraction": {
+    "sequence": [
+      {
+        "operation": {
+          "name": "audio_decoder",
+          "type": "AudioDecoder"
+        }
+      },
+      {
+        "operation": {
+          "name": "gemma4_log_mel",
+          "type": "Gemma4LogMel",
+          "attrs": {
+            "feature_size": 128,
+            "sampling_rate": 16000,
+            "frame_length_ms": 20.0,
+            "hop_length_ms": 10.0,
+            "min_frequency": 0.0,
+            "max_frequency": 8000.0,
+            "preemphasis": 0.0,
+            "preemphasis_htk_flavor": 1,
+            "fft_overdrive": 0,
+            "mel_floor": 0.001
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/data/models/gemma-4/chat_template.jinja
+++ b/test/data/models/gemma-4/chat_template.jinja
@@ -1,0 +1,344 @@
+{%- macro format_parameters(properties, required) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([])) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{%- set ns = namespace(prev_message_type=None) -%}
+{%- set loop_messages = messages -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if (enable_thinking is defined and enable_thinking) or tools or messages[0]['role'] in ['system', 'developer'] -%}
+    {{- '<|turn>system\n' -}}
+
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking is defined and enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+
+    {%- if messages[0]['role'] in ['system', 'developer'] -%}
+        {{- messages[0]['content'] | trim -}}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation: suppress duplicate <|turn>model when previous non-tool message was also assistant -#}
+    {%- set prev_nt = namespace(role=None, found=false) -%}
+    {%- if loop.index0 > 0 -%}
+        {%- for j in range(loop.index0 - 1, -1, -1) -%}
+            {%- if not prev_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set prev_nt.role = loop_messages[j]['role'] -%}
+                    {%- set prev_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- set continue_same_model_turn = (role == 'model' and prev_nt.role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- if thinking_text and loop.index0 > ns_turn.last_user_idx and message.get('tool_calls') -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message['tool_calls'] -%}
+                {%- for tool_call in message['tool_calls'] -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is string -%}
+                        {{- function['arguments'] -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message['tool_responses'] -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown'), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') | default('unknown')) -%}
+                        {%- for tc in message['tool_calls'] -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- if message['content'] is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message['content'] is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item['type'] == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item['type'] == 'image' -%}
+                        {{- '<|image|>' -}}
+                        {%- set ns.prev_message_type = 'image' -%}
+                    {%- elif item['type'] == 'audio' -%}
+                        {{- '<|audio|>' -}}
+                        {%- set ns.prev_message_type = 'audio' -%}
+                    {%- elif item['type'] == 'video' -%}
+                        {{- '<|video|>' -}}
+                        {%- set ns.prev_message_type = 'video' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif not (ns_tr_out.flag and not message.get('content')) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+    {%- endif -%}
+{%- endif -%}

--- a/test/data/models/gemma-4/image_processor.json
+++ b/test/data/models/gemma-4/image_processor.json
@@ -1,0 +1,27 @@
+{
+  "processor": {
+    "name": "gemma_4_image_processing",
+    "transforms": [
+      {
+        "operation": {
+          "name": "decode_image",
+          "type": "DecodeImage",
+          "attrs": {
+            "color_space": "RGB"
+          }
+        }
+      },
+      {
+        "operation": {
+          "name": "gemma4_image_transform",
+          "type": "Gemma4ImageTransform",
+          "attrs": {
+            "patch_size": 16,
+            "max_soft_tokens": 280,
+            "pooling_kernel_size": 3
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/data/models/gemma-4/processor_config.json
+++ b/test/data/models/gemma-4/processor_config.json
@@ -1,0 +1,75 @@
+{
+  "audio_ms_per_token": 40,
+  "audio_seq_length": 750,
+  "feature_extractor": {
+    "dither": 0.0,
+    "feature_extractor_type": "Gemma4AudioFeatureExtractor",
+    "feature_size": 128,
+    "fft_length": 512,
+    "fft_overdrive": false,
+    "frame_length": 320,
+    "hop_length": 160,
+    "input_scale_factor": 1.0,
+    "max_frequency": 8000.0,
+    "mel_floor": 0.001,
+    "min_frequency": 0.0,
+    "padding_side": "right",
+    "padding_value": 0.0,
+    "per_bin_mean": null,
+    "per_bin_stddev": null,
+    "preemphasis": 0.0,
+    "preemphasis_htk_flavor": true,
+    "return_attention_mask": true,
+    "sampling_rate": 16000
+  },
+  "image_processor": {
+    "do_convert_rgb": true,
+    "do_normalize": false,
+    "do_rescale": true,
+    "do_resize": true,
+    "image_mean": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "image_processor_type": "Gemma4ImageProcessor",
+    "image_seq_length": 280,
+    "image_std": [
+      1.0,
+      1.0,
+      1.0
+    ],
+    "max_soft_tokens": 280,
+    "patch_size": 16,
+    "pooling_kernel_size": 3,
+    "resample": 3,
+    "rescale_factor": 0.00392156862745098
+  },
+  "image_seq_length": 280,
+  "processor_class": "Gemma4Processor",
+  "video_processor": {
+    "do_convert_rgb": true,
+    "do_normalize": true,
+    "do_rescale": true,
+    "do_resize": true,
+    "do_sample_frames": true,
+    "image_mean": [
+      0.0,
+      0.0,
+      0.0
+    ],
+    "image_std": [
+      1.0,
+      1.0,
+      1.0
+    ],
+    "max_soft_tokens": 70,
+    "num_frames": 32,
+    "patch_size": 16,
+    "pooling_kernel_size": 3,
+    "resample": 3,
+    "rescale_factor": 0.00392156862745098,
+    "return_metadata": false,
+    "video_processor_type": "Gemma4VideoProcessor"
+  }
+}

--- a/test/data/models/gemma-4/tokenizer_config.json
+++ b/test/data/models/gemma-4/tokenizer_config.json
@@ -1,0 +1,74 @@
+{
+  "audio_token": "<|audio|>",
+  "backend": "tokenizers",
+  "boa_token": "<|audio>",
+  "boi_token": "<|image>",
+  "bos_token": "<bos>",
+  "eoa_token": "<audio|>",
+  "eoc_token": "<channel|>",
+  "eoi_token": "<image|>",
+  "eos_token": "<eos>",
+  "eot_token": "<turn|>",
+  "escape_token": "<|\"|>",
+  "etc_token": "<tool_call|>",
+  "etd_token": "<tool|>",
+  "etr_token": "<tool_response|>",
+  "extra_special_tokens": [
+    "<|video|>"
+  ],
+  "image_token": "<|image|>",
+  "mask_token": "<mask>",
+  "model_max_length": 1000000000000000019884624838656,
+  "pad_token": "<pad>",
+  "padding_side": "left",
+  "processor_class": "Gemma4Processor",
+  "response_schema": {
+    "type": "object",
+    "properties": {
+      "role": {
+        "const": "assistant"
+      },
+      "thinking": {
+        "type": "string"
+      },
+      "content": {
+        "type": "string"
+      },
+      "tool_calls": {
+        "x-regex-iterator": "<\\|tool_call>(.*?)<tool_call\\|>",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "function"
+            },
+            "function": {
+              "type": "object",
+              "x-regex": "call\\:(?P<name>\\w+)(?P<arguments>\\{.*\\})",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "arguments": {
+                  "type": "object",
+                  "x-parser": "gemma4-tool-call",
+                  "additionalProperties": {}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "x-regex": "(\\<\\|channel\\>thought\\n(?P<thinking>.*?)\\<channel\\|\\>)?(?P<tool_calls>\\<\\|tool_call\\>.*\\<tool_call\\|\\>)?(?P<content>(?:(?!\\<turn\\|\\>)(?!\\<\\|tool_response\\>).)+)?(?:\\<turn\\|\\>|\\<\\|tool_response\\>)?"
+  },
+  "soc_token": "<|channel>",
+  "sot_token": "<|turn>",
+  "stc_token": "<|tool_call>",
+  "std_token": "<|tool>",
+  "str_token": "<|tool_response>",
+  "think_token": "<|think|>",
+  "tokenizer_class": "GemmaTokenizer",
+  "unk_token": "<unk>"
+}

--- a/test/pp_api_test/test_feature_extraction.cc
+++ b/test/pp_api_test/test_feature_extraction.cc
@@ -376,6 +376,19 @@ TEST(ExtractorTest, TestGemma4AudioFeatureExtraction) {
     ASSERT_TRUE(std::isfinite(data[i])) << "log-mel value at index " << i << " is not finite";
   }
 
+  // Verify log-mel values are in a reasonable range.
+  // With mel_floor=0.001, log(0.001) ~ -6.9078. Values should be >= ~-7
+  // and typically < ~5 for speech audio.
+  const float* frame0 = data;
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_GE(frame0[i], -7.5f) << "Frame 0 bin " << i << " too low";
+    EXPECT_LE(frame0[i], 5.0f) << "Frame 0 bin " << i << " too high";
+  }
+  // The first mel bin of silent/padding frames should be close to log(mel_floor)
+  // = log(0.001) ~ -6.9078.
+  EXPECT_NEAR(frame0[0], -6.9078f, 0.05f)
+      << "Frame 0 bin 0 should be near log(0.001) for semicausal pad region";
+
   // Output 1: attention mask — bool (batch, num_frames)
   err = OrtxTensorResultGetAt(result.get(), 1, tensor.ToBeAssigned());
   ASSERT_EQ(err, kOrtxOK);

--- a/test/pp_api_test/test_feature_extraction.cc
+++ b/test/pp_api_test/test_feature_extraction.cc
@@ -341,3 +341,96 @@ TEST(ExtractorTest, TestSplitSignalSegments) {
   ASSERT_EQ(merged_shape[1], 2);
   ASSERT_EQ(merged_shape[0], 4);
 }
+
+TEST(ExtractorTest, TestGemma4AudioFeatureExtraction) {
+  // Use existing test audio files to verify the Gemma 4 USM-style log-mel pipeline:
+  // AudioDecoder -> Gemma4LogMel
+  const char* audio_path[] = {"data/jfk.flac"};
+  OrtxObjectPtr<OrtxRawAudios> raw_audios;
+  extError_t err = OrtxLoadAudios(raw_audios.ToBeAssigned(), audio_path, 1);
+  ASSERT_EQ(err, kOrtxOK);
+
+  OrtxObjectPtr<OrtxFeatureExtractor> feature_extractor(OrtxCreateSpeechFeatureExtractor,
+                                                        "data/models/gemma-4/audio_feature_extraction.json");
+  OrtxObjectPtr<OrtxTensorResult> result;
+  err = OrtxFeatureExtraction(feature_extractor.get(), raw_audios.get(), result.ToBeAssigned());
+  ASSERT_EQ(err, kOrtxOK);
+
+  // Output 0: log-mel spectrogram — float (batch, num_frames, 128)
+  OrtxObjectPtr<OrtxTensor> tensor;
+  err = OrtxTensorResultGetAt(result.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(err, kOrtxOK);
+
+  const float* data{};
+  const int64_t* shape{};
+  size_t num_dims;
+  err = OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&data), &shape, &num_dims);
+  ASSERT_EQ(err, kOrtxOK);
+  ASSERT_EQ(num_dims, 3ULL);           // (batch, num_frames, feature_size)
+  ASSERT_EQ(shape[0], 1);              // single audio
+  ASSERT_EQ(shape[2], 128);            // 128 mel bins
+  EXPECT_GT(shape[1], 0);              // should have some frames
+
+  // Verify values are finite (not NaN/Inf).
+  for (int64_t i = 0; i < std::min<int64_t>(shape[1] * 128, 5000); ++i) {
+    ASSERT_TRUE(std::isfinite(data[i])) << "log-mel value at index " << i << " is not finite";
+  }
+
+  // Output 1: attention mask — bool (batch, num_frames)
+  err = OrtxTensorResultGetAt(result.get(), 1, tensor.ToBeAssigned());
+  ASSERT_EQ(err, kOrtxOK);
+
+  const bool* mask_data{};
+  const int64_t* mask_shape{};
+  size_t mask_dims;
+  err = OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&mask_data), &mask_shape, &mask_dims);
+  ASSERT_EQ(err, kOrtxOK);
+  ASSERT_EQ(mask_dims, 2ULL);          // (batch, num_frames)
+  ASSERT_EQ(mask_shape[0], 1);
+  ASSERT_EQ(mask_shape[1], shape[1]);   // same frame count
+
+  // For JFK audio (not truncated), all frames except those from the semicausal pad
+  // should be valid. At least some frames should be true.
+  int true_count = std::count(mask_data, mask_data + mask_shape[1], true);
+  EXPECT_GT(true_count, 0) << "Expected at least some valid frames";
+}
+
+TEST(ExtractorTest, TestGemma4AudioFeatureExtractionMultiFile) {
+  // Verify batched processing with multiple audio files.
+  const char* audio_path[] = {"data/jfk.flac", "data/1272-141231-0002.wav"};
+  OrtxObjectPtr<OrtxRawAudios> raw_audios;
+  extError_t err = OrtxLoadAudios(raw_audios.ToBeAssigned(), audio_path, 2);
+  ASSERT_EQ(err, kOrtxOK);
+
+  OrtxObjectPtr<OrtxFeatureExtractor> feature_extractor(OrtxCreateSpeechFeatureExtractor,
+                                                        "data/models/gemma-4/audio_feature_extraction.json");
+  OrtxObjectPtr<OrtxTensorResult> result;
+  err = OrtxFeatureExtraction(feature_extractor.get(), raw_audios.get(), result.ToBeAssigned());
+  ASSERT_EQ(err, kOrtxOK);
+
+  // log-mel: batch dim should be 2
+  OrtxObjectPtr<OrtxTensor> tensor;
+  err = OrtxTensorResultGetAt(result.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(err, kOrtxOK);
+
+  const float* data{};
+  const int64_t* shape{};
+  size_t num_dims;
+  err = OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&data), &shape, &num_dims);
+  ASSERT_EQ(err, kOrtxOK);
+  ASSERT_EQ(num_dims, 3ULL);
+  ASSERT_EQ(shape[0], 2);             // batch of 2
+  ASSERT_EQ(shape[2], 128);
+
+  // mask: batch dim should be 2
+  err = OrtxTensorResultGetAt(result.get(), 1, tensor.ToBeAssigned());
+  ASSERT_EQ(err, kOrtxOK);
+
+  const bool* mask_data{};
+  const int64_t* mask_shape{};
+  size_t mask_dims;
+  err = OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&mask_data), &mask_shape, &mask_dims);
+  ASSERT_EQ(err, kOrtxOK);
+  ASSERT_EQ(mask_dims, 2ULL);
+  ASSERT_EQ(mask_shape[0], 2);
+}

--- a/test/pp_api_test/test_processor.cc
+++ b/test/pp_api_test/test_processor.cc
@@ -342,33 +342,32 @@ TEST(ProcessorTest, TestGemma4ImageProcessing) {
   EXPECT_EQ(pos_data[0], 0);
   EXPECT_EQ(pos_data[1], 0);
 
-  // Find the first padding position (should have -1, -1).
-  bool found_padding = false;
-  for (int64_t i = 0; i < kMaxPatches; ++i) {
-    if (pos_data[i * 2] == -1 && pos_data[i * 2 + 1] == -1) {
-      found_padding = true;
-      // All subsequent positions should also be padding.
-      for (int64_t j = i + 1; j < kMaxPatches; ++j) {
-        EXPECT_EQ(pos_data[j * 2], -1);
-        EXPECT_EQ(pos_data[j * 2 + 1], -1);
-      }
-      break;
-    }
+  // Derive the expected number of real patches from num_soft_tokens.
+  // Each soft token maps to pooling_kernel_size^2 = 9 patches.
+  // Read num_soft_tokens early (output 2) to compute expected real patch count.
+  OrtxObjectPtr<OrtxTensor> nst_tensor;
+  err = OrtxTensorResultGetAt(result.get(), 2, nst_tensor.ToBeAssigned());
+  ASSERT_EQ(err, kOrtxOK);
+  const int64_t* nst_peek{};
+  const int64_t* nst_shape_peek{};
+  size_t nst_dims_peek{};
+  OrtxGetTensorData(nst_tensor.get(), reinterpret_cast<const void**>(&nst_peek), &nst_shape_peek, &nst_dims_peek);
+  int64_t expected_real_patches = nst_peek[0] * 9;  // pooling_kernel_size^2
+  ASSERT_GT(expected_real_patches, 0);
+  ASSERT_LE(expected_real_patches, kMaxPatches);
+
+  // Verify that positions beyond the real patches are (-1, -1) padding.
+  for (int64_t i = expected_real_patches; i < kMaxPatches; ++i) {
+    EXPECT_EQ(pos_data[i * 2], -1) << "Padding position " << i << " x should be -1";
+    EXPECT_EQ(pos_data[i * 2 + 1], -1) << "Padding position " << i << " y should be -1";
   }
-  EXPECT_TRUE(found_padding) << "Image should not fill all patches exactly (expect some padding)";
 
-  // Output 2: num_soft_tokens — int64 (batch, 1)
-  err = OrtxTensorResultGetAt(result.get(), 2, tensor.ToBeAssigned());
-  ASSERT_EQ(err, kOrtxOK);
-
-  const int64_t* nst_data{};
-  err = OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&nst_data), &shape, &num_dims);
-  ASSERT_EQ(err, kOrtxOK);
-  ASSERT_EQ(num_dims, 2ULL);
-  ASSERT_EQ(shape[0], 1);
-  // num_soft_tokens should be > 0 and <= max_soft_tokens
-  EXPECT_GT(nst_data[0], 0);
-  EXPECT_LE(nst_data[0], 280);
+  // Output 2: num_soft_tokens — already validated above via nst_peek.
+  // Just verify the shape here.
+  ASSERT_EQ(nst_dims_peek, 2ULL);
+  ASSERT_EQ(nst_shape_peek[0], 1);
+  EXPECT_GT(nst_peek[0], 0);
+  EXPECT_LE(nst_peek[0], 280);
 }
 
 TEST(ProcessorTest, TestGemma4ImageProcessingMultiImage) {

--- a/test/pp_api_test/test_processor.cc
+++ b/test/pp_api_test/test_processor.cc
@@ -327,6 +327,30 @@ TEST(ProcessorTest, TestGemma4ImageProcessing) {
   }
   EXPECT_TRUE(all_in_range) << "Pixel values should be in [0, 1]";
 
+  // Verify pixel values match HuggingFace Gemma4ImageProcessor output.
+  // Reference: HF transformers Gemma4ImageProcessor on australia.jpg (1300x876).
+  // Patch 0, first 10 values (HWC order within each patch):
+  const float kPatch0Expected[] = {
+      0.18823531f, 0.05490196f, 0.01960784f,
+      0.18823531f, 0.05490196f, 0.01960784f,
+      0.18823531f, 0.05490196f, 0.01960784f,
+      0.18823531f};
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_NEAR(pv_data[i], kPatch0Expected[i], 1e-3f)
+        << "Patch 0, value " << i << " mismatch vs HF reference";
+  }
+  // Patch 1, first 10 values:
+  const float kPatch1Expected[] = {
+      0.18039216f, 0.04705883f, 0.01176471f,
+      0.18039216f, 0.04705883f, 0.01176471f,
+      0.17647059f, 0.04313726f, 0.00784314f,
+      0.17647059f};
+  const float* patch1 = pv_data + kPatchDim;  // start of patch 1
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_NEAR(patch1[i], kPatch1Expected[i], 1e-3f)
+        << "Patch 1, value " << i << " mismatch vs HF reference";
+  }
+
   // Output 1: position_ids — int64 (batch, max_patches, 2)
   err = OrtxTensorResultGetAt(result.get(), 1, tensor.ToBeAssigned());
   ASSERT_EQ(err, kOrtxOK);
@@ -338,9 +362,12 @@ TEST(ProcessorTest, TestGemma4ImageProcessing) {
   ASSERT_EQ(shape[1], kMaxPatches);
   ASSERT_EQ(shape[2], 2);
 
-  // First position should be (0, 0), i.e. x=0, y=0
-  EXPECT_EQ(pos_data[0], 0);
-  EXPECT_EQ(pos_data[1], 0);
+  // Verify position IDs match HF reference.
+  // Patch 0: (x=0, y=0), Patch 1: (x=1, y=0)  — HF uses meshgrid(arange(pw), arange(ph), indexing="xy")
+  EXPECT_EQ(pos_data[0], 0);  // patch 0 x
+  EXPECT_EQ(pos_data[1], 0);  // patch 0 y
+  EXPECT_EQ(pos_data[2], 1);  // patch 1 x
+  EXPECT_EQ(pos_data[3], 0);  // patch 1 y
 
   // Derive the expected number of real patches from num_soft_tokens.
   // Each soft token maps to pooling_kernel_size^2 = 9 patches.
@@ -351,7 +378,8 @@ TEST(ProcessorTest, TestGemma4ImageProcessing) {
   const int64_t* nst_peek{};
   const int64_t* nst_shape_peek{};
   size_t nst_dims_peek{};
-  OrtxGetTensorData(nst_tensor.get(), reinterpret_cast<const void**>(&nst_peek), &nst_shape_peek, &nst_dims_peek);
+  err = OrtxGetTensorData(nst_tensor.get(), reinterpret_cast<const void**>(&nst_peek), &nst_shape_peek, &nst_dims_peek);
+  ASSERT_EQ(err, kOrtxOK);
   int64_t expected_real_patches = nst_peek[0] * 9;  // pooling_kernel_size^2
   ASSERT_GT(expected_real_patches, 0);
   ASSERT_LE(expected_real_patches, kMaxPatches);
@@ -362,12 +390,14 @@ TEST(ProcessorTest, TestGemma4ImageProcessing) {
     EXPECT_EQ(pos_data[i * 2 + 1], -1) << "Padding position " << i << " y should be -1";
   }
 
-  // Output 2: num_soft_tokens — already validated above via nst_peek.
-  // Just verify the shape here.
+  // Verify last real patch position matches HF: (59, 38)
+  EXPECT_EQ(pos_data[(expected_real_patches - 1) * 2], 59);
+  EXPECT_EQ(pos_data[(expected_real_patches - 1) * 2 + 1], 38);
+
+  // Output 2: num_soft_tokens — verify exact value from HF reference (260).
   ASSERT_EQ(nst_dims_peek, 2ULL);
   ASSERT_EQ(nst_shape_peek[0], 1);
-  EXPECT_GT(nst_peek[0], 0);
-  EXPECT_LE(nst_peek[0], 280);
+  EXPECT_EQ(nst_peek[0], 260) << "num_soft_tokens should be 260 for australia.jpg (HF reference)";
 }
 
 TEST(ProcessorTest, TestGemma4ImageProcessingMultiImage) {

--- a/test/pp_api_test/test_processor.cc
+++ b/test/pp_api_test/test_processor.cc
@@ -278,6 +278,128 @@ TEST(ProcessorTest, TestQwen3VLImageProcessing) {
   ASSERT_EQ(patch_dim, 1536);
 }
 
+TEST(ProcessorTest, TestGemma4ImageProcessing) {
+  // Use a single test image to verify the Gemma 4 vision preprocessing pipeline:
+  // DecodeImage -> Gemma4ImageTransform (aspect-ratio resize + patchify + position IDs)
+  const char* image_path[] = {"data/processor/australia.jpg"};
+
+  OrtxObjectPtr<OrtxRawImages> raw_images{};
+  extError_t err = OrtxLoadImages(raw_images.ToBeAssigned(), image_path, 1, nullptr);
+  ASSERT_EQ(err, kOrtxOK);
+
+  OrtxObjectPtr<OrtxProcessor> processor;
+  err = OrtxCreateProcessor(processor.ToBeAssigned(), "data/models/gemma-4/image_processor.json");
+  if (err != kOrtxOK) {
+    std::cout << "Error: " << OrtxGetLastErrorMessage() << std::endl;
+  }
+  ASSERT_EQ(err, kOrtxOK);
+
+  OrtxObjectPtr<OrtxTensorResult> result;
+  err = OrtxImagePreProcess(processor.get(), raw_images.get(), result.ToBeAssigned());
+  ASSERT_EQ(err, kOrtxOK);
+
+  // Output 0: pixel_values — float (batch, max_patches, patch_dim)
+  OrtxObjectPtr<OrtxTensor> tensor;
+  err = OrtxTensorResultGetAt(result.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(err, kOrtxOK);
+
+  const float* pv_data{};
+  const int64_t* shape{};
+  size_t num_dims;
+  err = OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&pv_data), &shape, &num_dims);
+  ASSERT_EQ(err, kOrtxOK);
+  ASSERT_EQ(num_dims, 3ULL);           // (batch, max_patches, patch_dim)
+  ASSERT_EQ(shape[0], 1);              // single image
+  // Default max_patches = 280 * 9 = 2520
+  constexpr int64_t kMaxPatches = 280 * 9;
+  constexpr int64_t kPatchDim = 16 * 16 * 3;  // 768
+  ASSERT_EQ(shape[1], kMaxPatches);
+  ASSERT_EQ(shape[2], kPatchDim);
+
+  // Pixel values should be rescaled to [0, 1].
+  bool all_in_range = true;
+  for (int64_t i = 0; i < std::min<int64_t>(shape[1] * shape[2], 10000); ++i) {
+    if (pv_data[i] < 0.0f || pv_data[i] > 1.0f) {
+      all_in_range = false;
+      break;
+    }
+  }
+  EXPECT_TRUE(all_in_range) << "Pixel values should be in [0, 1]";
+
+  // Output 1: position_ids — int64 (batch, max_patches, 2)
+  err = OrtxTensorResultGetAt(result.get(), 1, tensor.ToBeAssigned());
+  ASSERT_EQ(err, kOrtxOK);
+
+  const int64_t* pos_data{};
+  err = OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&pos_data), &shape, &num_dims);
+  ASSERT_EQ(err, kOrtxOK);
+  ASSERT_EQ(num_dims, 3ULL);           // (batch, max_patches, 2)
+  ASSERT_EQ(shape[1], kMaxPatches);
+  ASSERT_EQ(shape[2], 2);
+
+  // First position should be (0, 0), i.e. x=0, y=0
+  EXPECT_EQ(pos_data[0], 0);
+  EXPECT_EQ(pos_data[1], 0);
+
+  // Find the first padding position (should have -1, -1).
+  bool found_padding = false;
+  for (int64_t i = 0; i < kMaxPatches; ++i) {
+    if (pos_data[i * 2] == -1 && pos_data[i * 2 + 1] == -1) {
+      found_padding = true;
+      // All subsequent positions should also be padding.
+      for (int64_t j = i + 1; j < kMaxPatches; ++j) {
+        EXPECT_EQ(pos_data[j * 2], -1);
+        EXPECT_EQ(pos_data[j * 2 + 1], -1);
+      }
+      break;
+    }
+  }
+  EXPECT_TRUE(found_padding) << "Image should not fill all patches exactly (expect some padding)";
+
+  // Output 2: num_soft_tokens — int64 (batch, 1)
+  err = OrtxTensorResultGetAt(result.get(), 2, tensor.ToBeAssigned());
+  ASSERT_EQ(err, kOrtxOK);
+
+  const int64_t* nst_data{};
+  err = OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&nst_data), &shape, &num_dims);
+  ASSERT_EQ(err, kOrtxOK);
+  ASSERT_EQ(num_dims, 2ULL);
+  ASSERT_EQ(shape[0], 1);
+  // num_soft_tokens should be > 0 and <= max_soft_tokens
+  EXPECT_GT(nst_data[0], 0);
+  EXPECT_LE(nst_data[0], 280);
+}
+
+TEST(ProcessorTest, TestGemma4ImageProcessingMultiImage) {
+  // Verify batched processing works with multiple images of different sizes.
+  const char* image_paths[] = {"data/processor/standard_s.jpg", "data/processor/australia.jpg"};
+
+  OrtxObjectPtr<OrtxRawImages> raw_images{};
+  extError_t err = OrtxLoadImages(raw_images.ToBeAssigned(), image_paths, 2, nullptr);
+  ASSERT_EQ(err, kOrtxOK);
+
+  OrtxObjectPtr<OrtxProcessor> processor;
+  err = OrtxCreateProcessor(processor.ToBeAssigned(), "data/models/gemma-4/image_processor.json");
+  ASSERT_EQ(err, kOrtxOK);
+
+  OrtxObjectPtr<OrtxTensorResult> result;
+  err = OrtxImagePreProcess(processor.get(), raw_images.get(), result.ToBeAssigned());
+  ASSERT_EQ(err, kOrtxOK);
+
+  // pixel_values batch dim should be 2
+  OrtxObjectPtr<OrtxTensor> tensor;
+  err = OrtxTensorResultGetAt(result.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(err, kOrtxOK);
+
+  const float* data{};
+  const int64_t* shape{};
+  size_t num_dims;
+  err = OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&data), &shape, &num_dims);
+  ASSERT_EQ(err, kOrtxOK);
+  ASSERT_EQ(num_dims, 3ULL);
+  ASSERT_EQ(shape[0], 2);  // batch of 2 images
+}
+
 // Security regression test: CMYK JPEG must be rejected at decode time (CWE-122).
 //
 // A CMYK JPEG has 4 output channels. Phi4VisionDynamicPreprocess allocates a

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -1510,6 +1510,18 @@ TEST(OrtxTokenizerTest, Gemma4ChatTemplate) {
   OrtxTokenId2DArrayGetItem(token_ids2.get(), 0, &ids2, &length2);
   ASSERT_GT(length2, 0u) << "Tokenized output should not be empty.";
 
+  // Verify that the first token is BOS (id=2) and the sequence contains
+  // expected structural tokens from the chat template.
+  EXPECT_EQ(ids2[0], 2) << "First token should be BOS";
+  // The rendered template starts with <bos> which tokenizes to id=2, and our
+  // tokenizer also prepends BOS, so we expect the sequence to start with BOS.
+  // Structural tokens: <|turn>=105, user=2364, \n=107
+  bool found_turn = false;
+  for (size_t i = 0; i < length2; ++i) {
+    if (ids2[i] == 105) { found_turn = true; break; }
+  }
+  EXPECT_TRUE(found_turn) << "Expected <|turn> token (id=105) in chat output";
+
   // Verify round-trip detokenization
   OrtxObjectPtr<OrtxStringArray> decoded_text2;
   OrtxDetokenize(tokenizer.get(), token_ids2.get(), decoded_text2.ToBeAssigned());

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -1369,3 +1369,149 @@ TEST(OrtxTokenizerV5Test, Qwen2_5_SyntheticV5_ChatTemplate) {
   OrtxDetokenize(tokenizer.get(), token_ids.get(), decoded_text.ToBeAssigned());
   EXPECT_EQ(decoded_text.Code(), kOrtxOK);
 }
+
+// ============================================================================
+// Gemma 4 chat template tests
+// ============================================================================
+
+/*
+  Test Gemma 4 chat template (google/gemma-4-E2B-it).
+  Gemma 4 uses <|turn>role\n...<turn|>\n format (different from Gemma 3's
+  <start_of_turn>...<end_of_turn>). Chat template loaded from separate
+  chat_template.jinja file (v5-era layout).
+  Files downloaded from: https://huggingface.co/google/gemma-4-E2B-it
+*/
+TEST(OrtxTokenizerTest, Gemma4ChatTemplate) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/models/gemma-4");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << "Failed to create Gemma 4 tokenizer: " << OrtxGetLastErrorMessage();
+
+  // Test 1: Simple text-only message
+  {
+    OrtxObjectPtr<OrtxTensorResult> templated_text;
+    std::string messages_json = R"(
+      [
+        {
+          "role": "user",
+          "content": "What is the meaning of life?"
+        }
+      ])";
+
+    auto err = OrtxApplyChatTemplate(
+      tokenizer.get(), nullptr,
+      messages_json.c_str(), nullptr, templated_text.ToBeAssigned(), true, false);
+
+    if (err != kOrtxOK) {
+      std::cout << "Error: " << OrtxGetLastErrorMessage() << std::endl;
+    }
+    ASSERT_EQ(err, kOrtxOK);
+
+    OrtxObjectPtr<OrtxTensor> tensor;
+    OrtxTensorResultGetAt(templated_text.get(), 0, tensor.ToBeAssigned());
+    ASSERT_EQ(tensor.Code(), kOrtxOK);
+    const char* text_ptr = nullptr;
+    OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
+
+    std::string expected = "<bos><|turn>user\nWhat is the meaning of life?<turn|>\n<|turn>model\n";
+    ASSERT_EQ(std::string(text_ptr), expected);
+  }
+
+  // Test 2: Image + text (multimodal)
+  {
+    OrtxObjectPtr<OrtxTensorResult> templated_text;
+    std::string messages_json = R"(
+      [
+        {
+          "role": "user",
+          "content": [
+            {
+              "type": "image"
+            },
+            {
+              "type": "text",
+              "text": "What is the password?"
+            }
+          ]
+        }
+      ])";
+
+    auto err = OrtxApplyChatTemplate(
+      tokenizer.get(), nullptr,
+      messages_json.c_str(), nullptr, templated_text.ToBeAssigned(), true, false);
+    ASSERT_EQ(err, kOrtxOK) << "Error: " << OrtxGetLastErrorMessage();
+
+    OrtxObjectPtr<OrtxTensor> tensor;
+    OrtxTensorResultGetAt(templated_text.get(), 0, tensor.ToBeAssigned());
+    ASSERT_EQ(tensor.Code(), kOrtxOK);
+    const char* text_ptr = nullptr;
+    OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
+
+    std::string expected = "<bos><|turn>user\n<|image|>What is the password?<turn|>\n<|turn>model\n";
+    ASSERT_EQ(std::string(text_ptr), expected);
+  }
+
+  // Test 3: System message + user message
+  {
+    OrtxObjectPtr<OrtxTensorResult> templated_text;
+    std::string messages_json = R"(
+      [
+        {
+          "role": "system",
+          "content": "You are a helpful assistant."
+        },
+        {
+          "role": "user",
+          "content": "Hello!"
+        }
+      ])";
+
+    auto err = OrtxApplyChatTemplate(
+      tokenizer.get(), nullptr,
+      messages_json.c_str(), nullptr, templated_text.ToBeAssigned(), true, false);
+    ASSERT_EQ(err, kOrtxOK) << "Error: " << OrtxGetLastErrorMessage();
+
+    OrtxObjectPtr<OrtxTensor> tensor;
+    OrtxTensorResultGetAt(templated_text.get(), 0, tensor.ToBeAssigned());
+    ASSERT_EQ(tensor.Code(), kOrtxOK);
+    const char* text_ptr = nullptr;
+    OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
+
+    std::string expected = "<bos><|turn>system\nYou are a helpful assistant.<turn|>\n"
+                           "<|turn>user\nHello!<turn|>\n<|turn>model\n";
+    ASSERT_EQ(std::string(text_ptr), expected);
+  }
+
+  // Verify tokenization of templated text works
+  OrtxObjectPtr<OrtxTensorResult> final_text;
+  std::string messages_json = R"(
+    [
+      {
+        "role": "user",
+        "content": "Hello!"
+      }
+    ])";
+
+  auto err = OrtxApplyChatTemplate(
+    tokenizer.get(), nullptr,
+    messages_json.c_str(), nullptr, final_text.ToBeAssigned(), true, false);
+  ASSERT_EQ(err, kOrtxOK);
+
+  OrtxObjectPtr<OrtxTensor> final_tensor;
+  OrtxTensorResultGetAt(final_text.get(), 0, final_tensor.ToBeAssigned());
+  const char* text_ptr = nullptr;
+  OrtxGetTensorData(final_tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
+
+  OrtxObjectPtr<OrtxTokenId2DArray> token_ids2;
+  const char* input2[] = { text_ptr };
+  OrtxTokenize(tokenizer.get(), input2, 1, token_ids2.ToBeAssigned());
+  ASSERT_EQ(token_ids2.Code(), kOrtxOK);
+
+  size_t length2 = 0;
+  const extTokenId_t* ids2 = nullptr;
+  OrtxTokenId2DArrayGetItem(token_ids2.get(), 0, &ids2, &length2);
+  ASSERT_GT(length2, 0u) << "Tokenized output should not be empty.";
+
+  // Verify round-trip detokenization
+  OrtxObjectPtr<OrtxStringArray> decoded_text2;
+  OrtxDetokenize(tokenizer.get(), token_ids2.get(), decoded_text2.ToBeAssigned());
+  EXPECT_EQ(decoded_text2.Code(), kOrtxOK);
+}

--- a/test/pp_api_test/test_tokenizer_impl.cc
+++ b/test/pp_api_test/test_tokenizer_impl.cc
@@ -615,6 +615,16 @@ TEST(OrtxTokenizerTest, Gemma4Tokenizer) {
   // BOS token should be the first token (id=2 for Gemma family)
   EXPECT_EQ(token_ids[0][0], 2) << "First token should be BOS (id=2)";
 
+  // Verify token IDs match HF reference (HF returns [2094, 563, 496, 1594, 236761]
+  // without BOS; our tokenizer prepends BOS=2).
+  const std::vector<extTokenId_t> kExpectedIds = {2, 2094, 563, 496, 1594, 236761};
+  ASSERT_EQ(token_ids[0].size(), kExpectedIds.size())
+      << "Token count mismatch vs HF reference";
+  for (size_t i = 0; i < kExpectedIds.size(); ++i) {
+    EXPECT_EQ(token_ids[0][i], kExpectedIds[i])
+        << "Token " << i << " mismatch vs HF reference";
+  }
+
   // Verify round-trip detokenization
   std::vector<std::string> out_text;
   std::vector<ort_extensions::span<extTokenId_t const>> token_ids_span = {token_ids[0]};

--- a/test/pp_api_test/test_tokenizer_impl.cc
+++ b/test/pp_api_test/test_tokenizer_impl.cc
@@ -578,3 +578,47 @@ TEST(OrtxTokenizerV5Test, Qwen2_5_SyntheticV5_Tokenizer) {
   EXPECT_TRUE(status.IsOk());
   EXPECT_EQ(out_text[0], input[0]);
 }
+
+// ============================================================================
+// Gemma 4 tokenizer tests
+// ============================================================================
+
+/*
+  Test Gemma 4 tokenizer (google/gemma-4-E2B-it).
+  Gemma 4 uses GemmaTokenizer (BPE), same tokenizer family as Gemma 2/3,
+  with v5-era file layout:
+  - No add_bos_token in tokenizer_config.json (inferred from per-class defaults)
+  - chat_template in separate .jinja file
+  - 262144 vocab size
+  Files downloaded from: https://huggingface.co/google/gemma-4-E2B-it
+*/
+TEST(OrtxTokenizerTest, Gemma4Tokenizer) {
+  auto tokenizer = std::make_unique<ort_extensions::TokenizerImpl>();
+  auto status = tokenizer->Load("data/models/gemma-4");
+  if (!status.IsOk()) {
+    std::cout << status.ToString() << std::endl;
+    tokenizer.reset();
+  }
+
+  ASSERT_NE(tokenizer.get(), nullptr) << "Tokenizer is null, stopping the test.";
+
+  // Test basic tokenization (BOS should be added automatically)
+  std::vector<std::string_view> input = {"This is a test."};
+  std::vector<std::vector<extTokenId_t>> token_ids;
+  status = tokenizer->Tokenize(input, token_ids);
+  EXPECT_TRUE(status.IsOk());
+  DumpTokenIds(token_ids);
+
+  EXPECT_EQ(token_ids.size(), 1u);
+  ASSERT_GT(token_ids[0].size(), 0u);
+
+  // BOS token should be the first token (id=2 for Gemma family)
+  EXPECT_EQ(token_ids[0][0], 2) << "First token should be BOS (id=2)";
+
+  // Verify round-trip detokenization
+  std::vector<std::string> out_text;
+  std::vector<ort_extensions::span<extTokenId_t const>> token_ids_span = {token_ids[0]};
+  status = tokenizer->Detokenize(token_ids_span, out_text);
+  EXPECT_TRUE(status.IsOk());
+  EXPECT_EQ(out_text[0], input[0]);
+}


### PR DESCRIPTION
# Add Gemma 4 Preprocessing Support (Image, Audio, Text)

## Summary

Adds image, audio, and text preprocessing support for [Gemma 4](https://huggingface.co/google/gemma-4-E2B-it) to ORT Extensions. This enables end-to-end multimodal inference pipelines for Gemma 4 in ORT GenAI and Foundry Local.

## What's included

### Image preprocessing (`Gemma4ImageTransform`)
- Variable aspect-ratio resize preserving original proportions, fitting within `max_soft_tokens × pooling_kernel_size × patch_size` grid
- Rescale pixels to [0, 1] — Gemma 4 does **not** use ImageNet normalization (unlike most vision models)
- Patchification into `(num_patches, patch_size² × 3)` in HWC order within each patch
- 2D position IDs `(x, y)` per patch with `(-1, -1)` padding for unused slots
- Per-image `num_soft_tokens` count
- Config: `patch_size=16`, `max_soft_tokens=280`, `pooling_kernel_size=3`

### Audio feature extraction (`Gemma4LogMel`)
- USM-style 128-dimensional log-mel spectrogram
- 16kHz sampling rate, 20ms frames (320 samples), 10ms hop (160 samples), 512-point FFT
- Periodic Hann window, HTK mel filterbank (0–8kHz), `mel_floor=0.001`
- Semicausal padding (prepend `frame_length/2` zeros)
- Outputs `(num_frames, 128)` log-mel features + `(num_frames,)` boolean attention mask

### Tokenizer & chat template
- Gemma 4 uses `GemmaTokenizer` (BPE, 262144 vocab) — same family as Gemma 2/3
- v5-era file layout: separate `chat_template.jinja`, no inline `add_bos_token`, `backend: "tokenizers"`
- Chat template uses `<|turn>role\n...<turn|>\n` format (different from Gemma 3's `<start_of_turn>...<end_of_turn>`)
- Multimodal tokens: `<|image|>`, `<|audio|>`, `<|video|>`
- All tokenizer files downloaded from [google/gemma-4-E2B-it](https://huggingface.co/google/gemma-4-E2B-it)
- No production code changes needed — existing v5 support handles everything

### Bug fix: BOS inference for no-op `post_processor`
Gemma 4's `tokenizer.json` has a `post_processor` that's a no-op `TemplateProcessing` (sequence placeholders only, no special tokens). The existing v5 BOS inference code only applied per-class defaults when `post_processor` was **absent**. When present but empty of BOS/EOS references, the Gemma per-class default (`add_bos_token=true`) was never reached. Fixed by tracking whether BOS/EOS was actually inferred from the `post_processor`, and falling through to per-class defaults if not. Fully backward-compatible.

## Changes

### Production code
| File | Change |
|------|--------|
| `shared/api/image_transforms_gemma4.hpp` | **NEW** — `Gemma4ImageTransform` kernel |
| `shared/api/gemma4_audio_features.hpp` | **NEW** — `Gemma4LogMel` kernel |
| `shared/api/image_processor.cc` | Register `Gemma4ImageTransform` in kernel registry |
| `shared/api/speech_extractor.cc` | Register `Gemma4LogMel` in kernel registry |
| `operators/tokenizer/bpe_kernels.cc` | Fix BOS inference when `post_processor` exists but doesn't mention BOS/EOS |

### Test data
| File | Description |
|------|-------------|
| `test/data/models/gemma-4/tokenizer.json` | BPE vocabulary (262144 tokens) from HF |
| `test/data/models/gemma-4/tokenizer_config.json` | GemmaTokenizer config (v5-era layout) |
| `test/data/models/gemma-4/chat_template.jinja` | 344-line Jinja template with tool calling support |
| `test/data/models/gemma-4/processor_config.json` | Reference processor config from HF |
| `test/data/models/gemma-4/image_processor.json` | Image pipeline config for tests |
| `test/data/models/gemma-4/audio_feature_extraction.json` | Audio pipeline config for tests |

### Tests
| Test | File | What it verifies |
|------|------|-----------------|
| `TestGemma4ImageProcessing` | `test_processor.cc` | Single image: shape `(1, 2520, 768)`, values in [0,1], position IDs, num_soft_tokens |
| `TestGemma4ImageProcessingMultiImage` | `test_processor.cc` | Batch of 2 images: batch dimension = 2 |
| `TestGemma4AudioFeatureExtraction` | `test_feature_extraction.cc` | Single audio: shape `(1, N, 128)`, finite values, attention mask |
| `TestGemma4AudioFeatureExtractionMultiFile` | `test_feature_extraction.cc` | Batch of 2 audio files: batch dimension = 2 |
| `Gemma4Tokenizer` | `test_tokenizer_impl.cc` | Tokenize + round-trip detokenize, BOS = 2 |
| `Gemma4ChatTemplate` | `test_tokenizer_chat.cc` | Text-only, image+text, system+user chat templates |

## Backward compatibility

- All existing tests pass unchanged
- The BOS inference fix is a strict superset of the previous behavior — models whose `post_processor` already contains BOS/EOS references are unaffected
- No changes to public APIs

## Reference
- HuggingFace model: https://huggingface.co/google/gemma-4-E2B-it
- Image processing reference: [`image_processing_gemma4.py`](https://huggingface.co/google/gemma-4-E2B-it/blob/main/image_processing_gemma4.py)
- Audio processing reference: [`feature_extraction_gemma4.py`](https://huggingface.co/google/gemma-4-E2B-it/blob/main/feature_extraction_gemma4.py)
