### PR TITLE
BPE: honour every Split in a Sequence pre_tokenizer

### DIFF
--- a/operators/tokenizer/bpe_tokenizer_model.hpp
+++ b/operators/tokenizer/bpe_tokenizer_model.hpp
@@ -93,24 +93,56 @@ class BpeModel {
 
     ORTX_JSON_RETURN_IF_NULL(node_pre_tokenizer, "pretokenizers", iter_node_list);
 
+    // A HuggingFace Sequence pre_tokenizer applies each child Split in order, with the
+    // output chunks of step N being fed into step N+1. When every Split uses
+    // behavior == "Isolated" (the only behavior we model), the chain is equivalent to a
+    // single alternation `p1|p2|...|pN` evaluated left-to-right — each chunk in the
+    // final segmentation matches exactly one of the patterns. We therefore concatenate
+    // the regexes with `|` and hand the union to PreTokenizerWithRegEx::Compile, which
+    // both fast-paths recognised sub-patterns and falls back to std::regex for the rest.
+    //
+    // Previously this loop overwrote pre_tokenizer_regex_ on every iteration, silently
+    // discarding all but the last Split. That caused mis-tokenisation for models such as
+    // tencent/Hy-MT1.5, whose Sequence contains three Splits (digits-of-1-to-3, CJK
+    // runs, then a GPT2-style fallback).
+    std::vector<std::string> split_regexes;
     for (const auto& node : *iter_node_list) {
       ORTX_JSON_RETURN_IF_NULL(&node, "type", iter_type);
       auto pre_type = iter_type->get<std::string>();
       if (pre_type == "Split") {
+        // Only Isolated behavior preserves the alternation equivalence above. If we ever
+        // encounter Removed/MergedWith* we'd silently change tokenisation, so reject.
+        auto iter_behavior = node.find("behavior");
+        if (iter_behavior != node.end() && !iter_behavior->is_null()) {
+          auto behavior = iter_behavior->get<std::string>();
+          if (behavior != "Isolated") {
+            return {kOrtxErrorNotImplemented,
+                    std::string("Unsupported Split behavior in Sequence pretokenizer: ") + behavior};
+          }
+        }
         ORTX_JSON_RETURN_IF_NULL(&node, "pattern", iter_pattern);
         ORTX_JSON_RETURN_IF_NULL(iter_pattern, "Regex", regex_str);
-        pre_tokenizer_regex_ = regex_str->get<std::string>();
-        // Validate the regex pattern
-        bpe::PreTokenizerWithRegEx pre_tokenizer;
-        auto status = pre_tokenizer.Compile(pre_tokenizer_regex_);
-        if (!status.IsOk()) {
-          return status;
-        }
+        split_regexes.push_back(regex_str->get<std::string>());
       } else {
         if (pre_tokenizer_types_.count(pre_type) == 0) {
           return {kOrtxErrorNotImplemented, "Unsupported pretokenizer type!"};
         }
         ; // TODO: implement other pretokenizer types
+      }
+    }
+
+    if (!split_regexes.empty()) {
+      std::string combined = split_regexes[0];
+      for (size_t i = 1; i < split_regexes.size(); ++i) {
+        combined += "|";
+        combined += split_regexes[i];
+      }
+      pre_tokenizer_regex_ = combined;
+      // Validate the combined regex pattern
+      bpe::PreTokenizerWithRegEx pre_tokenizer;
+      auto status = pre_tokenizer.Compile(pre_tokenizer_regex_);
+      if (!status.IsOk()) {
+        return status;
       }
     }
 

--- a/operators/tokenizer/bpe_tokenizer_model.hpp
+++ b/operators/tokenizer/bpe_tokenizer_model.hpp
@@ -57,6 +57,24 @@ class BpeModel {
     }
   }
 
