### PR TITLE
Fix String Vector OOB Vulnerability

### DIFF
--- a/operators/text/string_to_vector.cc
+++ b/operators/text/string_to_vector.cc
@@ -96,6 +96,12 @@ size_t StringToVectorImpl::ParseVectorLen(const std::string_view& line) {
 void StringToVectorImpl::ParseValues(const std::string_view& v, std::vector<int64_t>& values) {
   std::vector<std::string_view> value_strs = SplitString(v, " ", true);
 
+  if (value_strs.size() != values.size()) {
+    ORTX_CXX_API_THROW(
+        MakeString("All map lines must have ", values.size(), " value columns; got ", value_strs.size()),
+        ORT_INVALID_ARGUMENT);
+  }
+
   int64_t value;
   for (size_t i = 0; i < value_strs.size(); i++) {
     auto [end, ec] = std::from_chars(value_strs[i].data(), value_strs[i].data() + value_strs[i].size(), value);

--- a/operators/text/vector_to_string.cc
+++ b/operators/text/vector_to_string.cc
@@ -106,6 +106,12 @@ size_t VectorToStringImpl::ParseVectorLen(const std::string_view& line) {
 void VectorToStringImpl::ParseValues(const std::string_view& v, std::vector<int64_t>& values) {
   std::vector<std::string_view> value_strs = SplitString(v, " ", true);
 
+  if (value_strs.size() != values.size()) {
+    ORTX_CXX_API_THROW(
+        MakeString("All map lines must have ", values.size(), " value columns; got ", value_strs.size()),
+        ORT_INVALID_ARGUMENT);
+  }
+
   int64_t value;
   for (size_t i = 0; i < value_strs.size(); i++) {
     auto [end, ec] = std::from_chars(value_strs[i].data(), value_strs[i].data() + value_strs[i].size(), value);

--- a/test/static_test/test_vector_string_parse.cc
+++ b/test/static_test/test_vector_string_parse.cc
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 #include "gtest/gtest.h"
+
+#ifdef ENABLE_TF_STRING
 #include "text/vector_to_string.hpp"
 #include "text/string_to_vector.hpp"
 
@@ -55,3 +57,5 @@ TEST(StringToVectorTest, ConsistentLineWidthsSucceeds) {
   std::string unk = "0 0 0";
   EXPECT_NO_THROW(StringToVectorImpl(map, unk));
 }
+
+#endif  // ENABLE_TF_STRING

--- a/test/static_test/test_vector_string_parse.cc
+++ b/test/static_test/test_vector_string_parse.cc
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "gtest/gtest.h"
+#include "text/vector_to_string.hpp"
+#include "text/string_to_vector.hpp"
+
+// Test that VectorToStringImpl rejects a map attribute where a later line has
+// more value columns than the first line (which would previously cause a heap
+// OOB write in ParseValues).
+TEST(VectorToStringTest, InconsistentLineWidthThrows) {
+  // First line has 1 value column, second line has 16 — must be rejected.
+  std::string map = "a\t1\nb\t1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16";
+  std::string unk = "unk";
+  EXPECT_THROW(VectorToStringImpl(map, unk), std::exception);
+}
+
+// Test that VectorToStringImpl rejects a map attribute where a later line has
+// fewer value columns than the first line.
+TEST(VectorToStringTest, FewerColumnsThrows) {
+  // First line has 3 value columns, second line has 1.
+  std::string map = "a\t1 2 3\nb\t4";
+  std::string unk = "unk";
+  EXPECT_THROW(VectorToStringImpl(map, unk), std::exception);
+}
+
+// Test that VectorToStringImpl succeeds with consistent line widths.
+TEST(VectorToStringTest, ConsistentLineWidthsSucceeds) {
+  std::string map = "a\t1 2 3\nb\t4 5 6\nc\t7 8 9";
+  std::string unk = "unk";
+  EXPECT_NO_THROW(VectorToStringImpl(map, unk));
+}
+
+// Test that StringToVectorImpl rejects a map attribute where a later line has
+// more value columns than the first line.
+TEST(StringToVectorTest, InconsistentLineWidthThrows) {
+  // First line has 1 value column, second line has 16.
+  std::string map = "a\t1\nb\t1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16";
+  std::string unk = "0";
+  EXPECT_THROW(StringToVectorImpl(map, unk), std::exception);
+}
+
+// Test that StringToVectorImpl rejects a map attribute where a later line has
+// fewer value columns than the first line.
+TEST(StringToVectorTest, FewerColumnsThrows) {
+  // First line has 3 value columns, second line has 1.
+  std::string map = "a\t1 2 3\nb\t4";
+  std::string unk = "0 0 0";
+  EXPECT_THROW(StringToVectorImpl(map, unk), std::exception);
+}
+
+// Test that StringToVectorImpl succeeds with consistent line widths.
+TEST(StringToVectorTest, ConsistentLineWidthsSucceeds) {
+  std::string map = "a\t1 2 3\nb\t4 5 6\nc\t7 8 9";
+  std::string unk = "0 0 0";
+  EXPECT_NO_THROW(StringToVectorImpl(map, unk));
+}


### PR DESCRIPTION
## Fix heap OOB write in VectorToStringImpl::ParseValues and StringToVectorImpl::ParseValues

### Summary

Adds a bounds check to `ParseValues` in both `VectorToStringImpl` and `StringToVectorImpl` to prevent a heap buffer overflow write when a crafted ONNX model supplies a `map` attribute with inconsistent line widths.

### Problem

`ParseMappingTable` derives `vector_len_` from the **first** line of the `map` attribute and allocates a fixed-size `std::vector<int64_t> values(vector_len_)`. It then calls `ParseValues` for every subsequent line using the same buffer. `ParseValues` iterates based on the **current** line's token count (`value_strs.size()`) and writes to `values[i]` without checking whether `i` is within bounds.

An attacker-authored model with a short first line and a longer later line triggers a linear heap OOB write of attacker-chosen `int64_t` values at session-creation time.

### Fix

Added a size check at the top of `ParseValues` in both files:

```cpp
if (value_strs.size() != values.size()) {
  ORTX_CXX_API_THROW(
      MakeString("All map lines must have ", values.size(), " value columns; got ", value_strs.size()),
      ORT_INVALID_ARGUMENT);
}
```

This enforces the invariant that every line in the map must have the same number of value columns as the first line, and throws before any write occurs if violated.

### Files changed

- `operators/text/vector_to_string.cc` — bounds check in `ParseValues`
- `operators/text/string_to_vector.cc` — bounds check in `ParseValues` (copy-paste sibling)
- `test/static_test/test_vector_string_parse.cc` — new unit tests

### Testing

6 new tests added to the `ocos_test` target covering both operators:
- Rejects map with more columns on a later line (the OOB trigger case)
- Rejects map with fewer columns on a later line
- Accepts map with consistent column widths

All 60 tests in `ocos_test` pass.
