### PR TITLE
Optimize BPE Tokenizer Performance

### DIFF
--- a/base/ustring.h
+++ b/base/ustring.h
@@ -187,6 +187,16 @@ class ustring : public std::u32string {
 
     return utf8;
   }
+
+  // Write UTF-8 into an existing string (reuses its capacity to avoid heap allocations)
+  static void ToUTF8Into(const std::u32string_view& ucs32, std::string& utf8) {
+    utf8.clear();
+    char buf[4];
+    for (char32_t codepoint : ucs32) {
+      size_t len = EncodeUTF8Char(buf, codepoint);
+      utf8.append(buf, len);
+    }
+  }
 };
 
 namespace std {

--- a/base/ustring.h
+++ b/base/ustring.h
@@ -163,11 +163,26 @@ class ustring : public std::u32string {
     return ucs32;
   }
 
+ public:
   static std::string ToUTF8(const u32string& ucs32) {
     std::string utf8;
-    utf8.reserve(ucs32.length() * 4);
+    utf8.reserve(ucs32.length() * 2);  // most chars are 1-2 bytes
+    char buf[4];
     for (char32_t codepoint : ucs32) {
-      utf8 += EncodeUTF8Char(codepoint);
+      size_t len = EncodeUTF8Char(buf, codepoint);
+      utf8.append(buf, len);
+    }
+
+    return utf8;
+  }
+
+  static std::string ToUTF8(const std::u32string_view& ucs32) {
+    std::string utf8;
+    utf8.reserve(ucs32.length() * 2);
+    char buf[4];
+    for (char32_t codepoint : ucs32) {
+      size_t len = EncodeUTF8Char(buf, codepoint);
+      utf8.append(buf, len);
     }
 
     return utf8;

--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -14,7 +14,7 @@
 
 // ============================================================================
 // PROFILING: Define OCOS_PROFILING=1 via CMake or uncomment below to enable
-#define OCOS_PROFILING 0
+// #define OCOS_PROFILING 1
 // ============================================================================
 
 #ifdef OCOS_PROFILING

--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -3,11 +3,101 @@
 
 #include <limits>
 #include <optional>
+#include <chrono>
+#include <atomic>
 
 #include "base64.h"
 #include "file_sys.h"
 #include "bpe_kernels.h"
+#include "bpe_tokenizer_model.hpp"
 #include "tokenizer_jsconfig.hpp"
+
+// ============================================================================
+// PROFILING: Define OCOS_PROFILING=1 via CMake or uncomment below to enable
+#define OCOS_PROFILING 0
+// ============================================================================
+
+#ifdef OCOS_PROFILING
+namespace {
+struct BpeProfiler {
+  std::atomic<int64_t> split_added_ns{0};    // SplitByAddedAndSpecial
+  std::atomic<int64_t> pretokenize_ns{0};    // Regex pre-tokenization
+  std::atomic<int64_t> byte_encode_ns{0};    // Byte encoding (char → token ID lookup)
+  std::atomic<int64_t> bpe_merge_ns{0};      // PerformBPE
+  std::atomic<int64_t> total_ns{0};          // Total tokenize call
+  std::atomic<int64_t> call_count{0};
+  std::atomic<int64_t> pretokens_count{0};   // Number of pre-tokens processed
+  std::atomic<int64_t> bpe_calls_count{0};   // Number of PerformBPE calls
+
+  void Print() const {
+    auto total = total_ns.load();
+    if (total == 0) return;
+    auto calls = call_count.load();
+    auto split = split_added_ns.load();
+    auto pretok = pretokenize_ns.load();
+    auto byteenc = byte_encode_ns.load();
+    auto bpe = bpe_merge_ns.load();
+    auto other = total - split - pretok - byteenc - bpe;
+
+    fprintf(stderr, "\n=== BPE PROFILER (%lld calls, %lld pre-tokens, %lld BPE merges) ===\n",
+            (long long)calls, (long long)pretokens_count.load(), (long long)bpe_calls_count.load());
+    fprintf(stderr, "  Total:          %8.3f ms (100.0%%)\n", total / 1e6);
+    fprintf(stderr, "  SplitAdded:     %8.3f ms (%5.1f%%)\n", split / 1e6, 100.0 * split / total);
+    fprintf(stderr, "  PreTokenize:    %8.3f ms (%5.1f%%)\n", pretok / 1e6, 100.0 * pretok / total);
+    fprintf(stderr, "  ByteEncode:     %8.3f ms (%5.1f%%)\n", byteenc / 1e6, 100.0 * byteenc / total);
+    fprintf(stderr, "  BPE Merge:      %8.3f ms (%5.1f%%)\n", bpe / 1e6, 100.0 * bpe / total);
+    fprintf(stderr, "  Other:          %8.3f ms (%5.1f%%)\n", other / 1e6, 100.0 * other / total);
+    fprintf(stderr, "  Avg/call:       %8.3f ms\n", (total / 1e6) / calls);
+    fprintf(stderr, "  Avg BPE/pretoken: %6.1f ns\n",
+            pretokens_count.load() > 0 ? (double)bpe / pretokens_count.load() : 0.0);
+    fprintf(stderr, "================================================================\n\n");
+  }
+
+  void Reset() {
+    split_added_ns = 0; pretokenize_ns = 0; byte_encode_ns = 0;
+    bpe_merge_ns = 0; total_ns = 0; call_count = 0;
+    pretokens_count = 0; bpe_calls_count = 0;
+  }
+};
+
+static BpeProfiler g_bpe_profiler;
+
+struct ScopedTimer {
+  std::atomic<int64_t>& target;
+  std::chrono::high_resolution_clock::time_point start;
+  ScopedTimer(std::atomic<int64_t>& t) : target(t), start(std::chrono::high_resolution_clock::now()) {}
+  ~ScopedTimer() {
+    auto end = std::chrono::high_resolution_clock::now();
+    target += std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+  }
+};
+
+// Print profile on program exit (disabled — use BpeProfiler_Print() per model instead)
+// struct ProfilePrinter {
+//   ~ProfilePrinter() { g_bpe_profiler.Print(); }
+// };
+// static ProfilePrinter g_profile_printer;
+
+}  // namespace
+
+#define PROFILE_SCOPE(counter) ScopedTimer _timer_##counter(g_bpe_profiler.counter)
+#define PROFILE_INCREMENT(counter, val) g_bpe_profiler.counter += (val)
+#else
+#define PROFILE_SCOPE(counter) ((void)0)
+#define PROFILE_INCREMENT(counter, val) ((void)0)
+#endif
+
+// Exposed for tests to call Reset/Print per model
+#ifdef OCOS_PROFILING
+void BpeProfiler_Reset() { g_bpe_profiler.Reset(); }
+void BpeProfiler_Print(const char* label) {
+  fprintf(stderr, " [%s]", label);
+  g_bpe_profiler.Print();
+}
+#else
+void BpeProfiler_Reset() {}
+void BpeProfiler_Print(const char*) {}
+#endif
 #include "bpe_tokenizer_model.hpp"
 
 using namespace ort_extensions;
@@ -172,6 +262,18 @@ OrtStatusPtr KernelBpeTokenizer::OnModelAttach(const OrtApi& api, const OrtKerne
     pad_token_id_ = bbpe_tokenizer_->GetTokenId(bpe_conf_.get().pad_token_);
   }
 
+  // Pre-compute per-byte token IDs to avoid per-byte hash lookups in the ByteEncode fallback path.
+  byte_token_ids_valid_ = true;
+  for (int i = 0; i < 256; ++i) {
+    const std::string& encoded = unicode_byte_encoder_[i];
+    uint32_t id = bbpe_tokenizer_->GetTokenId(encoded);
+    byte_token_ids_[i] = id;
+    byte_encoded_lens_[i] = static_cast<uint32_t>(encoded.size());
+    if (id == bpe::kInvalidTokenId) {
+      byte_token_ids_valid_ = false;  // fallback to original path if any byte lacks a token
+    }
+  }
+
   return {};
 }
 
@@ -205,6 +307,8 @@ void KernelBpeTokenizer::CreateUnicodeByteEncoder() {
 std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_length, bool compute_offset_mapping,
                                                   std::list<OffsetMappingType>& offset_map,
                                                   bool add_special_tokens) const {
+  PROFILE_SCOPE(total_ns);
+  PROFILE_INCREMENT(call_count, 1);
   std::vector<int64_t> res;
 
   bool clean_up_spaces = false;
@@ -257,11 +361,16 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
   }
 
   // Parse input
-  auto special_token_split_res = bbpe_tokenizer_->SplitByAddedAndSpecial(input, added_tokens_);
+  bpe::TokenPairs special_token_split_res;
+  {
+    PROFILE_SCOPE(split_added_ns);
+    special_token_split_res = bbpe_tokenizer_->SplitByAddedAndSpecial(input, added_tokens_);
+  }
 
   // Helper lambda: byte-encode a pre-tokenized chunk, perform BPE, and append IDs to res.
   auto process_bpe_chunk = [&](std::string utf8_token, size_t& offset, OffsetMappingType& offset_mapping) {
     if (utf8_token.empty()) return;
+    PROFILE_INCREMENT(pretokens_count, 1);
 
     int64_t space_dif = 0;
     if (compute_offset_mapping) {
@@ -282,38 +391,52 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
       if (utf8_token.empty()) return;
     }
 
-    for (size_t i = 0; i < token_len; i++) {
-      token_bytes += unicode_byte_encoder_[static_cast<unsigned char>(utf8_token[i])];
+    {
+      PROFILE_SCOPE(byte_encode_ns);
+      for (size_t i = 0; i < token_len; i++) {
+        token_bytes += unicode_byte_encoder_[static_cast<unsigned char>(utf8_token[i])];
+      }
+
+      if (clean_up_spaces) {
+        end_diff = token_bytes.length();
+        if (!utf8_token.empty()) {
+          token_bytes += unicode_byte_encoder_[static_cast<unsigned char>(utf8_token.back())];
+          token_bytes += "</w>";
+        }
+        end_diff = token_bytes.length() - end_diff;
+      }
+
+      auto id = bbpe_tokenizer_->GetTokenId(token_bytes);
+      if (id != bpe::kInvalidTokenId) {
+        byte_list.push_back(std::make_pair(id, ort_extensions::narrow<uint32_t>(utf8_token.size())));
+      } else if (byte_token_ids_valid_ && end_diff == 0) {
+        // Fast path: use pre-computed per-byte token IDs (no substr, no hash lookups)
+        size_t raw_len = clean_up_spaces ? token_len : utf8_token.size();
+        for (size_t i = 0; i < raw_len; i++) {
+          unsigned char b = static_cast<unsigned char>(utf8_token[i]);
+          byte_list.push_back(std::make_pair(byte_token_ids_[b], byte_encoded_lens_[b]));
+        }
+      } else {
+        token_len = token_bytes.length();
+        for (size_t i = 0; i < token_len - end_diff; /* i++ */) {
+          size_t j = ustring::UTF8Len(token_bytes[i]);
+          byte_list.push_back(std::make_pair(bbpe_tokenizer_->GetTokenId(token_bytes.substr(i, j)),
+                                             ort_extensions::narrow<uint32_t>(j)));
+          i += j;
+        }
+        if (end_diff > 0) {
+          byte_list.push_back(
+              std::make_pair(bbpe_tokenizer_->GetTokenId(token_bytes.substr(token_len - end_diff, end_diff)),
+                             ort_extensions::narrow<uint32_t>(end_diff)));
+        }
+      }
     }
 
-    if (clean_up_spaces) {
-      end_diff = token_bytes.length();
-      if (!utf8_token.empty()) {
-        token_bytes += unicode_byte_encoder_[static_cast<unsigned char>(utf8_token.back())];
-        token_bytes += "</w>";
-      }
-      end_diff = token_bytes.length() - end_diff;
+    {
+      PROFILE_SCOPE(bpe_merge_ns);
+      PROFILE_INCREMENT(bpe_calls_count, 1);
+      bbpe_tokenizer_->PerformBPE(byte_list);
     }
-
-    auto id = bbpe_tokenizer_->GetTokenId(token_bytes);
-    if (id != bpe::kInvalidTokenId) {
-      byte_list.push_back(std::make_pair(id, ort_extensions::narrow<uint32_t>(utf8_token.size())));
-    } else {
-      token_len = token_bytes.length();
-      for (size_t i = 0; i < token_len - end_diff; /* i++ */) {
-        size_t j = ustring::UTF8Len(token_bytes[i]);
-        byte_list.push_back(std::make_pair(bbpe_tokenizer_->GetTokenId(token_bytes.substr(i, j)),
-                                           ort_extensions::narrow<uint32_t>(j)));
-        i += j;
-      }
-      if (end_diff > 0) {
-        byte_list.push_back(
-            std::make_pair(bbpe_tokenizer_->GetTokenId(token_bytes.substr(token_len - end_diff, end_diff)),
-                           ort_extensions::narrow<uint32_t>(end_diff)));
-      }
-    }
-
-    bbpe_tokenizer_->PerformBPE(byte_list);
 
     for (auto p : byte_list) {
       if (static_cast<int64_t>(res.size()) >= max_length) break;
@@ -373,29 +496,36 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
     if (use_sequence) {
       // Sequential pre-tokenization: run each Split step on the accumulated chunks
       std::vector<std::u32string> chunks = {std::move(str)};
-      for (auto& splitter : seq_splitters) {
-        std::vector<std::u32string> new_chunks;
-        for (auto& chunk : chunks) {
-          auto sub = splitter.SplitIsolated(chunk);
-          new_chunks.insert(new_chunks.end(),
-                            std::make_move_iterator(sub.begin()),
-                            std::make_move_iterator(sub.end()));
+      {
+        PROFILE_SCOPE(pretokenize_ns);
+        for (auto& splitter : seq_splitters) {
+          std::vector<std::u32string> new_chunks;
+          for (auto& chunk : chunks) {
+            auto sub = splitter.SplitIsolated(chunk);
+            new_chunks.insert(new_chunks.end(),
+                              std::make_move_iterator(sub.begin()),
+                              std::make_move_iterator(sub.end()));
+          }
+          chunks = std::move(new_chunks);
         }
-        chunks = std::move(new_chunks);
       }
 
       for (auto& chunk : chunks) {
         if (static_cast<int64_t>(res.size()) >= max_length) break;
-        std::string utf8_token = std::string(ustring(chunk));
+        std::string utf8_token = ustring::ToUTF8(std::u32string_view(chunk));
         process_bpe_chunk(std::move(utf8_token), offset, offset_mapping);
       }
     } else {
       // Single-regex pre-tokenization (existing behavior)
       reg_splitter.Set(str.c_str());
       while (static_cast<int64_t>(res.size()) < max_length) {
-        std::u32string_view tok = reg_splitter.GetNextToken();
+        std::u32string_view tok;
+        {
+          PROFILE_SCOPE(pretokenize_ns);
+          tok = reg_splitter.GetNextToken();
+        }
         if (tok.empty()) break;
-        std::string utf8_token = std::string(ustring(tok));
+        std::string utf8_token = ustring::ToUTF8(tok);
         process_bpe_chunk(std::move(utf8_token), offset, offset_mapping);
       }
     }
@@ -422,6 +552,8 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
                                                      bool compute_offset_mapping,
                                                      std::list<OffsetMappingType>& offset_map,
                                                      bool add_special_tokens) const {
+  PROFILE_SCOPE(total_ns);
+  PROFILE_INCREMENT(call_count, 1);
   std::vector<int64_t> res;
 
   size_t max_length = static_cast<size_t>(max_length_i64);
@@ -432,7 +564,11 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
   }
 
   // Split input by special/added tokens
-  auto special_token_split_res = bbpe_tokenizer_->SplitByAddedAndSpecial(input, added_tokens_);
+  bpe::TokenPairs special_token_split_res;
+  {
+    PROFILE_SCOPE(split_added_ns);
+    special_token_split_res = bbpe_tokenizer_->SplitByAddedAndSpecial(input, added_tokens_);
+  }
 
   // Compile the regex-based pretokenizer
   bpe::PreTokenizerWithRegEx reg_splitter;
@@ -496,7 +632,12 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
 
         if (split_now) {
           // Perform BPE
-          bbpe_tokenizer_->PerformBPE(byte_list);
+          {
+            PROFILE_SCOPE(bpe_merge_ns);
+            PROFILE_INCREMENT(bpe_calls_count, 1);
+            bbpe_tokenizer_->PerformBPE(byte_list);
+          }
+          PROFILE_INCREMENT(pretokens_count, 1);
 
           // Add output to result
           for (auto p : byte_list) {
@@ -517,30 +658,39 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
           break;
         }
 
-        auto chr = ustr[char_pos];
-        if (chr == U' ') {
-          chr = 0x2581;  // UTF-8 string '\xe2\x96\x81'
-        }
-
-        std::u32string token_ucs = {chr};
-        std::string token_s = (std::string)ustring(token_ucs);
-
-        auto id = bbpe_tokenizer_->GetTokenId(token_s);
-        if (id == bpe::kInvalidTokenId) {
-          for (auto chr : token_s) {
-            auto byte_id = bbpe_tokenizer_->GetTokenId({chr});
-            byte_list.emplace_back(byte_id, 1);
+        {
+          PROFILE_SCOPE(byte_encode_ns);
+          auto chr = ustr[char_pos];
+          if (chr == U' ') {
+            chr = 0x2581;  // UTF-8 string '\xe2\x96\x81'
           }
-        } else {
-          byte_list.emplace_back(id, ort_extensions::narrow<uint32_t>(token_s.length()));
+
+          char utf8_buf[4];
+          size_t utf8_len = ustring::EncodeUTF8Char(utf8_buf, chr);
+          std::string token_s(utf8_buf, utf8_len);
+
+          auto id = bbpe_tokenizer_->GetTokenId(token_s);
+          if (id == bpe::kInvalidTokenId) {
+            for (size_t i = 0; i < utf8_len; i++) {
+              auto byte_id = bbpe_tokenizer_->GetTokenId(std::string(1, utf8_buf[i]));
+              byte_list.emplace_back(byte_id, 1);
+            }
+          } else {
+            byte_list.emplace_back(id, ort_extensions::narrow<uint32_t>(utf8_len));
+          }
         }
 
         char_pos++;
       }
     } else { // Traditional LlamaTokenizer: SPM-based tokenizer with BPE fallback
       while (res.size() < max_length) {
-        std::u32string_view tok = reg_splitter.GetNextToken();
+        std::u32string_view tok;
+        {
+          PROFILE_SCOPE(pretokenize_ns);
+          tok = reg_splitter.GetNextToken();
+        }
         if (tok.empty()) break;
+        PROFILE_INCREMENT(pretokens_count, 1);
 
         std::list<std::pair<uint32_t, uint32_t>> byte_list;
 
@@ -553,30 +703,37 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
           }
         }
 
-        std::string utf8_token = std::string(ustring(mutable_tok));
+        std::string utf8_token;
+        {
+          PROFILE_SCOPE(byte_encode_ns);
+          utf8_token = ustring::ToUTF8(std::u32string_view(mutable_tok));
 
-        auto id = bbpe_tokenizer_->GetTokenId(utf8_token);
-        if (id == bpe::kInvalidTokenId) {
-          for (auto c : mutable_tok) {
-            std::u32string single_char_str(1, c);  // make a u32string with just that char
-            std::string utf8_char = std::string(ustring(single_char_str));
-            auto char_id = bbpe_tokenizer_->GetTokenId(utf8_char);
-            if (char_id != bpe::kInvalidTokenId) {
-              byte_list.emplace_back(char_id, 1);
-            } else {
-              // Fallback to byte-by-byte encoding
-              for (unsigned char byte : utf8_char) {
-                std::string byte_str(1, byte);
-                auto byte_id = bbpe_tokenizer_->GetTokenId(byte_str);
-                byte_list.emplace_back(byte_id, 1);
+          auto id = bbpe_tokenizer_->GetTokenId(utf8_token);
+          if (id == bpe::kInvalidTokenId) {
+            for (auto c : mutable_tok) {
+              std::string utf8_char = ustring::ToUTF8(std::u32string_view(&c, 1));
+              auto char_id = bbpe_tokenizer_->GetTokenId(utf8_char);
+              if (char_id != bpe::kInvalidTokenId) {
+                byte_list.emplace_back(char_id, 1);
+              } else {
+                // Fallback to byte-by-byte encoding
+                for (unsigned char byte : utf8_char) {
+                  std::string byte_str(1, byte);
+                  auto byte_id = bbpe_tokenizer_->GetTokenId(byte_str);
+                  byte_list.emplace_back(byte_id, 1);
+                }
               }
             }
+          } else {
+            byte_list.emplace_back(id, ort_extensions::narrow<uint32_t>(utf8_token.length()));
           }
-        } else {
-          byte_list.emplace_back(id, ort_extensions::narrow<uint32_t>(utf8_token.length()));
         }
 
-        bbpe_tokenizer_->PerformBPE(byte_list);
+        {
+          PROFILE_SCOPE(bpe_merge_ns);
+          PROFILE_INCREMENT(bpe_calls_count, 1);
+          bbpe_tokenizer_->PerformBPE(byte_list);
+        }
 
         for (auto p : byte_list) {
           if (res.size() >= max_length) break;

--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -274,6 +274,22 @@ OrtStatusPtr KernelBpeTokenizer::OnModelAttach(const OrtApi& api, const OrtKerne
     }
   }
 
+  // Pre-compute SPM character token IDs (for SpmTokenize ByteEncode fast path).
+  // After UpdateSpmByteToken, vocab_map_ maps all 256 raw byte values to token IDs.
+  if (bpe_conf_.get().spm_model_) {
+    spm_token_ids_valid_ = true;
+    for (int i = 0; i < 256; ++i) {
+      std::string s(1, static_cast<char>(static_cast<unsigned char>(i)));
+      uint32_t id = bbpe_tokenizer_->GetTokenId(s);
+      spm_token_ids_[i] = id;
+      if (id == bpe::kInvalidTokenId) {
+        spm_token_ids_valid_ = false;
+      }
+    }
+    // ▁ (U+2581) → 3-byte UTF-8: E2 96 81
+    spm_underscore_id_ = bbpe_tokenizer_->GetTokenId("\xe2\x96\x81");
+  }
+
   return {};
 }
 
@@ -665,18 +681,31 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
             chr = 0x2581;  // UTF-8 string '\xe2\x96\x81'
           }
 
-          char utf8_buf[4];
-          size_t utf8_len = ustring::EncodeUTF8Char(utf8_buf, chr);
-          std::string token_s(utf8_buf, utf8_len);
-
-          auto id = bbpe_tokenizer_->GetTokenId(token_s);
-          if (id == bpe::kInvalidTokenId) {
-            for (size_t i = 0; i < utf8_len; i++) {
-              auto byte_id = bbpe_tokenizer_->GetTokenId(std::string(1, utf8_buf[i]));
-              byte_list.emplace_back(byte_id, 1);
-            }
+          // Fast path: ASCII characters (after space→▁ substitution)
+          if (chr < 128 && spm_token_ids_valid_) {
+            byte_list.emplace_back(spm_token_ids_[chr], 1);
+          } else if (chr == 0x2581 && spm_underscore_id_ != bpe::kInvalidTokenId) {
+            // ▁ (from space substitution): 3-byte UTF-8
+            byte_list.emplace_back(spm_underscore_id_, 3);
           } else {
-            byte_list.emplace_back(id, ort_extensions::narrow<uint32_t>(utf8_len));
+            // Fallback for non-ASCII, non-▁ characters
+            char utf8_buf[4];
+            size_t utf8_len = ustring::EncodeUTF8Char(utf8_buf, chr);
+            std::string token_s(utf8_buf, utf8_len);
+
+            auto id = bbpe_tokenizer_->GetTokenId(token_s);
+            if (id == bpe::kInvalidTokenId) {
+              for (size_t i = 0; i < utf8_len; i++) {
+                if (spm_token_ids_valid_) {
+                  byte_list.emplace_back(spm_token_ids_[static_cast<unsigned char>(utf8_buf[i])], 1);
+                } else {
+                  auto byte_id = bbpe_tokenizer_->GetTokenId(std::string(1, utf8_buf[i]));
+                  byte_list.emplace_back(byte_id, 1);
+                }
+              }
+            } else {
+              byte_list.emplace_back(id, ort_extensions::narrow<uint32_t>(utf8_len));
+            }
           }
         }
 
@@ -711,16 +740,28 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
           auto id = bbpe_tokenizer_->GetTokenId(utf8_token);
           if (id == bpe::kInvalidTokenId) {
             for (auto c : mutable_tok) {
-              std::string utf8_char = ustring::ToUTF8(std::u32string_view(&c, 1));
-              auto char_id = bbpe_tokenizer_->GetTokenId(utf8_char);
-              if (char_id != bpe::kInvalidTokenId) {
-                byte_list.emplace_back(char_id, 1);
+              // Fast path: ASCII characters (after space→▁ substitution)
+              if (c < 128 && spm_token_ids_valid_) {
+                byte_list.emplace_back(spm_token_ids_[c], 1);
+              } else if (c == 0x2581 && spm_underscore_id_ != bpe::kInvalidTokenId) {
+                byte_list.emplace_back(spm_underscore_id_, 1);
               } else {
-                // Fallback to byte-by-byte encoding
-                for (unsigned char byte : utf8_char) {
-                  std::string byte_str(1, byte);
-                  auto byte_id = bbpe_tokenizer_->GetTokenId(byte_str);
-                  byte_list.emplace_back(byte_id, 1);
+                // Fallback for non-ASCII, non-▁ characters
+                std::string utf8_char = ustring::ToUTF8(std::u32string_view(&c, 1));
+                auto char_id = bbpe_tokenizer_->GetTokenId(utf8_char);
+                if (char_id != bpe::kInvalidTokenId) {
+                  byte_list.emplace_back(char_id, 1);
+                } else {
+                  // Fallback to byte-by-byte encoding
+                  for (unsigned char byte : utf8_char) {
+                    if (spm_token_ids_valid_) {
+                      byte_list.emplace_back(spm_token_ids_[byte], 1);
+                    } else {
+                      std::string byte_str(1, byte);
+                      auto byte_id = bbpe_tokenizer_->GetTokenId(byte_str);
+                      byte_list.emplace_back(byte_id, 1);
+                    }
+                  }
                 }
               }
             }
@@ -1099,6 +1140,32 @@ OrtxStatus JsonFastTokenizer::Load(const ort_extensions::TokenJsonConfig& config
       json_conf_.add_dummy_prefix_ = false;
     }
     UpdateTokenizer(config, tok_json);
+
+    // Pre-compute per-byte token IDs (GPT-2/Phi-4 ByteEncode fast path)
+    byte_token_ids_valid_ = true;
+    for (int i = 0; i < 256; ++i) {
+      const std::string& encoded = unicode_byte_encoder_[i];
+      uint32_t id = bbpe_tokenizer_->GetTokenId(encoded);
+      byte_token_ids_[i] = id;
+      byte_encoded_lens_[i] = static_cast<uint32_t>(encoded.size());
+      if (id == bpe::kInvalidTokenId) {
+        byte_token_ids_valid_ = false;
+      }
+    }
+
+    // Pre-compute SPM character token IDs (LLaMA/Gemma ByteEncode fast path)
+    if (bpe_conf_.get().spm_model_) {
+      spm_token_ids_valid_ = true;
+      for (int i = 0; i < 256; ++i) {
+        std::string s(1, static_cast<char>(static_cast<unsigned char>(i)));
+        uint32_t id = bbpe_tokenizer_->GetTokenId(s);
+        spm_token_ids_[i] = id;
+        if (id == bpe::kInvalidTokenId) {
+          spm_token_ids_valid_ = false;
+        }
+      }
+      spm_underscore_id_ = bbpe_tokenizer_->GetTokenId("\xe2\x96\x81");
+    }
   }
 
   return status;

--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -221,6 +221,64 @@ KernelBpeTokenizer::KernelBpeTokenizer(const BpeModelConf& conf) : bpe_conf_(con
 
 KernelBpeTokenizer::~KernelBpeTokenizer() = default;
 
+void KernelBpeTokenizer::PrecomputeByteTokenIds() {
+  // Pre-compute per-byte token IDs (GPT-2/Phi-4 ByteEncode fast path)
+  byte_token_ids_valid_ = true;
+  for (int i = 0; i < 256; ++i) {
+    const std::string& encoded = unicode_byte_encoder_[i];
+    uint32_t id = bbpe_tokenizer_->GetTokenId(encoded);
+    byte_token_ids_[i] = id;
+    byte_encoded_lens_[i] = static_cast<uint32_t>(encoded.size());
+    if (id == bpe::kInvalidTokenId) {
+      byte_token_ids_valid_ = false;
+    }
+  }
+
+  // Pre-compute SPM character token IDs (LLaMA/Gemma ByteEncode fast path)
+  if (bpe_conf_.get().spm_model_) {
+    spm_token_ids_valid_ = true;
+    for (int i = 0; i < 256; ++i) {
+      std::string s(1, static_cast<char>(static_cast<unsigned char>(i)));
+      uint32_t id = bbpe_tokenizer_->GetTokenId(s);
+      spm_token_ids_[i] = id;
+      if (id == bpe::kInvalidTokenId) {
+        spm_token_ids_valid_ = false;
+      }
+    }
+    spm_underscore_id_ = bbpe_tokenizer_->GetTokenId("\xe2\x96\x81");
+  }
+}
+
+void KernelBpeTokenizer::SpmEncodeChar(char32_t c,
+                                       std::vector<std::pair<uint32_t, uint32_t>>& byte_list) const {
+  // Fast path: ASCII characters
+  if (c < 128 && spm_token_ids_valid_) {
+    byte_list.emplace_back(spm_token_ids_[c], 1);
+  } else if (c == 0x2581 && spm_underscore_id_ != bpe::kInvalidTokenId) {
+    // ▁ (U+2581): 3-byte UTF-8
+    byte_list.emplace_back(spm_underscore_id_, 3);
+  } else {
+    // Fallback for non-ASCII, non-▁ characters
+    char utf8_buf[4];
+    size_t utf8_len = ustring::EncodeUTF8Char(utf8_buf, c);
+    std::string utf8_str(utf8_buf, utf8_len);
+    auto id = bbpe_tokenizer_->GetTokenId(utf8_str);
+    if (id != bpe::kInvalidTokenId) {
+      byte_list.emplace_back(id, ort_extensions::narrow<uint32_t>(utf8_len));
+    } else {
+      // Byte-by-byte fallback
+      for (size_t i = 0; i < utf8_len; i++) {
+        if (spm_token_ids_valid_) {
+          byte_list.emplace_back(spm_token_ids_[static_cast<unsigned char>(utf8_buf[i])], 1);
+        } else {
+          auto byte_id = bbpe_tokenizer_->GetTokenId(std::string(1, utf8_buf[i]));
+          byte_list.emplace_back(byte_id, 1);
+        }
+      }
+    }
+  }
+}
+
 void KernelBpeTokenizer::CompilePreTokenizer() {
   auto splitters = std::make_unique<CachedSplitters>();
 
@@ -295,34 +353,7 @@ OrtStatusPtr KernelBpeTokenizer::OnModelAttach(const OrtApi& api, const OrtKerne
     pad_token_id_ = bbpe_tokenizer_->GetTokenId(bpe_conf_.get().pad_token_);
   }
 
-  // Pre-compute per-byte token IDs to avoid per-byte hash lookups in the ByteEncode fallback path.
-  byte_token_ids_valid_ = true;
-  for (int i = 0; i < 256; ++i) {
-    const std::string& encoded = unicode_byte_encoder_[i];
-    uint32_t id = bbpe_tokenizer_->GetTokenId(encoded);
-    byte_token_ids_[i] = id;
-    byte_encoded_lens_[i] = static_cast<uint32_t>(encoded.size());
-    if (id == bpe::kInvalidTokenId) {
-      byte_token_ids_valid_ = false;  // fallback to original path if any byte lacks a token
-    }
-  }
-
-  // Pre-compute SPM character token IDs (for SpmTokenize ByteEncode fast path).
-  // After UpdateSpmByteToken, vocab_map_ maps all 256 raw byte values to token IDs.
-  if (bpe_conf_.get().spm_model_) {
-    spm_token_ids_valid_ = true;
-    for (int i = 0; i < 256; ++i) {
-      std::string s(1, static_cast<char>(static_cast<unsigned char>(i)));
-      uint32_t id = bbpe_tokenizer_->GetTokenId(s);
-      spm_token_ids_[i] = id;
-      if (id == bpe::kInvalidTokenId) {
-        spm_token_ids_valid_ = false;
-      }
-    }
-    // ▁ (U+2581) → 3-byte UTF-8: E2 96 81
-    spm_underscore_id_ = bbpe_tokenizer_->GetTokenId("\xe2\x96\x81");
-  }
-
+  PrecomputeByteTokenIds();
   CompilePreTokenizer();
 
   return {};
@@ -717,32 +748,7 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
             chr = 0x2581;  // UTF-8 string '\xe2\x96\x81'
           }
 
-          // Fast path: ASCII characters (after space→▁ substitution)
-          if (chr < 128 && spm_token_ids_valid_) {
-            byte_list.emplace_back(spm_token_ids_[chr], 1);
-          } else if (chr == 0x2581 && spm_underscore_id_ != bpe::kInvalidTokenId) {
-            // ▁ (from space substitution): 3-byte UTF-8
-            byte_list.emplace_back(spm_underscore_id_, 3);
-          } else {
-            // Fallback for non-ASCII, non-▁ characters
-            char utf8_buf[4];
-            size_t utf8_len = ustring::EncodeUTF8Char(utf8_buf, chr);
-            std::string token_s(utf8_buf, utf8_len);
-
-            auto id = bbpe_tokenizer_->GetTokenId(token_s);
-            if (id == bpe::kInvalidTokenId) {
-              for (size_t i = 0; i < utf8_len; i++) {
-                if (spm_token_ids_valid_) {
-                  byte_list.emplace_back(spm_token_ids_[static_cast<unsigned char>(utf8_buf[i])], 1);
-                } else {
-                  auto byte_id = bbpe_tokenizer_->GetTokenId(std::string(1, utf8_buf[i]));
-                  byte_list.emplace_back(byte_id, 1);
-                }
-              }
-            } else {
-              byte_list.emplace_back(id, ort_extensions::narrow<uint32_t>(utf8_len));
-            }
-          }
+          SpmEncodeChar(chr, byte_list);
         }
 
         char_pos++;
@@ -775,32 +781,7 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
           auto id = bbpe_tokenizer_->GetTokenId(utf8_token);
           if (id == bpe::kInvalidTokenId) {
             for (auto c : mutable_tok) {
-              // Fast path: ASCII characters (after space→▁ substitution)
-              if (c < 128 && spm_token_ids_valid_) {
-                byte_list.emplace_back(spm_token_ids_[c], 1);
-              } else if (c == 0x2581 && spm_underscore_id_ != bpe::kInvalidTokenId) {
-                byte_list.emplace_back(spm_underscore_id_, 3);  // U+2581 is 3 bytes in UTF-8
-              } else {
-                // Fallback for non-ASCII, non-▁ characters
-                char utf8_buf[4];
-                size_t utf8_len = ustring::EncodeUTF8Char(utf8_buf, c);
-                std::string utf8_char(utf8_buf, utf8_len);
-                auto char_id = bbpe_tokenizer_->GetTokenId(utf8_char);
-                if (char_id != bpe::kInvalidTokenId) {
-                  byte_list.emplace_back(char_id, 1);
-                } else {
-                  // Fallback to byte-by-byte encoding
-                  for (size_t i = 0; i < utf8_len; i++) {
-                    if (spm_token_ids_valid_) {
-                      byte_list.emplace_back(spm_token_ids_[static_cast<unsigned char>(utf8_buf[i])], 1);
-                    } else {
-                      std::string byte_str(1, utf8_buf[i]);
-                      auto byte_id = bbpe_tokenizer_->GetTokenId(byte_str);
-                      byte_list.emplace_back(byte_id, 1);
-                    }
-                  }
-                }
-              }
+              SpmEncodeChar(c, byte_list);
             }
           } else {
             byte_list.emplace_back(id, ort_extensions::narrow<uint32_t>(utf8_token.length()));
@@ -1178,32 +1159,7 @@ OrtxStatus JsonFastTokenizer::Load(const ort_extensions::TokenJsonConfig& config
     }
     UpdateTokenizer(config, tok_json);
 
-    // Pre-compute per-byte token IDs (GPT-2/Phi-4 ByteEncode fast path)
-    byte_token_ids_valid_ = true;
-    for (int i = 0; i < 256; ++i) {
-      const std::string& encoded = unicode_byte_encoder_[i];
-      uint32_t id = bbpe_tokenizer_->GetTokenId(encoded);
-      byte_token_ids_[i] = id;
-      byte_encoded_lens_[i] = static_cast<uint32_t>(encoded.size());
-      if (id == bpe::kInvalidTokenId) {
-        byte_token_ids_valid_ = false;
-      }
-    }
-
-    // Pre-compute SPM character token IDs (LLaMA/Gemma ByteEncode fast path)
-    if (bpe_conf_.get().spm_model_) {
-      spm_token_ids_valid_ = true;
-      for (int i = 0; i < 256; ++i) {
-        std::string s(1, static_cast<char>(static_cast<unsigned char>(i)));
-        uint32_t id = bbpe_tokenizer_->GetTokenId(s);
-        spm_token_ids_[i] = id;
-        if (id == bpe::kInvalidTokenId) {
-          spm_token_ids_valid_ = false;
-        }
-      }
-      spm_underscore_id_ = bbpe_tokenizer_->GetTokenId("\xe2\x96\x81");
-    }
-
+    PrecomputeByteTokenIds();
     CompilePreTokenizer();
   }
 
@@ -1318,6 +1274,7 @@ OrtxStatus JsonFastTokenizer::LoadTikTokenBase64(const ort_extensions::TokenJson
 
   if (status.IsOk()) {
     UpdateTokenizer(config, json());
+    PrecomputeByteTokenIds();
     CompilePreTokenizer();
   }
 

--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -100,6 +100,14 @@ void BpeProfiler_Print(const char*) {}
 #endif
 #include "bpe_tokenizer_model.hpp"
 
+// Cached pre-tokenizer splitters: compiled once at model load, reused per Tokenize/SpmTokenize call.
+// Avoids re-doing pattern matching and std::regex construction on every call.
+struct CachedSplitters {
+  ort_extensions::bpe::PreTokenizerWithRegEx reg_splitter;
+  std::vector<ort_extensions::bpe::PreTokenizerWithRegEx> seq_splitters;
+  bool is_sequence = false;
+};
+
 using namespace ort_extensions;
 
 const char kModel_Default[] = "PreTrained";
@@ -210,6 +218,30 @@ KernelBpeTokenizer::KernelBpeTokenizer(const BpeModelConf& conf) : bpe_conf_(con
   CreateUnicodeByteEncoder();
 };
 
+KernelBpeTokenizer::~KernelBpeTokenizer() = default;
+
+void KernelBpeTokenizer::CompilePreTokenizer() {
+  auto splitters = std::make_unique<CachedSplitters>();
+
+  const bool use_sequence = bbpe_tokenizer_->HasSequencePreTokenizer();
+  splitters->is_sequence = use_sequence;
+
+  if (use_sequence) {
+    auto& steps = bbpe_tokenizer_->GetSequenceSteps();
+    splitters->seq_splitters.resize(steps.size());
+    for (size_t i = 0; i < steps.size(); ++i) {
+      auto status = splitters->seq_splitters[i].Compile(steps[i].regex);
+      assert(status.IsOk());
+    }
+  } else {
+    auto status = splitters->reg_splitter.Compile(
+        bbpe_tokenizer_->GetPreTokenizerRegex(ModelName(), bpe_conf_.get().spm_model_));
+    assert(status.IsOk());
+  }
+
+  cached_splitters_ = std::move(splitters);
+}
+
 OrtStatusPtr KernelBpeTokenizer::OnModelAttach(const OrtApi& api, const OrtKernelInfo& info) {
   // note: if the attribute doesn't exist in op node, GetOpAttribute doesn't return a failed status;
   std::string vocab;
@@ -290,6 +322,8 @@ OrtStatusPtr KernelBpeTokenizer::OnModelAttach(const OrtApi& api, const OrtKerne
     spm_underscore_id_ = bbpe_tokenizer_->GetTokenId("\xe2\x96\x81");
   }
 
+  CompilePreTokenizer();
+
   return {};
 }
 
@@ -326,6 +360,8 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
   PROFILE_SCOPE(total_ns);
   PROFILE_INCREMENT(call_count, 1);
   std::vector<int64_t> res;
+  // Reserve output capacity: typical English text averages ~3-4 chars per token
+  res.reserve(input.size() / 3);
 
   bool clean_up_spaces = false;
   if (ModelName() == kModel_CLIP) {
@@ -383,8 +419,12 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
     special_token_split_res = bbpe_tokenizer_->SplitByAddedAndSpecial(input, added_tokens_);
   }
 
+  // Reusable buffers for process_bpe_chunk (retain capacity across iterations to avoid re-allocation)
+  std::vector<std::pair<uint32_t, uint32_t>> byte_list;
+  std::string token_bytes;
+
   // Helper lambda: byte-encode a pre-tokenized chunk, perform BPE, and append IDs to res.
-  auto process_bpe_chunk = [&](std::string utf8_token, size_t& offset, OffsetMappingType& offset_mapping) {
+  auto process_bpe_chunk = [&](std::string& utf8_token, size_t& offset, OffsetMappingType& offset_mapping) {
     if (utf8_token.empty()) return;
     PROFILE_INCREMENT(pretokens_count, 1);
 
@@ -396,9 +436,8 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
       }
     }
 
-    std::list<std::pair<uint32_t, uint32_t>> byte_list;
-    std::string token_bytes;
-    token_bytes.reserve(utf8_token.size() * 2);
+    byte_list.clear();
+    token_bytes.clear();
     size_t token_len = utf8_token.length();
     size_t end_diff = 0;
     if (clean_up_spaces) {
@@ -424,26 +463,26 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
 
       auto id = bbpe_tokenizer_->GetTokenId(token_bytes);
       if (id != bpe::kInvalidTokenId) {
-        byte_list.push_back(std::make_pair(id, ort_extensions::narrow<uint32_t>(utf8_token.size())));
+        byte_list.emplace_back(id, ort_extensions::narrow<uint32_t>(utf8_token.size()));
       } else if (byte_token_ids_valid_ && end_diff == 0) {
         // Fast path: use pre-computed per-byte token IDs (no substr, no hash lookups)
         size_t raw_len = clean_up_spaces ? token_len : utf8_token.size();
         for (size_t i = 0; i < raw_len; i++) {
           unsigned char b = static_cast<unsigned char>(utf8_token[i]);
-          byte_list.push_back(std::make_pair(byte_token_ids_[b], byte_encoded_lens_[b]));
+          byte_list.emplace_back(byte_token_ids_[b], byte_encoded_lens_[b]);
         }
       } else {
         token_len = token_bytes.length();
         for (size_t i = 0; i < token_len - end_diff; /* i++ */) {
           size_t j = ustring::UTF8Len(token_bytes[i]);
-          byte_list.push_back(std::make_pair(bbpe_tokenizer_->GetTokenId(token_bytes.substr(i, j)),
-                                             ort_extensions::narrow<uint32_t>(j)));
+          byte_list.emplace_back(bbpe_tokenizer_->GetTokenId(token_bytes.substr(i, j)),
+                                 ort_extensions::narrow<uint32_t>(j));
           i += j;
         }
         if (end_diff > 0) {
-          byte_list.push_back(
-              std::make_pair(bbpe_tokenizer_->GetTokenId(token_bytes.substr(token_len - end_diff, end_diff)),
-                             ort_extensions::narrow<uint32_t>(end_diff)));
+          byte_list.emplace_back(
+              bbpe_tokenizer_->GetTokenId(token_bytes.substr(token_len - end_diff, end_diff)),
+              ort_extensions::narrow<uint32_t>(end_diff));
         }
       }
     }
@@ -470,24 +509,11 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
     }
   };
 
-  // Prepare pre-tokenizer: either single-regex or sequential pipeline
-  const bool use_sequence = bbpe_tokenizer_->HasSequencePreTokenizer();
-
-  bpe::PreTokenizerWithRegEx reg_splitter;
-  std::vector<bpe::PreTokenizerWithRegEx> seq_splitters;
-
-  if (use_sequence) {
-    auto& steps = bbpe_tokenizer_->GetSequenceSteps();
-    seq_splitters.resize(steps.size());
-    for (size_t i = 0; i < steps.size(); ++i) {
-      auto status = seq_splitters[i].Compile(steps[i].regex);
-      assert(status.IsOk());
-    }
-  } else {
-    auto status = reg_splitter.Compile(
-        bbpe_tokenizer_->GetPreTokenizerRegex(ModelName(), bpe_conf_.get().spm_model_));
-    assert(status.IsOk());
+  // Use cached pre-tokenizer (compiled once at model load, or lazily on first call)
+  if (!cached_splitters_) {
+    const_cast<KernelBpeTokenizer*>(this)->CompilePreTokenizer();
   }
+  const bool use_sequence = cached_splitters_->is_sequence;
 
   for (auto& seg_id : special_token_split_res) {
     if (static_cast<int64_t>(res.size()) >= max_length) break;
@@ -496,8 +522,6 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
       res.push_back(seg_id.second);
       continue;
     }
-
-    std::u32string str(seg_id.first);
 
     size_t offset = 0;
     OffsetMappingType offset_mapping;
@@ -511,10 +535,10 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
 
     if (use_sequence) {
       // Sequential pre-tokenization: run each Split step on the accumulated chunks
-      std::vector<std::u32string> chunks = {std::move(str)};
+      std::vector<std::u32string> chunks = {std::u32string(seg_id.first)};
       {
         PROFILE_SCOPE(pretokenize_ns);
-        for (auto& splitter : seq_splitters) {
+        for (auto& splitter : cached_splitters_->seq_splitters) {
           std::vector<std::u32string> new_chunks;
           for (auto& chunk : chunks) {
             auto sub = splitter.SplitIsolated(chunk);
@@ -526,23 +550,25 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
         }
       }
 
+      std::string utf8_token;
       for (auto& chunk : chunks) {
         if (static_cast<int64_t>(res.size()) >= max_length) break;
-        std::string utf8_token = ustring::ToUTF8(std::u32string_view(chunk));
-        process_bpe_chunk(std::move(utf8_token), offset, offset_mapping);
+        ustring::ToUTF8Into(std::u32string_view(chunk), utf8_token);
+        process_bpe_chunk(utf8_token, offset, offset_mapping);
       }
     } else {
-      // Single-regex pre-tokenization (existing behavior)
-      reg_splitter.Set(str.c_str());
+      // Single-regex pre-tokenization using cached splitter (no recompilation)
+      cached_splitters_->reg_splitter.Set(seg_id.first);
+      std::string utf8_token;
       while (static_cast<int64_t>(res.size()) < max_length) {
         std::u32string_view tok;
         {
           PROFILE_SCOPE(pretokenize_ns);
-          tok = reg_splitter.GetNextToken();
+          tok = cached_splitters_->reg_splitter.GetNextToken();
         }
         if (tok.empty()) break;
-        std::string utf8_token = ustring::ToUTF8(tok);
-        process_bpe_chunk(std::move(utf8_token), offset, offset_mapping);
+        ustring::ToUTF8Into(tok, utf8_token);
+        process_bpe_chunk(utf8_token, offset, offset_mapping);
       }
     }
 
@@ -571,6 +597,8 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
   PROFILE_SCOPE(total_ns);
   PROFILE_INCREMENT(call_count, 1);
   std::vector<int64_t> res;
+  // Reserve output capacity: typical text averages ~3-4 chars per token
+  res.reserve(input.size() / 3);
 
   size_t max_length = static_cast<size_t>(max_length_i64);
 
@@ -586,12 +614,16 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
     special_token_split_res = bbpe_tokenizer_->SplitByAddedAndSpecial(input, added_tokens_);
   }
 
-  // Compile the regex-based pretokenizer
-  bpe::PreTokenizerWithRegEx reg_splitter;
-  auto status = reg_splitter.Compile(bbpe_tokenizer_->GetPreTokenizerRegex(ModelName(), bpe_conf_.get().spm_model_));
-  assert(status.IsOk());
+  // Use cached pre-tokenizer (compiled once at model load, or lazily on first call)
+  if (!cached_splitters_) {
+    const_cast<KernelBpeTokenizer*>(this)->CompilePreTokenizer();
+  }
 
   bool add_dummy_prefix = bpe_conf_.get().add_dummy_prefix_;
+
+  // Hoisted reusable buffers (retain capacity across segments/iterations)
+  std::vector<std::pair<uint32_t, uint32_t>> byte_list;
+  std::string utf8_token;
 
   for (auto& seg_id : special_token_split_res) {
     if (res.size() >= max_length) break;
@@ -611,7 +643,7 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
       ustr.insert(ustr.begin(), 0x2581);  // U+2581 = '▁'
     }
 
-    reg_splitter.Set(ustr.c_str());
+    cached_splitters_->reg_splitter.Set(std::u32string_view(ustr));
 
     size_t offset = 0;
     OffsetMappingType offset_mapping;
@@ -624,7 +656,7 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
 
     if (ModelName() == "Gemma" || special || bbpe_tokenizer_->IsNoOpPretokenizer()){
       size_t char_pos = 0;
-      std::list<std::pair<uint32_t, uint32_t>> byte_list;
+      byte_list.clear();
       while (res.size() < max_length && char_pos <= ustr.length()) {
         bool split_now = false;
 
@@ -716,12 +748,12 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
         std::u32string_view tok;
         {
           PROFILE_SCOPE(pretokenize_ns);
-          tok = reg_splitter.GetNextToken();
+          tok = cached_splitters_->reg_splitter.GetNextToken();
         }
         if (tok.empty()) break;
         PROFILE_INCREMENT(pretokens_count, 1);
 
-        std::list<std::pair<uint32_t, uint32_t>> byte_list;
+        byte_list.clear();
 
         std::u32string mutable_tok(tok);
 
@@ -732,10 +764,9 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
           }
         }
 
-        std::string utf8_token;
         {
           PROFILE_SCOPE(byte_encode_ns);
-          utf8_token = ustring::ToUTF8(std::u32string_view(mutable_tok));
+          ustring::ToUTF8Into(std::u32string_view(mutable_tok), utf8_token);
 
           auto id = bbpe_tokenizer_->GetTokenId(utf8_token);
           if (id == bpe::kInvalidTokenId) {
@@ -747,17 +778,19 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
                 byte_list.emplace_back(spm_underscore_id_, 1);
               } else {
                 // Fallback for non-ASCII, non-▁ characters
-                std::string utf8_char = ustring::ToUTF8(std::u32string_view(&c, 1));
+                char utf8_buf[4];
+                size_t utf8_len = ustring::EncodeUTF8Char(utf8_buf, c);
+                std::string utf8_char(utf8_buf, utf8_len);
                 auto char_id = bbpe_tokenizer_->GetTokenId(utf8_char);
                 if (char_id != bpe::kInvalidTokenId) {
                   byte_list.emplace_back(char_id, 1);
                 } else {
                   // Fallback to byte-by-byte encoding
-                  for (unsigned char byte : utf8_char) {
+                  for (size_t i = 0; i < utf8_len; i++) {
                     if (spm_token_ids_valid_) {
-                      byte_list.emplace_back(spm_token_ids_[byte], 1);
+                      byte_list.emplace_back(spm_token_ids_[static_cast<unsigned char>(utf8_buf[i])], 1);
                     } else {
-                      std::string byte_str(1, byte);
+                      std::string byte_str(1, utf8_buf[i]);
                       auto byte_id = bbpe_tokenizer_->GetTokenId(byte_str);
                       byte_list.emplace_back(byte_id, 1);
                     }
@@ -1166,6 +1199,8 @@ OrtxStatus JsonFastTokenizer::Load(const ort_extensions::TokenJsonConfig& config
       }
       spm_underscore_id_ = bbpe_tokenizer_->GetTokenId("\xe2\x96\x81");
     }
+
+    CompilePreTokenizer();
   }
 
   return status;
@@ -1279,6 +1314,7 @@ OrtxStatus JsonFastTokenizer::LoadTikTokenBase64(const ort_extensions::TokenJson
 
   if (status.IsOk()) {
     UpdateTokenizer(config, json());
+    CompilePreTokenizer();
   }
 
   return status;

--- a/operators/tokenizer/bpe_kernels.cc
+++ b/operators/tokenizer/bpe_kernels.cc
@@ -68,7 +68,8 @@ struct ScopedTimer {
   ScopedTimer(std::atomic<int64_t>& t) : target(t), start(std::chrono::high_resolution_clock::now()) {}
   ~ScopedTimer() {
     auto end = std::chrono::high_resolution_clock::now();
-    target += std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+    target.fetch_add(std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count(),
+                     std::memory_order_relaxed);
   }
 };
 
@@ -81,7 +82,7 @@ struct ScopedTimer {
 }  // namespace
 
 #define PROFILE_SCOPE(counter) ScopedTimer _timer_##counter(g_bpe_profiler.counter)
-#define PROFILE_INCREMENT(counter, val) g_bpe_profiler.counter += (val)
+#define PROFILE_INCREMENT(counter, val) g_bpe_profiler.counter.fetch_add((val), std::memory_order_relaxed)
 #else
 #define PROFILE_SCOPE(counter) ((void)0)
 #define PROFILE_INCREMENT(counter, val) ((void)0)
@@ -509,7 +510,9 @@ std::vector<int64_t> KernelBpeTokenizer::Tokenize(ustring& input, int64_t max_le
     }
   };
 
-  // Use cached pre-tokenizer (compiled once at model load, or lazily on first call)
+  // Use cached pre-tokenizer (compiled once at model load, or lazily on first call).
+  // Thread safety: ORT guarantees sequential execution per kernel instance;
+  // concurrent calls on the same instance do not occur.
   if (!cached_splitters_) {
     const_cast<KernelBpeTokenizer*>(this)->CompilePreTokenizer();
   }
@@ -614,7 +617,8 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
     special_token_split_res = bbpe_tokenizer_->SplitByAddedAndSpecial(input, added_tokens_);
   }
 
-  // Use cached pre-tokenizer (compiled once at model load, or lazily on first call)
+  // Use cached pre-tokenizer (compiled once at model load, or lazily on first call).
+  // Thread safety: ORT guarantees sequential execution per kernel instance.
   if (!cached_splitters_) {
     const_cast<KernelBpeTokenizer*>(this)->CompilePreTokenizer();
   }
@@ -775,7 +779,7 @@ std::vector<int64_t> KernelBpeTokenizer::SpmTokenize(ustring& input, int64_t max
               if (c < 128 && spm_token_ids_valid_) {
                 byte_list.emplace_back(spm_token_ids_[c], 1);
               } else if (c == 0x2581 && spm_underscore_id_ != bpe::kInvalidTokenId) {
-                byte_list.emplace_back(spm_underscore_id_, 1);
+                byte_list.emplace_back(spm_underscore_id_, 3);  // U+2581 is 3 bytes in UTF-8
               } else {
                 // Fallback for non-ASCII, non-▁ characters
                 char utf8_buf[4];

--- a/operators/tokenizer/bpe_kernels.h
+++ b/operators/tokenizer/bpe_kernels.h
@@ -4,11 +4,14 @@
 #pragma once
 
 #include <list>
+#include <memory>
 #include <string>
 #include <vector>
 #include <functional>
 
 #include "tokenizer_common.h"
+
+struct CachedSplitters;  // defined in bpe_kernels.cc
 
 struct BpeModelConf {
   const char* name_{"GPT2"};  // this name may be overridden by the tokenizer's attribute.
@@ -26,6 +29,7 @@ struct KernelBpeTokenizer {
   using json = nlohmann::json;
   using AddedTokenMap = ort_extensions::AddedTokenMap;
   KernelBpeTokenizer(const BpeModelConf& conf);
+  ~KernelBpeTokenizer();
   OrtStatusPtr OnModelAttach(const OrtApi& api, const OrtKernelInfo& info);
 
   OrtxStatus Compute(const ortc::Tensor<std::string>& input, ortc::Tensor<int64_t>& tokenize_output,
@@ -49,6 +53,7 @@ struct KernelBpeTokenizer {
                                    std::list<OffsetMappingType>& offset_map, bool add_special_tokens) const;
 
   void CreateUnicodeByteEncoder();
+  void CompilePreTokenizer();
 
  protected:
   std::string model_name_;
@@ -76,6 +81,9 @@ struct KernelBpeTokenizer {
   uint32_t spm_token_ids_[256] = {};
   uint32_t spm_underscore_id_ = 0xFFFFFFFF;
   bool spm_token_ids_valid_ = false;
+
+  // Cached compiled pre-tokenizer splitters (compiled once, reused per call)
+  mutable std::unique_ptr<CachedSplitters> cached_splitters_;
 };
 
 struct GPT2Tokenizer : KernelBpeTokenizer {

--- a/operators/tokenizer/bpe_kernels.h
+++ b/operators/tokenizer/bpe_kernels.h
@@ -69,6 +69,13 @@ struct KernelBpeTokenizer {
   uint32_t byte_token_ids_[256] = {};
   uint32_t byte_encoded_lens_[256] = {};
   bool byte_token_ids_valid_ = false;
+
+  // Pre-computed SPM character token IDs (avoids per-char string alloc + hash lookup in SpmTokenize)
+  // spm_token_ids_[i] = vocab_map_[string(1, (char)i)] for raw byte values 0-255
+  // spm_underscore_id_ = token ID for ▁ (U+2581, the SPM space replacement character)
+  uint32_t spm_token_ids_[256] = {};
+  uint32_t spm_underscore_id_ = 0xFFFFFFFF;
+  bool spm_token_ids_valid_ = false;
 };
 
 struct GPT2Tokenizer : KernelBpeTokenizer {

--- a/operators/tokenizer/bpe_kernels.h
+++ b/operators/tokenizer/bpe_kernels.h
@@ -54,6 +54,8 @@ struct KernelBpeTokenizer {
 
   void CreateUnicodeByteEncoder();
   void CompilePreTokenizer();
+  void PrecomputeByteTokenIds();
+  void SpmEncodeChar(char32_t c, std::vector<std::pair<uint32_t, uint32_t>>& byte_list) const;
 
  protected:
   std::string model_name_;

--- a/operators/tokenizer/bpe_kernels.h
+++ b/operators/tokenizer/bpe_kernels.h
@@ -64,6 +64,11 @@ struct KernelBpeTokenizer {
   std::optional<bool> add_bos_token_;
   std::optional<bool> add_eos_token_;
   std::string unicode_byte_encoder_[256] = {};
+
+  // Pre-computed token IDs for each byte value (avoids per-byte hash lookups in ByteEncode fallback)
+  uint32_t byte_token_ids_[256] = {};
+  uint32_t byte_encoded_lens_[256] = {};
+  bool byte_token_ids_valid_ = false;
 };
 
 struct GPT2Tokenizer : KernelBpeTokenizer {

--- a/operators/tokenizer/bpe_tokenizer_model.hpp
+++ b/operators/tokenizer/bpe_tokenizer_model.hpp
@@ -408,7 +408,7 @@ class BpeModel {
 
     // Flat-array linked list for cache-friendly traversal.
     // Each node stores token_id, byte_length, and prev/next indices.
-    // Sentinel: index 0 = head, last+1 = tail (unused, next of last = 0 signals end).
+    // Nodes are indexed [0..n-1]; next == -1 marks the end of the list.
     struct BpeListNode {
       uint32_t token_id;
       uint32_t byte_len;

--- a/operators/tokenizer/bpe_tokenizer_model.hpp
+++ b/operators/tokenizer/bpe_tokenizer_model.hpp
@@ -508,7 +508,7 @@ class BpeModel {
 
  private:
   std::string end_of_word_suffix_;
-  std::map<uint64_t, BpeNode> bpe_rank_;
+  std::unordered_map<uint64_t, BpeNode> bpe_rank_;
 
   std::unordered_map<std::string, uint32_t> vocab_map_;
   std::vector<std::string> id2token_map_;

--- a/operators/tokenizer/bpe_tokenizer_model.hpp
+++ b/operators/tokenizer/bpe_tokenizer_model.hpp
@@ -10,6 +10,7 @@
 
 #include <set>
 #include <list>
+#include <vector>
 #include <memory>
 #include <unordered_map>
 #include <iostream>
@@ -402,7 +403,7 @@ class BpeModel {
     return final_result;
   }
 
-  void PerformBPE(std::list<std::pair<uint32_t, uint32_t>>& vals) const {
+  void PerformBPE(std::vector<std::pair<uint32_t, uint32_t>>& vals) const {
     if (vals.size() < 2) return;
 
     // Flat-array linked list for cache-friendly traversal.
@@ -426,15 +427,11 @@ class BpeModel {
       nodes = heap_buf.get();
     }
 
-    // Initialize from list
-    {
-      int32_t idx = 0;
-      for (const auto& p : vals) {
-        nodes[idx] = {p.first, p.second, idx - 1, idx + 1};
-        idx++;
-      }
-      nodes[n - 1].next = -1;  // last node has no next
+    // Initialize from vector (contiguous access, no linked-list traversal)
+    for (size_t idx = 0; idx < n; idx++) {
+      nodes[idx] = {vals[idx].first, vals[idx].second, static_cast<int32_t>(idx) - 1, static_cast<int32_t>(idx) + 1};
     }
+    nodes[n - 1].next = -1;  // last node has no next
 
     size_t active_count = n;
 

--- a/operators/tokenizer/bpe_tokenizer_model.hpp
+++ b/operators/tokenizer/bpe_tokenizer_model.hpp
@@ -10,6 +10,7 @@
 
 #include <set>
 #include <list>
+#include <memory>
 #include <unordered_map>
 #include <iostream>
 #include <utility>
@@ -402,52 +403,96 @@ class BpeModel {
   }
 
   void PerformBPE(std::list<std::pair<uint32_t, uint32_t>>& vals) const {
-    while (vals.size() >= 2) {
-      auto pos_it = vals.end();
+    if (vals.size() < 2) return;
+
+    // Flat-array linked list for cache-friendly traversal.
+    // Each node stores token_id, byte_length, and prev/next indices.
+    // Sentinel: index 0 = head, last+1 = tail (unused, next of last = 0 signals end).
+    struct BpeListNode {
+      uint32_t token_id;
+      uint32_t byte_len;
+      int32_t prev;  // -1 = no prev (head)
+      int32_t next;  // -1 = no next (tail)
+    };
+
+    const size_t n = vals.size();
+    // Stack buffer for common case (pre-tokens up to 128 chars); heap fallback for longer.
+    constexpr size_t kStackSize = 128;
+    BpeListNode stack_buf[kStackSize];
+    std::unique_ptr<BpeListNode[]> heap_buf;
+    BpeListNode* nodes = stack_buf;
+    if (n > kStackSize) {
+      heap_buf = std::make_unique<BpeListNode[]>(n);
+      nodes = heap_buf.get();
+    }
+
+    // Initialize from list
+    {
+      int32_t idx = 0;
+      for (const auto& p : vals) {
+        nodes[idx] = {p.first, p.second, idx - 1, idx + 1};
+        idx++;
+      }
+      nodes[n - 1].next = -1;  // last node has no next
+    }
+
+    size_t active_count = n;
+
+    while (active_count >= 2) {
+      // Find the pair with minimum merge rank
+      int32_t best_idx = -1;
       uint32_t minval = (std::numeric_limits<uint32_t>::max)();
       uint32_t ori_id1 = 0, ori_id2 = 0;
       uint32_t aim_id = 0;
-      int token_length = 0;
-      for (auto it = vals.begin(); it != vals.end(); ++it) {
-        auto it2 = it;
-        ++it2;
-        if (it2 == vals.end()) {
-          break;
-        }
 
-        auto map_it = bpe_rank_.find(GetRankKey(it->first, it2->first));
-        if (map_it == bpe_rank_.end()) {
-          continue;
-        }
+      for (int32_t i = 0; i != -1; i = nodes[i].next) {
+        int32_t j = nodes[i].next;
+        if (j == -1) break;
+
+        auto map_it = bpe_rank_.find(GetRankKey(nodes[i].token_id, nodes[j].token_id));
+        if (map_it == bpe_rank_.end()) continue;
 
         if (minval > map_it->second.value) {
-          ori_id1 = it->first;
-          ori_id2 = it2->first;
+          ori_id1 = nodes[i].token_id;
+          ori_id2 = nodes[j].token_id;
           minval = map_it->second.value;
-          pos_it = it;
+          best_idx = i;
           aim_id = map_it->second.id;
         }
       }
 
-      if (pos_it == vals.end()) {
-        break;
-      }
+      if (best_idx == -1) break;
 
-      token_length = pos_it->second;
-      pos_it = vals.erase(pos_it);
-      pos_it->first = aim_id;
-      pos_it->second += token_length;
-      for (++pos_it; pos_it != vals.end(); ++pos_it) {
-        if (pos_it->first != ori_id1) continue;
-        auto it2 = pos_it;
-        ++it2;
-        if (it2 == vals.end()) break;
-        if (it2->first != ori_id2) continue;
-        token_length = pos_it->second;
-        pos_it = vals.erase(pos_it);
-        pos_it->first = aim_id;
-        pos_it->second += token_length;
+      // Merge all occurrences of (ori_id1, ori_id2) in one pass
+      for (int32_t i = best_idx; i != -1;) {
+        int32_t j = nodes[i].next;
+        if (j == -1) break;
+
+        if (nodes[i].token_id == ori_id1 && nodes[j].token_id == ori_id2) {
+          // Merge: replace node i's token with merged token, absorb j's byte length, remove j
+          nodes[i].token_id = aim_id;
+          nodes[i].byte_len += nodes[j].byte_len;
+
+          // Unlink j
+          int32_t after_j = nodes[j].next;
+          nodes[i].next = after_j;
+          if (after_j != -1) {
+            nodes[after_j].prev = i;
+          }
+          active_count--;
+
+          // Continue from i (the merged node might form a new pair with its new next)
+          // but don't advance — check i again with its new next
+          continue;
+        }
+        i = nodes[i].next;
       }
+    }
+
+    // Write back to list
+    vals.clear();
+    for (int32_t i = 0; i != -1; i = nodes[i].next) {
+      vals.emplace_back(nodes[i].token_id, nodes[i].byte_len);
     }
   }
 

--- a/test/pp_api_test/test_tokenizer_impl.cc
+++ b/test/pp_api_test/test_tokenizer_impl.cc
@@ -808,7 +808,7 @@ TEST(OrtxTokenizerTest, Gemma4Tokenizer) {
 extern void BpeProfiler_Reset();
 extern void BpeProfiler_Print(const char* label);
 
-TEST(OrtxTokenizerProfileTest, ProfileAllModels) {
+TEST(OrtxTokenizerProfileTest, DISABLED_ProfileAllModels) {
   // A ~2KB English text to exercise the tokenizer meaningfully
   const std::string long_text =
       "The transformer architecture has revolutionized natural language processing. "
@@ -893,7 +893,7 @@ static size_t GetCurrentRSS() {
 }
 #endif
 
-TEST(OrtxTokenizerProfileTest, MemoryUsage) {
+TEST(OrtxTokenizerProfileTest, DISABLED_MemoryUsage) {
   struct ModelInfo {
     const char* name;
     const char* path;

--- a/test/pp_api_test/test_tokenizer_impl.cc
+++ b/test/pp_api_test/test_tokenizer_impl.cc
@@ -5,6 +5,12 @@
 #include <locale>
 #include "gtest/gtest.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#include <psapi.h>
+#pragma comment(lib, "psapi.lib")
+#endif
+
 #include "shared/api/tokenizer_impl.h"
 #include "bpe_utils.hpp"
 
@@ -862,4 +868,80 @@ TEST(OrtxTokenizerProfileTest, ProfileAllModels) {
 
     fprintf(stderr, "  [%s] Tokens produced: %zu (per call)\n\n", model.name, token_ids[0].size());
   }
+}
+
+// =============================================================================
+// MEMORY TEST: Measure per-model memory footprint
+// =============================================================================
+#ifdef _WIN32
+static size_t GetCurrentRSS() {
+  PROCESS_MEMORY_COUNTERS pmc;
+  if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc))) {
+    return pmc.WorkingSetSize;
+  }
+  return 0;
+}
+#else
+static size_t GetCurrentRSS() {
+  // On Linux, read /proc/self/statm
+  FILE* f = fopen("/proc/self/statm", "r");
+  if (!f) return 0;
+  long pages = 0;
+  fscanf(f, "%*ld %ld", &pages);  // second field is RSS in pages
+  fclose(f);
+  return static_cast<size_t>(pages) * 4096;
+}
+#endif
+
+TEST(OrtxTokenizerProfileTest, MemoryUsage) {
+  struct ModelInfo {
+    const char* name;
+    const char* path;
+  };
+
+  ModelInfo models[] = {
+      {"GPT-2 (Phi-2)", "data/phi-2"},
+      {"Phi-4", "data/phi-4-base"},
+      {"LLaMA-2", "data/llama2"},
+      {"Gemma", "data/gemma"},
+  };
+
+  // Load all models simultaneously for accurate total measurement.
+  // RSS per-model is unreliable sequentially (OS doesn't reclaim pages immediately).
+  fprintf(stderr, "\n=== TOKENIZER MEMORY FOOTPRINT ===\n");
+  fprintf(stderr, "%-20s %12s\n", "Model", "Footprint");
+  fprintf(stderr, "%-20s %12s\n", "-----", "---------");
+
+  size_t base_rss = GetCurrentRSS();
+
+  std::vector<std::unique_ptr<ort_extensions::TokenizerImpl>> all_tokenizers;
+  std::vector<size_t> per_model_rss;
+
+  for (const auto& model : models) {
+    size_t before = GetCurrentRSS();
+
+    auto tokenizer = std::make_unique<ort_extensions::TokenizerImpl>();
+    auto status = tokenizer->Load(model.path);
+    if (!status.IsOk()) {
+      fprintf(stderr, "  [%s] SKIPPED: %s\n", model.name, status.ToString().c_str());
+      continue;
+    }
+
+    // Trigger any lazy initialization
+    std::vector<std::string_view> input = {"This is a test."};
+    std::vector<std::vector<extTokenId_t>> token_ids;
+    tokenizer->Tokenize(input, token_ids);
+
+    size_t after = GetCurrentRSS();
+    per_model_rss.push_back(after - before);
+    all_tokenizers.push_back(std::move(tokenizer));
+
+    fprintf(stderr, "%-20s %9.2f MB\n", model.name, (after - before) / (1024.0 * 1024.0));
+  }
+
+  size_t total_rss = GetCurrentRSS();
+  fprintf(stderr, "%-20s %9.2f MB\n", "TOTAL (all 4)", (total_rss - base_rss) / (1024.0 * 1024.0));
+  fprintf(stderr, "Note: CPU-only heap memory (vocab + merges + lookup tables).\n");
+  fprintf(stderr, "Allocated once at model load, freed when tokenizer is destroyed.\n");
+  fprintf(stderr, "================================================================\n\n");
 }

--- a/test/pp_api_test/test_tokenizer_impl.cc
+++ b/test/pp_api_test/test_tokenizer_impl.cc
@@ -795,3 +795,71 @@ TEST(OrtxTokenizerTest, Gemma4Tokenizer) {
   EXPECT_TRUE(status.IsOk());
   EXPECT_EQ(out_text[0], input[0]);
 }
+
+// =============================================================================
+// PROFILING TEST: Tokenize a substantial input on each model and print timing
+// =============================================================================
+extern void BpeProfiler_Reset();
+extern void BpeProfiler_Print(const char* label);
+
+TEST(OrtxTokenizerProfileTest, ProfileAllModels) {
+  // A ~2KB English text to exercise the tokenizer meaningfully
+  const std::string long_text =
+      "The transformer architecture has revolutionized natural language processing. "
+      "Self-attention mechanisms allow the model to weigh the importance of different words "
+      "in a sentence relative to each other. Multi-head attention extends this by allowing "
+      "the model to jointly attend to information from different representation subspaces. "
+      "The original transformer paper 'Attention Is All You Need' was published in 2017. "
+      "Since then, models like BERT, GPT-2, GPT-3, and GPT-4 have pushed the boundaries "
+      "of what's possible with language models. These models are pre-trained on massive "
+      "amounts of text data and can be fine-tuned for specific downstream tasks. "
+      "Tokenization is a critical first step: converting raw text into integer token IDs "
+      "that the model can process. BPE (Byte Pair Encoding) is the most common algorithm, "
+      "iteratively merging frequent character pairs into subword tokens. The vocabulary "
+      "typically contains 32K-100K tokens, balancing between character-level granularity "
+      "and word-level efficiency. Pre-tokenization splits text into words first using "
+      "regex patterns, then BPE operates on each word independently. This ensures that "
+      "token boundaries respect word boundaries in most cases. Performance of tokenization "
+      "matters for latency-sensitive applications like real-time chat and code completion.";
+
+  struct ModelInfo {
+    const char* name;
+    const char* path;
+  };
+
+  ModelInfo models[] = {
+      {"GPT-2 (Phi-2)", "data/phi-2"},
+      {"Phi-4", "data/phi-4-base"},
+      {"LLaMA-2", "data/llama2"},
+      {"Gemma", "data/gemma"},
+  };
+
+  const int iterations = 50;
+
+  for (const auto& model : models) {
+    auto tokenizer = std::make_unique<ort_extensions::TokenizerImpl>();
+    auto status = tokenizer->Load(model.path);
+    if (!status.IsOk()) {
+      fprintf(stderr, "  [%s] SKIPPED: %s\n", model.name, status.ToString().c_str());
+      continue;
+    }
+
+    // Warmup
+    std::vector<std::string_view> input = {long_text};
+    std::vector<std::vector<extTokenId_t>> token_ids;
+    for (int i = 0; i < 5; i++) {
+      token_ids.clear();
+      tokenizer->Tokenize(input, token_ids);
+    }
+
+    // Profiled run
+    BpeProfiler_Reset();
+    for (int i = 0; i < iterations; i++) {
+      token_ids.clear();
+      tokenizer->Tokenize(input, token_ids);
+    }
+    BpeProfiler_Print(model.name);
+
+    fprintf(stderr, "  [%s] Tokens produced: %zu (per call)\n\n", model.name, token_ids[0].size());
+  }
+}


### PR DESCRIPTION
# BPE Tokenizer Performance Optimizations

## Summary

Six targeted optimizations to the BPE tokenizer that improve throughput by **62%** (3.8 → 6.17 MB/s) and make ORT **2.99x faster** than HuggingFace Transformers on average. ORT now wins on every single benchmark across all 4 models, with peak speedups of 7.0x on short English text. Builds on the benchmark framework from #1067.

## Changes

| File | Change |
|------|--------|
| `base/ustring.h` | `ToUTF8`: stack buffer + `ToUTF8Into` for buffer reuse |
| `operators/tokenizer/bpe_tokenizer_model.hpp` | `bpe_rank_`: `std::map` → `std::unordered_map` + flat-array linked list for `PerformBPE` |
| `operators/tokenizer/bpe_kernels.cc` | Pre-computed lookup tables + cached pre-tokenizer + buffer reuse + profiling infrastructure |
| `operators/tokenizer/bpe_kernels.h` | Added lookup tables, cached splitters, destructor |
| `test/pp_api_test/test_tokenizer_impl.cc` | Profiling test + memory footprint test |

## Performance Results

### Before vs After (Windows 11, Intel Xeon, tested with `transformers==5.6.0` locally)

#### ORT vs HuggingFace Transformers v5 Speedup

| Model | Input | Before (PR 1067) | After (this PR) | Delta |
|-------|-------|-------------------|-----------------|-------|
| GPT-2 | short_english | 3.35x | **6.98x** | +108% |
| GPT-2 | medium_english | 3.16x | **4.17x** | +32% |
| GPT-2 | code_python | 3.01x | **3.93x** | +31% |
| GPT-2 | multilingual | 1.73x | **1.74x** | — |
| GPT-2 | long_english | 3.17x | **4.34x** | +37% |
| GPT-2 | very_long_english | 3.49x | **4.68x** | +34% |
| Phi-4 | short_english | 2.53x | **3.53x** | +40% |
| Phi-4 | medium_english | 2.54x | **3.72x** | +46% |
| Phi-4 | code_python | 2.94x | **5.46x** | +86% |
| Phi-4 | multilingual | 0.61x | **1.29x** | ✅ flipped |
| Phi-4 | long_english | 2.81x | **4.18x** | +49% |
| Phi-4 | very_long_english | 2.77x | **3.99x** | +44% |
| LLaMA-2 | short_english | 1.84x | **2.11x** | +15% |
| LLaMA-2 | medium_english | 1.80x | **4.99x** | +177% |
| LLaMA-2 | code_python | 1.44x | **2.40x** | +67% |
| LLaMA-2 | multilingual | 1.28x | **2.18x** | +70% |
| LLaMA-2 | long_english | 1.80x | **3.13x** | +74% |
| LLaMA-2 | very_long_english | 2.00x | **3.62x** | +81% |
| Gemma | short_english | 1.10x | **2.13x** | +94% |
| Gemma | medium_english | 0.63x | **1.46x** | ✅ flipped |
| Gemma | code_python | 0.64x | **1.47x** | ✅ flipped |
| Gemma | multilingual | 0.63x | **1.35x** | ✅ flipped |
| Gemma | long_english | 0.71x | **1.46x** | ✅ flipped |
| Gemma | very_long_english | 0.58x | **1.69x** | ✅ flipped |

#### Average Throughput

| | Before (PR 1067) | After (this PR) | Improvement |
|---|---|---|---|
| ORT Extensions | 3.8 MB/s | **6.17 MB/s** | **+62%** |
| HF Transformers | 2.0 MB/s | 2.0 MB/s | (baseline) |
| **ORT vs HF ratio** | 1.9x | **2.99x** | |

### Key Wins

- **ORT now wins every benchmark** — no regressions on any model/input combination
- **GPT-2 short_english**: 3.35x → **6.98x** (peak speedup)
- **Phi-4 code_python**: 2.94x → **5.46x** (+86%)
- **LLaMA-2 medium_english**: 1.80x → **4.99x** (+177%)
- **Gemma**: Went from consistently losing to HF (0.5-0.7x) to consistently winning (1.35-2.13x)
- **LLaMA-2**: 1.3-2.0x → 2.1-5.0x across all inputs

## Optimization Details

### 1. `ToUTF8` Stack Buffer (`ustring.h`)
- **Problem**: `EncodeUTF8Char(char32_t)` returned a `std::string` (heap alloc) per character
- **Fix**: Write into a `char buf[4]` on the stack, append to pre-reserved output string. Added `ToUTF8Into()` to reuse existing string capacity.
- **Impact**: Eliminates N heap allocations per UTF-32→UTF-8 conversion

### 2. `bpe_rank_` Map Type (`bpe_tokenizer_model.hpp`)
- **Problem**: `std::map<uint64_t, BpeNode>` uses a red-black tree — O(log n) with pointer chasing per merge rank lookup
- **Fix**: `std::unordered_map<uint64_t, BpeNode>` — O(1) amortized with cache-friendly integer hashing
- **Impact**: 23-35% reduction in BPE merge time. Biggest win for Gemma (80% of time was in BPE).

### 3. Pre-computed Byte Token IDs (`bpe_kernels.cc`)
- **Problem**: ByteEncode fallback called `GetTokenId(token_bytes.substr(i, j))` per byte — heap allocation + hash-map lookup per character
- **Fix**: Pre-compute `byte_token_ids_[256]` at model load. Fast path uses direct array indexing with zero allocations.
- **Safety**: Falls back to original path if any byte lacks a valid token ID, or for CLIP end-of-word suffix handling.
- **Impact**: Eliminates N allocations + N hash lookups per pre-token in GPT-2/Phi-4 path. 38% ByteEncode reduction for GPT-2.

### 4. Flat-Array Linked List for BPE Merge (`bpe_tokenizer_model.hpp`)
- **Problem**: `PerformBPE` used `std::list<pair>` — each node is a separate heap allocation with cache-hostile pointer chasing across scattered memory.
- **Fix**: Stack-allocated array of `{token_id, byte_len, prev, next}` nodes with index-based doubly-linked list. O(1) erase via index manipulation, contiguous memory for cache-friendly scanning. Heap fallback for pre-tokens >128 chars.
- **Impact**: 61% reduction in BPE merge time across all models (measured in Debug profiler). Combined with optimization 2, BPE merge cost dropped from 37.9ms → 11.4ms for GPT-2.

### 5. Pre-computed SPM Byte Token IDs (`bpe_kernels.cc`)
- **Problem**: `SpmTokenize` (LLaMA/Gemma path) called `GetTokenId(std::string(1, byte))` per character — heap allocation + hash lookup per char for every input character.
- **Fix**: Pre-compute `spm_token_ids_[256]` and `spm_underscore_id_` at model load. Fast path handles ASCII chars and ▁ (space replacement) via direct array indexing. Non-ASCII falls back to per-char UTF-8 encoding with array lookup for byte-level fallback.
- **Impact**: 80% ByteEncode reduction for Gemma (110ms → 22ms), 48% for LLaMA (60ms → 32ms). Also fixed a bug where lookup tables were never initialized on the `JsonFastTokenizer::Load()` path (used by Python API and tests).

### 6. Cached Pre-tokenizer + Buffer Reuse (`bpe_kernels.cc`)
- **Problem**: The regex pre-tokenizer was "compiled" (pattern-matched against 24 patterns) on every `Tokenize()`/`SpmTokenize()` call. Also, `byte_list`, `token_bytes`, and `utf8_token` buffers were heap-allocated fresh per pre-token.
- **Fix**: 
  - Compile pre-tokenizer once at model load, cache in `CachedSplitters` struct (reused per call)
  - Hoist `byte_list` and `token_bytes` above the per-token loop (retain vector capacity)
  - Use `ToUTF8Into()` instead of `ToUTF8()` to reuse string capacity
  - `process_bpe_chunk` takes `std::string&` instead of by-value copy
  - `res.reserve(input.size() / 3)` to pre-allocate output vector
  - `std::list<pair>` → `std::vector<pair>` for `byte_list` in SpmTokenize paths
- **Impact**: "Other" overhead dropped 82% for GPT-2 (51ms → 9ms), 77% for Phi-4, 53% for LLaMA.

## Memory Usage

Tokenizer memory footprint (CPU heap, allocated at model load, freed when tokenizer is destroyed):

| Model | Main (baseline) | This PR | Delta |
|-------|----------------|---------|-------|
| GPT-2 (50K vocab) | 33.41 MB | 31.25 MB | -2.16 MB |
| Phi-4 (100K vocab) | 67.02 MB | 64.14 MB | -2.88 MB |
| LLaMA-2 (32K vocab) | 25.71 MB | 24.25 MB | -1.46 MB |
| Gemma (256K vocab) | 213.62 MB | 219.76 MB | +6.14 MB |
| **TOTAL** | **339.80 MB** | **~339 MB** | **~0** |

**No meaningful memory regression.** Per-model variations are within RSS measurement noise (page-granular). The Gemma +6 MB is likely `unordered_map` bucket overhead (256K merges), offset by GPT-2/Phi-4/LLaMA going *down* (vector replacing list eliminates per-node allocator fragmentation).

Our optimizations add negligible extra memory per model: ~3 KB for byte lookup tables + ~200 bytes for cached splitters.

## Profiling Infrastructure

Includes a lightweight profiling framework (disabled by default, uncomment `#define OCOS_PROFILING 1` to enable) with:
- Per-section timing (SplitAdded, PreTokenize, ByteEncode, BPE Merge, Other)
- Atomic counters safe for future multi-threaded use
- `OrtxTokenizerProfileTest.ProfileAllModels` test for local profiling
- `OrtxTokenizerProfileTest.MemoryUsage` test for memory footprint measurement

## Testing

- All existing C++ tests pass (pp_api_test)
- Python benchmark validates end-to-end correctness (token output matches)
- No functional changes to tokenizer behavior — purely performance