+  // Validate that a Split node uses a tokenisation behavior we faithfully model.
+  // Only "Isolated" is supported — under Isolated, each match is kept as its own
+  // pre-token, which is the behavior assumed both by the single-Split fast path
+  // and by the Sequence-of-Splits alternation path below. Removed/MergedWith*
+  // would silently change tokenisation, so reject them explicitly.
+  static OrtxStatus ValidateSplitBehavior(const json& split_node, const char* context) {
+    auto iter_behavior = split_node.find("behavior");
+    if (iter_behavior == split_node.end() || iter_behavior->is_null()) {
+      return {};
+    }
+    auto behavior = iter_behavior->get<std::string>();
+    if (behavior != "Isolated") {
+      return {kOrtxErrorNotImplemented,
+              std::string("Unsupported Split behavior in ") + context + ": " + behavior};
+    }
+    return {};
+  }
+
   OrtxStatus LoadPreTokenizer(const json& bpe_model) {
     auto root_node = &bpe_model;
     ORTX_JSON_RETURN_IF_NULL(root_node, "pre_tokenizer", node_pre_tokenizer);
@@ -71,6 +89,10 @@ class BpeModel {
       // E.g., chatglm3 has: {"type": "Split", "pattern": {"String": "<!dummy-prefix!>"}}
       // A Split on a literal String that never appears in normal text is effectively a no-op.
       if (pre_token_type == "Split") {
+        auto behavior_status = ValidateSplitBehavior(*node_pre_tokenizer, "top-level Split pretokenizer");
+        if (!behavior_status.IsOk()) {
+          return behavior_status;
+        }
         auto iter_pattern = node_pre_tokenizer->find("pattern");
         if (iter_pattern != node_pre_tokenizer->end()) {
           auto iter_regex = iter_pattern->find("Regex");
@@ -110,15 +132,9 @@ class BpeModel {
       ORTX_JSON_RETURN_IF_NULL(&node, "type", iter_type);
       auto pre_type = iter_type->get<std::string>();
       if (pre_type == "Split") {
-        // Only Isolated behavior preserves the alternation equivalence above. If we ever
-        // encounter Removed/MergedWith* we'd silently change tokenisation, so reject.
-        auto iter_behavior = node.find("behavior");
-        if (iter_behavior != node.end() && !iter_behavior->is_null()) {
-          auto behavior = iter_behavior->get<std::string>();
-          if (behavior != "Isolated") {
-            return {kOrtxErrorNotImplemented,
-                    std::string("Unsupported Split behavior in Sequence pretokenizer: ") + behavior};
-          }
+        auto behavior_status = ValidateSplitBehavior(node, "Sequence pretokenizer");
+        if (!behavior_status.IsOk()) {
+          return behavior_status;
         }
         ORTX_JSON_RETURN_IF_NULL(&node, "pattern", iter_pattern);
         ORTX_JSON_RETURN_IF_NULL(iter_pattern, "Regex", regex_str);

--- a/test/test_fast_tokenizer.py
+++ b/test/test_fast_tokenizer.py
@@ -53,21 +53,74 @@ class TestAutoTokenizer(unittest.TestCase):
                 raise
 
 
-    def test_hy_mt_sequence_of_splits(self):
-        # tencent/Hy-MT1.5-1.8B-2bit has a pre_tokenizer of type Sequence containing
-        # three Split regexes (digits-of-1-to-3, CJK runs, then a GPT2-style fallback).
-        # Prior to honouring every Split in the Sequence, only the last regex was kept,
-        # which mistokenised plain English as a single byte token.
-        tokenizer = AutoTokenizer.from_pretrained(
-            "tencent/Hy-MT1.5-1.8B-2bit", use_fast=True, trust_remote_code=True)
-        text = ["Hello, world!", "The cat is sleeping.", "明天有雨。"]
+    def test_sequence_of_splits_pre_tokenizer(self):
+        # Regression test for a Sequence pre_tokenizer containing multiple Split
+        # regexes (HuggingFace allows this; models like tencent/Hy-MT1.5 ship one
+        # with three Splits). Prior to this fix, ort-extensions silently kept only
+        # the LAST Split in the Sequence, so any text matched by an earlier pattern
+        # was mis-tokenised. We build a tiny synthetic tokenizer here rather than
+        # downloading a remote model so the test is deterministic and offline.
+        import json as _json
+        import tempfile
 
-        ort_tok, _ = gen_processing_models(tokenizer, pre_kwargs={})
+        from tokenizers import Regex, Tokenizer, decoders, models, pre_tokenizers
+        from transformers import PreTrainedTokenizerFast
+
+        # Byte-level BPE vocab over the 256-char ByteLevel alphabet (gpt2-style
+        # mapping of raw bytes to printable code points). No merges -> every
+        # token is one byte, which makes the round-trip easy to reason about
+        # while still exercising the pre-tokeniser path end-to-end.
+        alphabet = pre_tokenizers.ByteLevel.alphabet()
+        vocab = {ch: i for i, ch in enumerate(sorted(alphabet))}
+        tok = Tokenizer(models.BPE(vocab=vocab, merges=[]))
+        # Sequence with two Isolated Splits: digit runs (1-3) and a GPT2-style
+        # word/whitespace pattern. The pre-fix bug would have dropped the digit
+        # rule and only kept the GPT2 one.
+        tok.pre_tokenizer = pre_tokenizers.Sequence([
+            pre_tokenizers.Split(Regex(r"\p{N}{1,3}"), behavior="isolated"),
+            pre_tokenizers.Split(
+                Regex(
+                    r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+"
+                ),
+                behavior="isolated",
+            ),
+            pre_tokenizers.ByteLevel(add_prefix_space=False, use_regex=False),
+        ])
+        tok.decoder = decoders.ByteLevel()
+        hf_tok = PreTrainedTokenizerFast(tokenizer_object=tok)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # gen_processing_models reads the saved tokenizer.json on disk.
+            hf_tok.save_pretrained(tmpdir)
+            # Sanity-check that the saved tokenizer.json really does have a
+            # Sequence with multiple Splits (otherwise this test would regress
+            # to the single-Split case and not exercise the bug).
+            with open(f"{tmpdir}/tokenizer.json", encoding="utf-8") as fh:
+                spec = _json.load(fh)
+            pretokens = spec["pre_tokenizer"]["pretokenizers"]
+            splits = [p for p in pretokens if p.get("type") == "Split"]
+            self.assertGreaterEqual(len(splits), 2)
+
+            reloaded = AutoTokenizer.from_pretrained(tmpdir)
+            ort_tok, _ = gen_processing_models(reloaded, pre_kwargs={})
+
+        # Mix of words and digit runs to exercise both Split patterns.
+        text = ["hello 123 world", "abc 42 def 9 ghi", "no digits here"]
         actual_ids, *_ = ort_inference(ort_tok, text)
+        pad_id = reloaded.pad_token_id  # may be None for tokenizers without an explicit pad
         for n, t in enumerate(text):
-            expected_ids = tokenizer.encode(t, return_tensors="np")
-            np.testing.assert_array_equal(
-                expected_ids[0], actual_ids[n][:expected_ids.shape[1]])
+            expected = reloaded.encode(t, return_tensors="np")[0]
+            row = actual_ids[n]
+            if pad_id is not None:
+                row = row[row != pad_id]
+            # Length must match exactly; a slice-then-compare would let extra
+            # trailing tokens pass silently.
+            self.assertEqual(
+                len(row),
+                len(expected),
+                f"Token count mismatch for {t!r}: ort={list(row)} hf={list(expected)}",
+            )
+            np.testing.assert_array_equal(expected, row)
 
 
 if __name__ == '__main__':

--- a/test/test_fast_tokenizer.py
+++ b/test/test_fast_tokenizer.py
@@ -53,5 +53,22 @@ class TestAutoTokenizer(unittest.TestCase):
                 raise
 
 
+    def test_hy_mt_sequence_of_splits(self):
+        # tencent/Hy-MT1.5-1.8B-2bit has a pre_tokenizer of type Sequence containing
+        # three Split regexes (digits-of-1-to-3, CJK runs, then a GPT2-style fallback).
+        # Prior to honouring every Split in the Sequence, only the last regex was kept,
+        # which mistokenised plain English as a single byte token.
+        tokenizer = AutoTokenizer.from_pretrained(
+            "tencent/Hy-MT1.5-1.8B-2bit", use_fast=True, trust_remote_code=True)
+        text = ["Hello, world!", "The cat is sleeping.", "明天有雨。"]
+
+        ort_tok, _ = gen_processing_models(tokenizer, pre_kwargs={})
+        actual_ids, *_ = ort_inference(ort_tok, text)
+        for n, t in enumerate(text):
+            expected_ids = tokenizer.encode(t, return_tensors="np")
+            np.testing.assert_array_equal(
+                expected_ids[0], actual_ids[n][:expected_ids.shape[1]])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem

When the HuggingFace `pre_tokenizer` is a `Sequence` of multiple `Split` nodes, the loader at `bpe_tokenizer_model.hpp:96-115` overwrites `pre_tokenizer_regex_` on every iteration and only the **last** Split survives. All earlier regexes are silently dropped.

This breaks tokenisers such as [`tencent/Hy-MT1.5-1.8B-2bit`](https://huggingface.co/tencent/Hy-MT1.5-1.8B-2bit), whose pre-tokenizer is:

```json
{"type": "Sequence", "pretokenizers": [
  {"type": "Split", "pattern": {"Regex": "\\\\p{N}{1,3}"}, "behavior": "Isolated"},
  {"type": "Split", "pattern": {"Regex": "[一-龥぀-ゟ゠-ヿ]+"}, "behavior": "Isolated"},
  {"type": "Split", "pattern": {"Regex": "[!\"#$%&'()*+,\\\\-./:;<=>?@\\\\[\\\\\\\\\\\\]^_\`{|}~][A-Za-z]+|..."}, "behavior": "Isolated"},
  {"type": "ByteLevel", ...}
]}
```


## Fix

When every Split has `behavior: "Isolated"`, applying them in sequence is equivalent to a single alternation `p1|p2|...|pN` — each chunk of the final segmentation matches exactly one of the patterns. `PreTokenizerWithRegEx::Compile` already accepts that union (fast-paths recognised sub-patterns, falls back to `std::regex` for the rest), so we simply concatenate the Splits with `|` instead of overwriting.

Unsupported behaviors (`Removed`, `MergedWith*`) are now rejected explicitly rather than silently producing wrong tokens.

## Test

Added a regression test `test_hy_mt_sequence_of_splits` in `test/test_fast_tokenizer.py` that loads the Hy-MT1.5 tokenizer and compares ORT-Extensions output against HuggingFace fast-tokenizer output for both English and Chinese inputs.

## Validation

End-to-end verified with a mobius-exported Hy-MT1.5-1.8B-2bit ONNX model running through ORT GenAI:
- Before: `"The cat is sleeping on the chair."` → `"<6c>"` (single byte token)
- After: `"The cat is sleeping on the chair."` → `"El gato está durmiendo en la silla."`
