### PR TITLE
Adding dlib's fft dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,9 @@ if(OCOS_ENABLE_MATH)
     file(GLOB TARGET_SRC_MATH_CUDA "operators/math/cuda/*.*")
     list(APPEND TARGET_SRC_MATH ${TARGET_SRC_MATH_CUDA})
   endif()
-  list(APPEND TARGET_SRC ${dlib_SOURCE_DIR}/dlib/fft/fft.cpp) # For the OCOS_ENABLE_AUDIO=OFF so that unknown symbol error shouldn't come.
+  if(NOT OCOS_ENABLE_AUDIO)
+    list(APPEND TARGET_SRC ${dlib_SOURCE_DIR}/dlib/fft/fft.cpp) # For the OCOS_ENABLE_AUDIO=OFF so that unknown symbol error shouldn't come.
+  endif()
   list(APPEND TARGET_SRC ${TARGET_SRC_MATH} ${TARGET_SRC_DLIB} ${TARGET_SRC_INVERSE})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,7 +377,6 @@ if(OCOS_ENABLE_DLIB)
   # To avoid the unintentional using some unwanted component, we only include the test_for_odr_violations.cpp
   # to check if there is any violation in build configuration to ensure compiling some dlib source files correctly.
   file(GLOB TARGET_SRC_DLIB "${dlib_SOURCE_DIR}/dlib/test_for_odr_violations.cpp")
-  list(APPEND TARGET_SRC_DLIB ${dlib_SOURCE_DIR}/dlib/fft/fft.cpp) # For the OCOS_ENABLE_AUDIO=OFF so that unknown symbol error shouldn't come.
 endif()
 
 if(OCOS_ENABLE_TF_STRING)
@@ -411,7 +410,7 @@ if(OCOS_ENABLE_MATH)
     file(GLOB TARGET_SRC_MATH_CUDA "operators/math/cuda/*.*")
     list(APPEND TARGET_SRC_MATH ${TARGET_SRC_MATH_CUDA})
   endif()
-
+  list(APPEND TARGET_SRC ${dlib_SOURCE_DIR}/dlib/fft/fft.cpp) # For the OCOS_ENABLE_AUDIO=OFF so that unknown symbol error shouldn't come.
   list(APPEND TARGET_SRC ${TARGET_SRC_MATH} ${TARGET_SRC_DLIB} ${TARGET_SRC_INVERSE})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,7 @@ if(OCOS_ENABLE_DLIB)
   # To avoid the unintentional using some unwanted component, we only include the test_for_odr_violations.cpp
   # to check if there is any violation in build configuration to ensure compiling some dlib source files correctly.
   file(GLOB TARGET_SRC_DLIB "${dlib_SOURCE_DIR}/dlib/test_for_odr_violations.cpp")
+  list(APPEND TARGET_SRC_DLIB ${dlib_SOURCE_DIR}/dlib/fft/fft.cpp) # For the OCOS_ENABLE_AUDIO=OFF so that unknown symbol error shouldn't come.
 endif()
 
 if(OCOS_ENABLE_TF_STRING)
@@ -629,7 +630,7 @@ if(OCOS_ENABLE_VISION)
     if (NOT OCOS_ENABLE_DLIB)
       message(FATAL_ERROR "Vision operators require DLIB to be enabled.") # for now, we need dlib for image processing
     endif()
-    include(ext_imgcodecs)  
+    include(ext_imgcodecs)
     target_include_directories(ocos_operators PUBLIC ${libPNG_SOURCE_DIR} ${libJPEG_SOURCE_DIR})
     target_link_libraries(ocos_operators PUBLIC ${PNG_LIBRARY} ${JPEG_LIBRARY})
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,6 +511,9 @@ if(MSVC)
   add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:SHELL:--compiler-options /utf-8>" "$<$<COMPILE_LANGUAGE:CXX,C>:/utf-8>")
 endif()
 
+#Removing duplicate files added to the target sources.
+list(REMOVE_DUPLICATES TARGET_SRC_NOEXCEPTION)
+list(REMOVE_DUPLICATES TARGET_SRC)
 # Library will not be built if the target src for the lib does not contain any valid *.cc files.
 # Hence the placeholders `noexcep_operators_placeholder.cc` and `ocos_operators_placeholder.cc`
 # are added to the target sources for TARGET_SRC_NOEXCEPTION and TARGET_SRC respectively


### PR DESCRIPTION
Using the build.sh as 

```
./build.sh -DCMAKE_POLICY_VERSION_MINIMUM=3.5   -DONNXRUNTIME_LIB_DIR=/usr/local/lib -DONNXRUNTIME_INCLUDE_DIR=/usr/local/include/onnxruntime  -DCMAKE_INSTALL_PREFIX=/usr/local -DOCOS_ENABLE_OPENCV_CODECS=OFF -DOCOS_ENABLE_VISION=OFF -DOCOS_ENABLE_AUDIO=OFF -DOCOS_ENABLE_CV2=OFF
```


Problem:
```
[ 96%] Linking CXX shared library lib/libortextensions.so
ld: 0711-317 ERROR: Undefined symbol: ._ZN4dlib3fftIfEEvRKNS_8fft_sizeEPKNSt3__17complexIT_EEPS7_b
ld: 0711-345 Use the -bloadmap or -bnoquiet option to obtain more information.
.ibm-clang: error: linker command failed with exit code 8 (use -v to see invocation)
gmake[2]: *** [CMakeFiles/extensions_shared.dir/build.make:109: lib/libortextensions.so] Error 8
gmake[1]: *** [CMakeFiles/Makefile2:639: CMakeFiles/extensions_shared.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
/home/Kushal/onnxruntime-1.20.0/aixoss/onnxruntime-extensions/test/static_test/test_ustring.cc:32:29: warning: 'codecvt_utf8<char32_t>' is deprecated [-Wdeprecated-declarations]

```

After my changes.
```
[ 92%] Linking CXX executable bin/ocos_test
[100%] Built target ocos_test
[100%] Built target extensions_test
```