### PR TITLE
Support Sequence pre-tokenizer with sequential Split steps

### DIFF
--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -258,11 +258,97 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
 
   // Parse input
   auto special_token_split_res = bbpe_tokenizer_->SplitByAddedAndSpecial(input, added_tokens_);
+
+  // Helper lambda: byte-encode a pre-tokenized chunk, perform BPE, and append IDs to res.
+  auto process_bpe_chunk = [&](std::string utf8_token, size_t& offset, OffsetMappingType& offset_mapping) {
+    if (utf8_token.empty()) return;
+
+    int64_t space_dif = 0;
+    if (compute_offset_mapping) {
+      if (utf8_token[0] == ' ') {
+        offset++;
+        space_dif = -1;
+      }
+    }
+
+    std::list<std::pair<uint32_t, uint32_t>> byte_list;
+    std::string token_bytes;
+    token_bytes.reserve(utf8_token.size() * 2);
+    size_t token_len = utf8_token.length();
+    size_t end_diff = 0;
+    if (clean_up_spaces) {
+      utf8_token.erase(std::remove(utf8_token.begin(), utf8_token.end(), U' '), utf8_token.end());
+      token_len = utf8_token.empty() ? 0 : utf8_token.length() - 1;
+      if (utf8_token.empty()) return;
+    }
+
+    for (size_t i = 0; i < token_len; i++) {
+      token_bytes += unicode_byte_encoder_[static_cast<unsigned char>(utf8_token[i])];
+    }
+
+    if (clean_up_spaces) {
+      end_diff = token_bytes.length();
+      if (!utf8_token.empty()) {
+        token_bytes += unicode_byte_encoder_[static_cast<unsigned char>(utf8_token.back())];
+        token_bytes += "</w>";
+      }
+      end_diff = token_bytes.length() - end_diff;
+    }
+
+    auto id = bbpe_tokenizer_->GetTokenId(token_bytes);
+    if (id != bpe::kInvalidTokenId) {
+      byte_list.push_back(std::make_pair(id, ort_extensions::narrow<uint32_t>(utf8_token.size())));
+    } else {
+      token_len = token_bytes.length();
+      for (size_t i = 0; i < token_len - end_diff; /* i++ */) {
+        size_t j = ustring::UTF8Len(token_bytes[i]);
+        byte_list.push_back(std::make_pair(bbpe_tokenizer_->GetTokenId(token_bytes.substr(i, j)),
+                                           ort_extensions::narrow<uint32_t>(j)));
+        i += j;
+      }
+      if (end_diff > 0) {
+        byte_list.push_back(
+            std::make_pair(bbpe_tokenizer_->GetTokenId(token_bytes.substr(token_len - end_diff, end_diff)),
+                           ort_extensions::narrow<uint32_t>(end_diff)));
+      }
+    }
+
+    bbpe_tokenizer_->PerformBPE(byte_list);
+
+    for (auto p : byte_list) {
+      if (static_cast<int64_t>(res.size()) >= max_length) break;
+      res.push_back(p.first);
+      if (compute_offset_mapping) {
+        if (clean_up_spaces) {
+          offset_mapping.emplace_back(std::make_pair(offset, ort_extensions::narrow<size_t>(offset + p.second)));
+          offset += p.second;
+        } else {
+          auto adjusted = static_cast<size_t>(static_cast<int64_t>(p.second) + space_dif);
+          offset_mapping.emplace_back(std::make_pair(offset, ort_extensions::narrow<size_t>(offset + adjusted)));
+          offset += adjusted;
+        }
+      }
+    }
+  };
+
+  // Prepare pre-tokenizer: either single-regex or sequential pipeline
+  const bool use_sequence = bbpe_tokenizer_->HasSequencePreTokenizer();
+
   bpe::PreTokenizerWithRegEx reg_splitter;
-  // NOTE: the pattern was already validated on loading json file.
-  // safe to ingore the return value here.
-  auto status = reg_splitter.Compile(bbpe_tokenizer_->GetPreTokenizerRegex(ModelName(), bpe_conf_.get().spm_model_));
-  assert(status.IsOk());
+  std::vector<bpe::PreTokenizerWithRegEx> seq_splitters;
+
+  if (use_sequence) {
+    auto& steps = bbpe_tokenizer_->GetSequenceSteps();
+    seq_splitters.resize(steps.size());
+    for (size_t i = 0; i < steps.size(); ++i) {
+      auto status = seq_splitters[i].Compile(steps[i].regex);
+      assert(status.IsOk());
+    }
+  } else {
+    auto status = reg_splitter.Compile(
+        bbpe_tokenizer_->GetPreTokenizerRegex(ModelName(), bpe_conf_.get().spm_model_));
+    assert(status.IsOk());
+  }
 
   for (auto& seg_id : special_token_split_res) {
     if (static_cast<int64_t>(res.size()) >= max_length) break;
@@ -272,9 +358,7 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
       continue;
     }
 
-    // Note: keep ptr to make sure the string_view is valid in the following process
     std::u32string str(seg_id.first);
-    reg_splitter.Set(str.c_str());
 
     size_t offset = 0;
     OffsetMappingType offset_mapping;
@@ -286,85 +370,33 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
       }
     }
 
-    while (static_cast<int64_t>(res.size()) < max_length) {
-      std::u32string_view tok = reg_splitter.GetNextToken();
-      if (tok.empty()) {
-        break;
+    if (use_sequence) {
+      // Sequential pre-tokenization: run each Split step on the accumulated chunks
+      std::vector<std::u32string> chunks = {std::move(str)};
+      for (auto& splitter : seq_splitters) {
+        std::vector<std::u32string> new_chunks;
+        for (auto& chunk : chunks) {
+          auto sub = splitter.SplitIsolated(chunk);
+          new_chunks.insert(new_chunks.end(),
+                            std::make_move_iterator(sub.begin()),
+                            std::make_move_iterator(sub.end()));
+        }
+        chunks = std::move(new_chunks);
       }
 
-      std::string utf8_token = std::string(ustring(tok));
-      size_t space_dif = 0;
-      if (compute_offset_mapping) {
-        // Handle special case for offset mapping
-        if (utf8_token.at(0) == ' ') {
-          offset++;
-          space_dif = -1;  // account for spaces used in offset map algorithm in bpe(byte_list_)
-        }
+      for (auto& chunk : chunks) {
+        if (static_cast<int64_t>(res.size()) >= max_length) break;
+        std::string utf8_token = std::string(ustring(chunk));
+        process_bpe_chunk(std::move(utf8_token), offset, offset_mapping);
       }
-
-      std::list<std::pair<uint32_t, uint32_t>> byte_list;
-      std::string token_bytes;
-      token_bytes.reserve(utf8_token.size() * 2);
-      size_t token_len = utf8_token.length();
-      size_t end_diff = 0;
-      if (clean_up_spaces) {
-        // Whitespace clean
-        utf8_token.erase(std::remove(utf8_token.begin(), utf8_token.end(), U' '), utf8_token.end());
-        token_len = utf8_token.length() - 1;
-      }
-
-      for (size_t i = 0; i < token_len; i++) {
-        token_bytes += unicode_byte_encoder_[static_cast<unsigned char>(utf8_token[i])];
-      }
-
-      if (clean_up_spaces) {
-        end_diff = token_bytes.length();
-        if (!utf8_token.empty()) {
-          token_bytes += unicode_byte_encoder_[static_cast<unsigned char>(utf8_token.back())];
-          token_bytes += "</w>";
-        }
-        end_diff = token_bytes.length() - end_diff;
-      }
-
-      auto id = bbpe_tokenizer_->GetTokenId(token_bytes);
-      if (id != bpe::kInvalidTokenId) {
-        byte_list.push_back(std::make_pair(id, ort_extensions::narrow<uint32_t>(utf8_token.size())));
-      } else {
-        token_len = token_bytes.length();
-        for (size_t i = 0; i < token_len - end_diff; /* i++ */) {
-          size_t j = ustring::UTF8Len(token_bytes[i]);
-          byte_list.push_back(std::make_pair(bbpe_tokenizer_->GetTokenId(token_bytes.substr(i, j)),
-                                             ort_extensions::narrow<uint32_t>(j)));
-          i += j;
-        }
-        if (end_diff > 0) {
-          byte_list.push_back(
-              std::make_pair(bbpe_tokenizer_->GetTokenId(token_bytes.substr(token_len - end_diff, end_diff)),
-                             ort_extensions::narrow<uint32_t>(end_diff)));
-        }
-      }
-
-      // Perform BPE
-      bbpe_tokenizer_->PerformBPE(byte_list);
-
-      // Add output to result
-      for (auto p : byte_list) {
-        if (static_cast<int64_t>(res.size()) >= max_length) {
-          break;
-        }
-
-        res.push_back(p.first);
-
-        if (compute_offset_mapping) {
-          if (clean_up_spaces) {
-            offset_mapping.emplace_back(std::make_pair(offset, ort_extensions::narrow<size_t>(offset + p.second)));
-            offset += p.second;
-          } else {
-            offset_mapping.emplace_back(
-                std::make_pair(offset, ort_extensions::narrow<size_t>(offset + (size_t)p.second + space_dif)));
-            offset += ((size_t)p.second + space_dif);
-          }
-        }
+    } else {
+      // Single-regex pre-tokenization (existing behavior)
+      reg_splitter.Set(str.c_str());
+      while (static_cast<int64_t>(res.size()) < max_length) {
+        std::u32string_view tok = reg_splitter.GetNextToken();
+        if (tok.empty()) break;
+        std::string utf8_token = std::string(ustring(tok));
+        process_bpe_chunk(std::move(utf8_token), offset, offset_mapping);
       }
     }
 

--- a/operators/tokenizer/bpe_tokenizer_model.hpp
+++ b/operators/tokenizer/bpe_tokenizer_model.hpp
@@ -99,18 +99,17 @@ class BpeModel {
       if (pre_type == "Split") {
         ORTX_JSON_RETURN_IF_NULL(&node, "pattern", iter_pattern);
         ORTX_JSON_RETURN_IF_NULL(iter_pattern, "Regex", regex_str);
-        pre_tokenizer_regex_ = regex_str->get<std::string>();
-        // Validate the regex pattern
+        auto regex = NormalizeJsonRegexEscapes(regex_str->get<std::string>());
         bpe::PreTokenizerWithRegEx pre_tokenizer;
-        auto status = pre_tokenizer.Compile(pre_tokenizer_regex_);
+        auto status = pre_tokenizer.Compile(regex);
         if (!status.IsOk()) {
           return status;
         }
+        sequence_steps_.push_back({std::move(regex)});
       } else {
         if (pre_tokenizer_types_.count(pre_type) == 0) {
           return {kOrtxErrorNotImplemented, "Unsupported pretokenizer type!"};
         }
-        ; // TODO: implement other pretokenizer types
       }
     }
 
@@ -475,6 +474,14 @@ class BpeModel {
 
   bool IsNoOpPretokenizer() const { return no_op_pretokenizer_; }
 
+  struct SequencePreTokenizerStep {
+    std::string regex;
+  };
+
+  bool HasSequencePreTokenizer() const { return !sequence_steps_.empty(); }
+
+  const std::vector<SequencePreTokenizerStep>& GetSequenceSteps() const { return sequence_steps_; }
+
   std::string GetPreTokenizerRegex(const std::string& model_name, bool spm_model = false) const {
     if (!pre_tokenizer_regex_.empty()) {
       return pre_tokenizer_regex_;
@@ -511,8 +518,25 @@ class BpeModel {
   TrieTree<char32_t> added_tokens_;
   std::string pre_tokenizer_regex_;
   bool no_op_pretokenizer_ = false;
+  std::vector<SequencePreTokenizerStep> sequence_steps_;
 
   std::set<std::string_view> pre_tokenizer_types_;
+
+  static std::string NormalizeJsonRegexEscapes(std::string regex) {
+    std::string normalized;
+    normalized.reserve(regex.size());
+    for (char ch : regex) {
+      switch (ch) {
+        case '\r': normalized += "\\r"; break;
+        case '\n': normalized += "\\n"; break;
+        case '\t': normalized += "\\t"; break;
+        case '\f': normalized += "\\f"; break;
+        case '\v': normalized += "\\v"; break;
+        default:   normalized += ch;    break;
+      }
+    }
+    return normalized;
+  }
 };
 
 }  // namespace ort_extensions

--- a/operators/tokenizer/bpe_utils.hpp
+++ b/operators/tokenizer/bpe_utils.hpp
@@ -940,12 +940,20 @@ class PreTokenizerWithRegEx {
     std::u32string unmatched;
 
     while (!m_text.empty()) {
+      auto before = m_text;
       auto res = TryMatch();
       if (res.empty()) {
         unmatched += m_text[0];
         m_last_char = m_text[0];
         m_text = m_text.substr(1);
         continue;
+      }
+      // MatchWithSTLRegEx may skip characters before the match (regex_search
+      // finds the next match anywhere in the remaining text). Capture the
+      // skipped gap so nothing is lost.
+      if (res.data() > before.data()) {
+        size_t gap_len = static_cast<size_t>(res.data() - before.data());
+        unmatched.append(before.data(), gap_len);
       }
       if (!unmatched.empty()) {
         results.push_back(std::move(unmatched));

--- a/operators/tokenizer/bpe_utils.hpp
+++ b/operators/tokenizer/bpe_utils.hpp
@@ -687,6 +687,88 @@ class PreTokenizerWithRegEx {
     return {};
   }
 
+  static bool IsCJK(char32_t ch) {
+    return (ch >= 0x4E00 && ch <= 0x9FA5) ||   // 一-龥
+           (ch >= 0x3040 && ch <= 0x309F) ||    // ぀-ゟ (Hiragana)
+           (ch >= 0x30A0 && ch <= 0x30FF);      // ゠-ヿ (Katakana)
+  }
+
+  // "[一-龥぀-ゟ゠-ヿ]+"
+  std::u32string_view Match_CJK_Pattern() {
+    if (m_text.empty()) return {};
+    if (!IsCJK(m_text[0])) return {};
+    size_t i = 1;
+    while (i < m_text.size() && IsCJK(m_text[i])) i++;
+    auto res = m_text.substr(0, i);
+    m_text = m_text.substr(i);
+    return res;
+  }
+
+  static bool IsP(char32_t ch) {
+    return IsCategory(ch, ufal::unilib::unicode::P);
+  }
+
+  static bool IsS(char32_t ch) {
+    return IsCategory(ch, ufal::unilib::unicode::S);
+  }
+
+  static bool IsPS(char32_t ch) { return IsP(ch) || IsS(ch); }
+
+  // "[^\r\n\p{L}\p{P}\p{S}]?[\p{L}\p{M}]+"
+  std::u32string_view Match_Hunyuan_Pattern_1() {
+    if (m_text.empty()) return {};
+
+    size_t i = 0;
+    if (!IsRN(m_text[0]) && !IsL(m_text[0]) && !IsP(m_text[0]) && !IsS(m_text[0])) {
+      i = 1;
+    }
+
+    if (i >= m_text.size() || !IsLM(m_text[i])) return {};
+
+    while (i < m_text.size() && IsLM(m_text[i])) i++;
+
+    auto res = m_text.substr(0, i);
+    m_text = m_text.substr(i);
+    return res;
+  }
+
+  // " ?[\p{P}\p{S}]+[\r\n]*"
+  std::u32string_view Match_Hunyuan_Pattern_2() {
+    if (m_text.empty()) return {};
+
+    size_t i = 0;
+    if (m_text[0] == U' ') i = 1;
+    if (i >= m_text.size() || !IsPS(m_text[i])) return {};
+
+    while (i < m_text.size() && IsPS(m_text[i])) i++;
+    while (i < m_text.size() && IsRN(m_text[i])) i++;
+
+    auto res = m_text.substr(0, i);
+    m_text = m_text.substr(i);
+    return res;
+  }
+
+  static bool IsAsciiPunct(char32_t ch) {
+    return (ch >= 0x21 && ch <= 0x2F) || (ch >= 0x3A && ch <= 0x40) ||
+           (ch >= 0x5B && ch <= 0x60) || (ch >= 0x7B && ch <= 0x7E);
+  }
+
+  static bool IsAsciiLetter(char32_t ch) {
+    return (ch >= U'A' && ch <= U'Z') || (ch >= U'a' && ch <= U'z');
+  }
+
+  // "[!"#$%&'()*+,\-./:;<=>?@\[\\\]^_`{|}~][A-Za-z]+"
+  std::u32string_view Match_Hunyuan_Pattern_3() {
+    if (m_text.empty()) return {};
+    if (!IsAsciiPunct(m_text[0])) return {};
+    size_t i = 1;
+    if (i >= m_text.size() || !IsAsciiLetter(m_text[i])) return {};
+    while (i < m_text.size() && IsAsciiLetter(m_text[i])) i++;
+    auto res = m_text.substr(0, i);
+    m_text = m_text.substr(i);
+    return res;
+  }
+
   // "(\p{N})"
   std::u32string_view Match_General_Pattern_1() {
 
@@ -730,6 +812,10 @@ class PreTokenizerWithRegEx {
         {R"(\p{N}{1,3})", &PreTokenizerWithRegEx::Match_LLAMA3_Pattern_3},
         {R"(\s*[\r\n]+)", &PreTokenizerWithRegEx::Match_LLAMA3_Pattern_5},
         {R"(\p{N})", &PreTokenizerWithRegEx::Match_General_Pattern_1},
+        {R"([一-龥぀-ゟ゠-ヿ]+)", &PreTokenizerWithRegEx::Match_CJK_Pattern},
+        {R"([!"#$%&'()*+,\-./:;<=>?@\[\\\]^_`{|}~][A-Za-z]+)", &PreTokenizerWithRegEx::Match_Hunyuan_Pattern_3},
+        {R"([^\r\n\p{L}\p{P}\p{S}]?[\p{L}\p{M}]+)", &PreTokenizerWithRegEx::Match_Hunyuan_Pattern_1},
+        {R"( ?[\p{P}\p{S}]+[\r\n]*)", &PreTokenizerWithRegEx::Match_Hunyuan_Pattern_2},
     };
 
     std::string regex_compound = regex;
@@ -843,6 +929,35 @@ class PreTokenizerWithRegEx {
     }
 
     return {};
+  }
+
+  // Split text into chunks preserving both matched and unmatched regions.
+  // Mirrors HuggingFace's Split pre-tokenizer with behavior=Isolated:
+  // regex matches AND inter-match gaps both become separate output chunks.
+  std::vector<std::u32string> SplitIsolated(const std::u32string& text) {
+    std::vector<std::u32string> results;
+    Set(text);
+    std::u32string unmatched;
+
+    while (!m_text.empty()) {
+      auto res = TryMatch();
+      if (res.empty()) {
+        unmatched += m_text[0];
+        m_last_char = m_text[0];
+        m_text = m_text.substr(1);
+        continue;
+      }
+      if (!unmatched.empty()) {
+        results.push_back(std::move(unmatched));
+        unmatched.clear();
+      }
+      results.emplace_back(res);
+      m_last_char = res.back();
+    }
+    if (!unmatched.empty()) {
+      results.push_back(std::move(unmatched));
+    }
+    return results;
   }
 
  public:

--- a/test/test_fast_tokenizer.py
+++ b/test/test_fast_tokenizer.py
@@ -129,5 +129,50 @@ class TestAutoTokenizer(unittest.TestCase):
                     raise
 
 
+    def test_split_sequence_with_fallback_regex(self):
+        """Verify that SplitIsolated works when a Split regex is NOT in the
+        hardcoded pattern table, forcing the STL std::regex fallback path."""
+        from tokenizers import Regex, Tokenizer
+        from tokenizers.decoders import ByteLevel as ByteLevelDecoder
+        from tokenizers.models import BPE
+        from tokenizers.pre_tokenizers import ByteLevel, Sequence, Split
+
+        with tempfile.TemporaryDirectory() as tokenizer_dir:
+            vocab = {token: idx for idx, token in enumerate(ByteLevel.alphabet())}
+            vocab["<unk>"] = len(vocab)
+
+            tokenizer = Tokenizer(BPE(vocab=vocab, merges=[], unk_token="<unk>"))
+            tokenizer.pre_tokenizer = Sequence([
+                # [aeiou]+ is not in the hardcoded pattern table — forces fallback
+                Split(Regex(r"[aeiou]+"), behavior="isolated"),
+                ByteLevel(add_prefix_space=False, use_regex=False),
+            ])
+            tokenizer.decoder = ByteLevelDecoder()
+
+            tokenizer_json_path = os.path.join(tokenizer_dir, "tokenizer.json")
+            tokenizer.save(tokenizer_json_path)
+            with open(os.path.join(tokenizer_dir, "tokenizer_config.json"), "w", encoding="utf-8") as f:
+                json.dump({
+                    "tokenizer_class": "PreTrainedTokenizerFast",
+                    "add_bos_token": False,
+                    "add_eos_token": False,
+                }, f)
+
+            ort_tok, _ = gen_processing_models(tokenizer_dir, pre_kwargs={}, schema_v2=True)
+
+            text = ["hello world", "aeiou", "xyz", "banana"]
+
+            ort_outputs = ort_inference(ort_tok, text)
+            actual_ids = ort_outputs[0] if isinstance(ort_outputs, tuple) else ort_outputs
+            for n, sample in enumerate(text):
+                expected_ids = np.asarray(tokenizer.encode(sample).ids, dtype=np.int64)
+                try:
+                    np.testing.assert_array_equal(expected_ids, actual_ids[n][:expected_ids.shape[0]])
+                except AssertionError:
+                    print("the failed fallback-regex sentence index is ", n)
+                    print("the failed fallback-regex sentence is ", repr(sample))
+                    raise
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_fast_tokenizer.py
+++ b/test/test_fast_tokenizer.py
@@ -1,5 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+import json
+import os
+import tempfile
 import unittest
 import transformers
 import numpy as np
@@ -51,6 +54,79 @@ class TestAutoTokenizer(unittest.TestCase):
             except AssertionError:
                 print("the failed sentence index is ", n)
                 raise
+
+
+    @staticmethod
+    def _create_hunyuan_like_tokenizer(tokenizer_dir):
+        """Build a minimal Hunyuan-style tokenizer with a Sequence of 3 Split steps + ByteLevel."""
+        from tokenizers import Regex, Tokenizer
+        from tokenizers.decoders import ByteLevel as ByteLevelDecoder
+        from tokenizers.models import BPE
+        from tokenizers.pre_tokenizers import ByteLevel, Sequence, Split
+
+        vocab = {token: idx for idx, token in enumerate(ByteLevel.alphabet())}
+        vocab["<unk>"] = len(vocab)
+
+        tokenizer = Tokenizer(BPE(vocab=vocab, merges=[], unk_token="<unk>"))
+        tokenizer.pre_tokenizer = Sequence([
+            Split(Regex(r"\p{N}{1,3}"), behavior="isolated"),
+            Split(Regex("[一-龥぀-ゟ゠-ヿ]+"), behavior="isolated"),
+            Split(Regex(
+                r"""[!"#$%&'()*+,\-./:;<=>?@\[\\\]^_`{|}~][A-Za-z]+"""
+                r"""|[^\r\n\p{L}\p{P}\p{S}]?[\p{L}\p{M}]+"""
+                r"""| ?[\p{P}\p{S}]+[\r\n]*"""
+                r"""|\s*[\r\n]+"""
+                r"""|\s+(?!\S)"""
+                r"""|\s+"""
+            ), behavior="isolated"),
+            ByteLevel(add_prefix_space=False, use_regex=False),
+        ])
+        tokenizer.decoder = ByteLevelDecoder()
+        tokenizer_json_path = os.path.join(tokenizer_dir, "tokenizer.json")
+        tokenizer.save(tokenizer_json_path)
+
+        with open(tokenizer_json_path, encoding="utf-8") as f:
+            tokenizer_json = json.load(f)
+        split_regex = tokenizer_json["pre_tokenizer"]["pretokenizers"][2]["pattern"]["Regex"]
+        tokenizer_json["pre_tokenizer"]["pretokenizers"][2]["pattern"]["Regex"] = (
+            split_regex.replace(r"\r", "\r").replace(r"\n", "\n")
+        )
+        with open(tokenizer_json_path, "w", encoding="utf-8") as f:
+            json.dump(tokenizer_json, f, ensure_ascii=False)
+
+        with open(os.path.join(tokenizer_dir, "tokenizer_config.json"), "w", encoding="utf-8") as f:
+            json.dump({
+                "tokenizer_class": "PreTrainedTokenizerFast",
+                "add_bos_token": False,
+                "add_eos_token": False,
+            }, f)
+
+        return tokenizer
+
+    def test_hunyuan_split_sequence_tokenization(self):
+        """Verify that a Sequence of multiple Split steps + ByteLevel produces
+        the same token IDs as HuggingFace's tokenizers library."""
+        with tempfile.TemporaryDirectory() as tokenizer_dir:
+            tokenizer = self._create_hunyuan_like_tokenizer(tokenizer_dir)
+            ort_tok, _ = gen_processing_models(tokenizer_dir, pre_kwargs={}, schema_v2=True)
+
+            text = [
+                "abc1234中文!Hello",
+                "Hello\tWorld",
+                "Line1\nLine2",
+                "价格是￥12.50",
+            ]
+
+            ort_outputs = ort_inference(ort_tok, text)
+            actual_ids = ort_outputs[0] if isinstance(ort_outputs, tuple) else ort_outputs
+            for n, sample in enumerate(text):
+                expected_ids = np.asarray(tokenizer.encode(sample).ids, dtype=np.int64)
+                try:
+                    np.testing.assert_array_equal(expected_ids, actual_ids[n][:expected_ids.shape[0]])
+                except AssertionError:
+                    print("the failed Hunyuan sentence index is ", n)
+                    print("the failed Hunyuan sentence is ", sample.encode("unicode_escape").decode("ascii"))
+                    raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Support Sequence pre-tokenizer with sequential Split steps

## Problem

HuggingFace `tokenizer.json` files may specify a **Sequence** pre-tokenizer containing multiple `Split` steps followed by `ByteLevel` (e.g. [Hunyuan](https://huggingface.co/tencent/Hunyuan-1.8B-Instruct), GPT-OSS, Qwen 2.5). The existing code on `main` handles the Sequence loop by overwriting `pre_tokenizer_regex_` with each Split entry — only the **last** Split regex survives, silently discarding earlier steps.

For single-Split models (like GPT-OSS) this happened to work. For multi-Split models (like Hunyuan with 3 Split steps), earlier patterns were lost and tokenization produced incorrect results.

## Solution

Implement true sequential pre-tokenization matching the [HuggingFace tokenizers Rust library](https://github.com/huggingface/tokenizers):

- **[`Sequence::pre_tokenize`](https://github.com/huggingface/tokenizers/blob/main/tokenizers/src/pre_tokenizers/sequence.rs#L43-L48)** — the `for` loop that runs each step sequentially on the same `PreTokenizedString`
- **[`Split::pre_tokenize`](https://github.com/huggingface/tokenizers/blob/main/tokenizers/src/pre_tokenizers/split.rs#L82-L88)** — splits text using a regex with configurable behavior
- **[`Isolated` behavior](https://github.com/huggingface/tokenizers/blob/main/tokenizers/src/tokenizer/normalizer.rs#L74-L88)** — keeps both matched and unmatched regions as separate chunks
- **[`Pattern::find_matches` for Regex](https://github.com/huggingface/tokenizers/blob/main/tokenizers/src/tokenizer/pattern.rs#L56-L70)** — returns contiguous coverage of the entire input, nothing is dropped
- **[`ByteLevel` with `use_regex: false`](https://github.com/huggingface/tokenizers/blob/main/tokenizers/src/pre_tokenizers/byte_level.rs#L112-L122)** — only does byte-to-unicode mapping, no GPT-2 regex splitting

## Changes

| File | What |
|------|------|
| `bpe_utils.hpp` | Add `SplitIsolated()` — splits text preserving both matched and unmatched regions. Add CJK/Hunyuan hardcoded matchers + pattern table entries. |
| `bpe_tokenizer_model.hpp` | Store Sequence Split steps in `sequence_steps_` vector instead of overwriting a single string. Add `NormalizeJsonRegexEscapes()` for CR/LF handling from JSON parsing. |
| `bpe_kernels.cc` | In `Tokenize()`, branch on `HasSequencePreTokenizer()`: Sequence models run the sequential pipeline; non-Sequence models use the existing single-regex path unchanged. `SpmTokenize()` is untouched. |
| `test_fast_tokenizer.py` | Add `test_hunyuan_split_sequence_tokenization` — builds a synthetic Hunyuan-style tokenizer (3 Split steps + ByteLevel) and verifies ORT matches HuggingFace across CJK, numbers, tabs, newlines, and mixed content. |

Non-Sequence tokenizers (GPT-2, Llama, Phi, CLIP, Falcon, etc.) are completely unaffected — `HasSequencePreTokenizer()` returns false and the existing code path runs.

## Testing

| Test | Result |
|------|--------|
| `test_gpt_oss_chat_template` (was failing) | PASS |
| `test_hunyuan_split_sequence_tokenization` (new) | PASS |
| `tencent/Hunyuan-1.8B-Instruct` (11 strings) | All match HuggingFace |
| Full test suite (local, Windows) | 155 passed, 35 skipped — zero regressions vs `main` |
| Models verified | GPT-2, GPT-OSS, Llama, Mistral, Phi-3/4, CLIP, BERT, RoBERTa, T5, Falcon, Qwen, DeepSeek, Whisper, OLMa, Hunyuan |
