### PR TITLE
Skip Tool Normalization for GPT-OSS/Harmony Templates

### DIFF
--- a/shared/api/chat_template.cc
+++ b/shared/api/chat_template.cc
@@ -413,6 +413,25 @@ OrtxStatus TokenizerImpl::ApplyChatTemplate(const char* template_str, const char
     // Check Phi-4-mini tool call case for quote normalization
     bool phi_4_mini = false;
 
+    // Determine whether to skip tool normalization based on template content.
+    // GPT-OSS/Harmony templates access `tool.function` directly (they expect the raw OpenAI format),
+    // so NormalizeTools() would break them by unwrapping the function object.
+    // Other templates (Phi-4, Qwen) either use a flat format or access `tool_call.function`.
+    bool skip_tool_normalization = false;
+    {
+      std::string tmpl_str(activated_str);
+      // Look for "tool.function" but exclude "tool_call.function" matches
+      size_t pos = 0;
+      while ((pos = tmpl_str.find("tool.function", pos)) != std::string::npos) {
+        // Check that this isn't part of "tool_call.function"
+        if (pos < 5 || tmpl_str.substr(pos - 5, 5) != "call.") {
+          skip_tool_normalization = true;
+          break;
+        }
+        pos += 13;
+      }
+    }
+
     // Case 1: Check if tools are inside messages (for Phi-4-mini)
     if (actual_messages.is_array()) {
       for (auto& message_obj : actual_messages) {
@@ -420,11 +439,15 @@ OrtxStatus TokenizerImpl::ApplyChatTemplate(const char* template_str, const char
           // Set flag for Phi-4 tools to true
           phi_4_mini = true;
 
-          // Normalize the tools inside the message
-          json tools_json = NormalizeTools(message_obj["tools"].get<std::string>().c_str());
-          
-          // Update the tools in the message
-          message_obj["tools"] = tools_json;
+          if (skip_tool_normalization) {
+            // GPT-OSS/Harmony: parse tools as-is without normalization
+            json tools_json = json::parse(message_obj["tools"].get<std::string>().c_str());
+            message_obj["tools"] = tools_json;
+          } else {
+            // Normalize the tools inside the message
+            json tools_json = NormalizeTools(message_obj["tools"].get<std::string>().c_str());
+            message_obj["tools"] = tools_json;
+          }
         }
       }
     }
@@ -432,9 +455,15 @@ OrtxStatus TokenizerImpl::ApplyChatTemplate(const char* template_str, const char
     // Case 2: Check if we received tools separately (for Qwen or others)
     if (tools && *tools) {
       std::string tools_str = minja::normalize_newlines(tools);
-      json tools_json = NormalizeTools(tools_str.c_str());
+      json tools_json;
+      if (skip_tool_normalization) {
+        // GPT-OSS/Harmony: pass raw tools without normalization
+        tools_json = json::parse(tools_str.c_str());
+      } else {
+        tools_json = NormalizeTools(tools_str.c_str());
+      }
 
-      // Add normalized tools to the context if tools are passed separately
+      // Add tools to the context
       context = minja::Context::make(json({
           {"messages", actual_messages},
           {"tools", tools_json},

--- a/shared/api/chat_template.cc
+++ b/shared/api/chat_template.cc
@@ -420,16 +420,8 @@ OrtxStatus TokenizerImpl::ApplyChatTemplate(const char* template_str, const char
     bool skip_tool_normalization = false;
     {
       std::string tmpl_str(activated_str);
-      // Look for "tool.function" but exclude "tool_call.function" matches
-      size_t pos = 0;
-      while ((pos = tmpl_str.find("tool.function", pos)) != std::string::npos) {
-        // Check that this isn't part of "tool_call.function"
-        if (pos < 5 || tmpl_str.substr(pos - 5, 5) != "call.") {
-          skip_tool_normalization = true;
-          break;
-        }
-        pos += 13;
-      }
+      // Look for "tool.function" in the template (Harmony/GPT-OSS expects raw OpenAI tool objects).
+      skip_tool_normalization = tmpl_str.find("tool.function") != std::string::npos;
     }
 
     // Case 1: Check if tools are inside messages (for Phi-4-mini)
@@ -441,8 +433,12 @@ OrtxStatus TokenizerImpl::ApplyChatTemplate(const char* template_str, const char
 
           if (skip_tool_normalization) {
             // GPT-OSS/Harmony: parse tools as-is without normalization
-            json tools_json = json::parse(message_obj["tools"].get<std::string>().c_str());
-            message_obj["tools"] = tools_json;
+            const auto tools_text = message_obj["tools"].get<std::string>();
+            json tools_json = json::parse(tools_text, nullptr, /*allow_exceptions=*/false);
+            if (tools_json.is_discarded()) {
+              throw std::runtime_error("Invalid tools JSON.");
+            }
+            message_obj["tools"] = std::move(tools_json);
           } else {
             // Normalize the tools inside the message
             json tools_json = NormalizeTools(message_obj["tools"].get<std::string>().c_str());
@@ -458,7 +454,10 @@ OrtxStatus TokenizerImpl::ApplyChatTemplate(const char* template_str, const char
       json tools_json;
       if (skip_tool_normalization) {
         // GPT-OSS/Harmony: pass raw tools without normalization
-        tools_json = json::parse(tools_str.c_str());
+        tools_json = json::parse(tools_str, nullptr, /*allow_exceptions=*/false);
+        if (tools_json.is_discarded()) {
+          throw std::runtime_error("Invalid tools JSON.");
+        }
       } else {
         tools_json = NormalizeTools(tools_str.c_str());
       }

--- a/test/data/gpt-oss/chat_template.jinja
+++ b/test/data/gpt-oss/chat_template.jinja
@@ -1,0 +1,318 @@
+{#-
+  In addition to the normal inputs of `messages` and `tools`, this template also accepts the
+  following kwargs:
+  - "builtin_tools": A list, can contain "browser" and/or "python".
+  - "model_identity": A string that optionally describes the model identity".
+  - "reasoning_effort": A string that describes the reasoning effort, defaults to "medium".
+ #}
+
+{#- Tool Definition Rendering ============================================== #}
+{%- macro render_typescript_type(param_spec, required_params, is_nullable=false) -%}
+    {%- if param_spec.type == "array" -%}
+        {%- if param_spec['items'] -%}
+            {%- if param_spec['items']['type'] == "string" -%}
+                {{- "string[]" }}
+            {%- elif param_spec['items']['type'] == "number" -%}
+                {{- "number[]" }}
+            {%- elif param_spec['items']['type'] == "integer" -%}
+                {{- "number[]" }}
+            {%- elif param_spec['items']['type'] == "boolean" -%}
+                {{- "boolean[]" }}
+            {%- else -%}
+                {%- set inner_type = render_typescript_type(param_spec['items'], required_params) -%}
+                {%- if inner_type == "object | object" or inner_type|length > 50 -%}
+                    {{- "any[]" }}
+                {%- else -%}
+                    {{- inner_type + "[]" }}
+                {%- endif -%}
+            {%- endif -%}
+            {%- if param_spec.nullable -%}
+                {{- " | null" }}
+            {%- endif -%}
+        {%- else -%}
+            {{- "any[]" }}
+            {%- if param_spec.nullable -%}
+                {{- " | null" }}
+            {%- endif -%}
+        {%- endif -%}
+    {%- elif param_spec.type is defined and param_spec.type is iterable and param_spec.type is not string and param_spec.type is not mapping and param_spec.type[0] is defined -%}
+        {#- Handle array of types like ["object", "object"] from Union[dict, list] #}
+        {%- if param_spec.type | length > 1 -%}
+            {{- param_spec.type | join(" | ") }}
+        {%- else -%}
+            {{- param_spec.type[0] }}
+        {%- endif -%}
+    {%- elif param_spec.oneOf -%}
+        {#- Handle oneOf schemas - check for complex unions and fallback to any #}
+        {%- set has_object_variants = false -%}
+        {%- for variant in param_spec.oneOf -%}
+            {%- if variant.type == "object" -%}
+                {%- set has_object_variants = true -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {%- if has_object_variants and param_spec.oneOf|length > 1 -%}
+            {{- "any" }}
+        {%- else -%}
+            {%- for variant in param_spec.oneOf -%}
+                {{- render_typescript_type(variant, required_params) -}}
+                {%- if variant.description %}
+                    {{- "// " + variant.description }}
+                {%- endif -%}
+                {%- if variant.default is defined %}
+                    {{ "// default: " + variant.default|tojson }}
+                {%- endif -%}
+                {%- if not loop.last %}
+                    {{- " | " }}
+                {% endif -%}
+            {%- endfor -%}
+        {%- endif -%}
+    {%- elif param_spec.type == "string" -%}
+        {%- if param_spec.enum -%}
+            {{- '"' + param_spec.enum|join('" | "') + '"' -}}
+        {%- else -%}
+            {{- "string" }}
+            {%- if param_spec.nullable %}
+                {{- " | null" }}
+            {%- endif -%}
+        {%- endif -%}
+    {%- elif param_spec.type == "number" -%}
+        {{- "number" }}
+    {%- elif param_spec.type == "integer" -%}
+        {{- "number" }}
+    {%- elif param_spec.type == "boolean" -%}
+        {{- "boolean" }}
+
+    {%- elif param_spec.type == "object" -%}
+        {%- if param_spec.properties -%}
+            {{ - "{\n" }}
+            {%- for prop_name, prop_spec in param_spec.properties.items() -%}
+                {{- prop_name -}}
+                {%- if prop_name not in (param_spec.required or []) -%}
+                    {{- "?" }}
+                {%- endif -%}
+                {{- ": " }}
+                {{ render_typescript_type(prop_spec, param_spec.required or []) }}
+                {%- if not loop.last -%}
+                    {{-", " }}
+                {%- endif -%}
+            {%- endfor -%}
+            {{- "}" }}
+        {%- else -%}
+            {{- "object" }}
+        {%- endif -%}
+    {%- else -%}
+        {{- "any" }}
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- macro render_tool_namespace(namespace_name, tools) -%}
+    {{- "## " + namespace_name + "\n\n" }}
+    {{- "namespace " + namespace_name + " {\n\n" }}
+    {%- for tool in tools %}
+        {%- set tool = tool.function %}
+        {{- "// " + tool.description + "\n" }}
+        {{- "type "+ tool.name + " = (" }}
+        {%- if tool.parameters and tool.parameters.properties -%}
+            {{- "_: " }}
+            {{- "{\n" }}
+            {%- for param_name, param_spec in tool.parameters.properties.items() %}
+                {{- "// " + param_spec.description + "\n" }}
+                {{- param_name }}
+                {%- if param_name not in (tool.parameters.required or []) -%}
+                    {{- "?" }}
+                {%- endif -%}
+                {{- ": " }}
+                {{- render_typescript_type(param_spec, tool.parameters.required or []) }}
+                {%- if param_spec.default is defined -%}
+                    {%- if param_spec.oneOf %}
+                        {{- "// default: " + param_spec.default }}
+                    {%- else %}
+                        {{- ", // default: " + param_spec.default|tojson }}
+                    {%- endif -%}
+                {%- endif -%}
+                {%- if not loop.last %}
+                    {{- ",\n" }}
+                {%- endif -%}
+            {%- endfor %}
+            {{- ",\n}) => any;\n" }}
+        {%- else -%}
+            {{- "\n}) => any;\n" }}
+        {%- endif -%}
+    {%- endfor %}
+    {{- "\n} // namespace " + namespace_name }}
+{%- endmacro -%}
+
+{%- macro render_builtin_tools(browser_tool, python_tool) -%}
+    {%- if browser_tool %}
+        {{- "## browser\n\n" }}
+        {{- "// Tool for browsing.\n" }}
+        {{- "// The `cursor` appears in brackets before each browsing display: `[{cursor}]`.\n" }}
+        {{- "// Cite information from the tool using the following format:\n" }}
+        {{- "// `【{cursor}†L{line_start}(-L{line_end})?】`, for example: `【6†L9-L11】` or `【8†L3】`.\n" }}
+        {{- "// Do not quote more than 10 words directly from the tool output.\n" }}
+        {{- "// sources=web (default: web)\n" }}
+        {{- "namespace browser {\n\n" }}
+        {{- "// Searches for information related to `query` and displays `topn` results.\n" }}
+        {{- "type search = (_: {\n" }}
+        {{- "query: string,\n" }}
+        {{- "topn?: number, // default: 10\n" }}
+        {{- "source?: string,\n" }}
+        {{- "}) => any;\n\n" }}
+        {{- "// Opens the link `id` from the page indicated by `cursor` starting at line number `loc`, showing `num_lines` lines.\n" }}
+        {{- "// Valid link ids are displayed with the formatting: `【{id}†.*】`.\n" }}
+        {{- "// If `cursor` is not provided, the most recent page is implied.\n" }}
+        {{- "// If `id` is a string, it is treated as a fully qualified URL associated with `source`.\n" }}
+        {{- "// If `loc` is not provided, the viewport will be positioned at the beginning of the document or centered on the most relevant passage, if available.\n" }}
+        {{- "// Use this function without `id` to scroll to a new location of an opened page.\n" }}
+        {{- "type open = (_: {\n" }}
+        {{- "id?: number | string, // default: -1\n" }}
+        {{- "cursor?: number, // default: -1\n" }}
+        {{- "loc?: number, // default: -1\n" }}
+        {{- "num_lines?: number, // default: -1\n" }}
+        {{- "view_source?: boolean, // default: false\n" }}
+        {{- "source?: string,\n" }}
+        {{- "}) => any;\n\n" }}
+        {{- "// Finds exact matches of `pattern` in the current page, or the page given by `cursor`.\n" }}
+        {{- "type find = (_: {\n" }}
+        {{- "pattern: string,\n" }}
+        {{- "cursor?: number, // default: -1\n" }}
+        {{- "}) => any;\n\n" }}
+        {{- "} // namespace browser\n\n" }}
+    {%- endif -%}
+
+    {%- if python_tool %}
+        {{- "## python\n\n" }}
+        {{- "Use this tool to execute Python code in your chain of thought. The code will not be shown to the user. This tool should be used for internal reasoning, but not for code that is intended to be visible to the user (e.g. when creating plots, tables, or files).\n\n" }}
+        {{- "When you send a message containing Python code to python, it will be executed in a stateful Jupyter notebook environment. python will respond with the output of the execution or time out after 120.0 seconds. The drive at '/mnt/data' can be used to save and persist user files. Internet access for this session is UNKNOWN. Depends on the cluster.\n\n" }}
+    {%- endif -%}
+{%- endmacro -%}
+
+{#- System Message Construction ============================================ #}
+{%- macro build_system_message() -%}
+    {%- if model_identity is not defined %}
+        {{- "You are ChatGPT, a large language model trained by OpenAI.\n" -}}
+    {%- else %}
+        {{- model_identity }}
+    {%- endif %}
+    {{- "Knowledge cutoff: 2024-06\n" }}
+    {{- "Current date: " + strftime_now("%Y-%m-%d") + "\n\n" }}
+    {%- if reasoning_effort is not defined %}
+        {%- set reasoning_effort = "medium" %}
+    {%- endif %}
+    {{- "reasoning: " + reasoning_effort + "\n\n" }}
+    {%- if builtin_tools %}
+        {{- "# Tools\n\n" }}
+        {%- set available_builtin_tools = namespace(browser=false, python=false) %}
+        {%- for tool in builtin_tools %}
+            {%- if tool == "browser" %}
+                {%- set available_builtin_tools.browser = true %}
+            {%- elif tool == "python" %}
+                {%- set available_builtin_tools.python = true %}
+            {%- endif %}
+        {%- endfor %}
+        {{- render_builtin_tools(available_builtin_tools.browser, available_builtin_tools.python) }}
+    {%- endif -%}
+    {{- "# Valid channels: analysis, commentary, final. Channel must be included for every message.\n" }}
+    {{- "Calls to these tools must go to the commentary channel: 'functions'." }}
+{%- endmacro -%}
+
+{#- CoT Dropping Logic ================================================== #}
+{%- set cot_final_indices = [] -%}
+{%- for idx in range(messages|length) -%}
+    {%- set m = messages[idx] -%}
+    {%- if m.role == 'assistant' and m.get('channel', '') == 'final' -%}
+        {%- if cot_final_indices.append(idx) -%}{%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- set cot_last_final_idx = cot_final_indices[-1] if cot_final_indices else none -%}
+{%- set cot_last_user_idx = none -%}
+{%- if cot_last_final_idx is not none -%}
+    {%- for idx in range(cot_last_final_idx - 1, -1, -1) -%}
+        {%- if messages[idx].role == 'user' and cot_last_user_idx is none -%}
+            {%- set cot_last_user_idx = idx -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endif -%}
+
+{#- Main Template Logic ================================================= #}
+{#- Set defaults #}
+{%- set auto_drop = auto_drop_analysis if auto_drop_analysis is defined else true -%}
+
+{#- Render system message #}
+{{- "<|start|>system<|message|>" }}
+{{- build_system_message() }}
+{{- "<|end|>" }}
+
+{#- Extract developer message #}
+{%- if messages[0].role == "developer" or messages[0].role == "system" %}
+    {%- set developer_message = messages[0].content %}
+    {%- set loop_messages = messages[1:] %}
+{%- else %}
+    {%- set developer_message = "" %}
+    {%- set loop_messages = messages %}
+{%- endif %}
+
+{#- Render developer message #}
+{%- if developer_message or tools %}
+    {{- "<|start|>developer<|message|>" }}
+    {%- if developer_message %}
+        {{- "# Instructions\n\n" }}
+        {{- developer_message }}
+    {%- endif %}
+    {%- if tools -%}
+        {{- "\n\n" }}
+        {{- "# Tools\n\n" }}
+        {{- render_tool_namespace("functions", tools) }}
+    {%- endif -%}
+    {{- "<|end|>" }}
+{%- endif %}
+
+{#- Render messages #}
+{%- set last_tool_call = namespace(name=none) %}
+{%- for message in loop_messages -%}
+    {%- set skip = false -%}
+    
+    {# Apply CoT dropping logic #}
+    {%- if auto_drop and cot_last_final_idx is not none and loop.index0 < cot_last_final_idx -%}
+        {%- if message.role == 'assistant' and message.get('channel', '') != 'final' -%}
+            {%- if cot_last_user_idx is none or loop.index0 > cot_last_user_idx -%}
+                {%- set skip = true -%}
+            {%- endif -%}
+        {%- elif message.role == 'user' and message.get('channel', '') == 'analysis' -%}
+            {%- set skip = true -%}
+        {%- endif -%}
+    {%- endif -%}
+    
+    {%- if not skip -%}
+        {#- At this point only assistant/user/tool messages should remain #}
+        {%- if message.role == 'assistant' -%}
+            {%- if "tool_calls" in message %}
+                {# I'm assuming max 1 tool call per message here, which might be wrong #}
+                {{- "<|start|>assistant<|channel|>analysis<|message|>" + message.content }}
+                {{- "<|end|><|start|>assistant to=" }}
+                {{- "functions." + message.tool_calls[0].name + "<|channel|>commentary json<|message|>" }}
+                {{- message.tool_calls[0].arguments|tojson }}
+                {{- "<|end|>" }}
+                {%- set last_tool_call.name = message.tool_calls[0].name %}
+            {%- elif "thinking" in message %}
+                {#- CoT is dropped during all model inputs, so we never actually render it #}
+                {{- "<|start|>assistant<|channel|>final<|message|>" + message.content + "<|end|>" }}
+            {%- else %}
+                {{- "<|start|>assistant<|message|>" + message.content + "<|end|>" }}
+            {%- endif %}
+        {%- elif message.role == 'tool' -%}
+            {%- if last_tool_call.name is none %}
+                {{- raise_exception("Message has tool role, but there was no previous assistant message with a tool call!") }}
+            {%- endif %}
+            {{- "<|start|>functions." + last_tool_call.name }}
+            {{- " to=assistant<|channel|>commentary<|message|>" + message.content|tojson + "<|end|>" }}
+        {%- else -%}
+            {{- "<|start|>user<|message|>" + message.content + "<|end|>" }}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Generation prompt #}
+{%- if add_generation_prompt -%}
+<|start|>assistant
+{%- endif -%} 

--- a/test/data/gpt-oss/tokenizer_config.json
+++ b/test/data/gpt-oss/tokenizer_config.json
@@ -1,0 +1,183 @@
+{
+  "added_tokens_decoder": {
+    "199998": {
+      "content": "<|startoftext|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "199999": {
+      "content": "<|endoftext|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200000": {
+      "content": "<|reserved_200000|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200001": {
+      "content": "<|reserved_200001|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200002": {
+      "content": "<|return|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200003": {
+      "content": "<|constrain|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200004": {
+      "content": "<|reserved_200004|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200005": {
+      "content": "<|channel|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200006": {
+      "content": "<|start|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200007": {
+      "content": "<|end|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200008": {
+      "content": "<|message|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200009": {
+      "content": "<|reserved_200009|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200010": {
+      "content": "<|reserved_200010|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200011": {
+      "content": "<|reserved_200011|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200012": {
+      "content": "<|call|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200013": {
+      "content": "<|reserved_200013|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200014": {
+      "content": "<|reserved_200014|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200015": {
+      "content": "<|reserved_200015|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200016": {
+      "content": "<|reserved_200016|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200017": {
+      "content": "<|reserved_200017|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    },
+    "200018": {
+      "content": "<|endofprompt|>",
+      "lstrip": false,
+      "normalized": false,
+      "rstrip": false,
+      "single_word": false,
+      "special": true
+    }
+  },
+  "bos_token": "<|startoftext|>",
+  "clean_up_tokenization_spaces": false,
+  "eos_token": "<|return|>",
+  "extra_special_tokens": {},
+  "model_input_names": [
+    "input_ids",
+    "attention_mask"
+  ],
+  "model_max_length": 1000000000000000019884624838656,
+  "pad_token": "<|endoftext|>",
+  "tokenizer_class": "PreTrainedTokenizerFast"
+}

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -1243,6 +1243,427 @@ TEST(OrtxTokenizerTest, Qwen2_5_ChatTemplateWithOAIFunctionType) {
 }
 
 // ============================================================================
+// GPT-OSS / Harmony format tests
+// ============================================================================
+
+/*
+  Test GPT-OSS (Harmony) chat template basic message formatting.
+  Verifies that messages are rendered with Harmony special tokens:
+  <|start|>, <|end|>, <|message|>, <|channel|>
+  and that the system message is auto-generated.
+*/
+TEST(OrtxTokenizerTest, GptOssChatTemplateBasic) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/gpt-oss");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << "Failed to create GPT-OSS tokenizer: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensorResult> templated_text;
+  std::string messages_json = R"(
+    [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant."
+      },
+      {
+        "role": "user",
+        "content": "Hello, how are you?"
+      }
+    ])";
+
+  auto err = OrtxApplyChatTemplate(
+    tokenizer.get(), nullptr,
+    messages_json.c_str(), nullptr,
+    templated_text.ToBeAssigned(), true, false);
+  ASSERT_EQ(err, kOrtxOK) << "Error: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensor> tensor;
+  OrtxTensorResultGetAt(templated_text.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(tensor.Code(), kOrtxOK);
+  const char* text_ptr = nullptr;
+  OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
+
+  std::string output(text_ptr);
+
+  // Verify system message is auto-generated with Harmony tokens
+  EXPECT_NE(output.find("<|start|>system<|message|>"), std::string::npos)
+      << "Missing system message start token";
+  EXPECT_NE(output.find("# Valid channels: analysis, commentary, final."), std::string::npos)
+      << "Missing channel instruction in system message";
+
+  // Verify developer message contains user's system content
+  EXPECT_NE(output.find("<|start|>developer<|message|>"), std::string::npos)
+      << "Missing developer message start";
+  EXPECT_NE(output.find("# Instructions\n\nYou are a helpful assistant."), std::string::npos)
+      << "Missing developer instructions";
+  EXPECT_NE(output.find("<|end|>"), std::string::npos)
+      << "Missing end token";
+
+  // Verify user message
+  EXPECT_NE(output.find("<|start|>user<|message|>Hello, how are you?<|end|>"), std::string::npos)
+      << "Missing or malformed user message";
+
+  // Verify generation prompt
+  EXPECT_NE(output.find("<|start|>assistant"), std::string::npos)
+      << "Missing generation prompt";
+}
+
+/*
+  Test GPT-OSS (Harmony) chat template with tools passed separately.
+  Verifies that tools in OpenAI format [{"type":"function","function":{...}}]
+  are NOT normalized/unwrapped and are rendered as TypeScript namespace definitions.
+  This is the key test for the skip_tool_normalization fix.
+*/
+TEST(OrtxTokenizerTest, GptOssChatTemplateWithTools) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/gpt-oss");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << "Failed to create GPT-OSS tokenizer: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensorResult> templated_text;
+  std::string messages_json = R"(
+    [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant with tool access."
+      },
+      {
+        "role": "user",
+        "content": "What's the weather in Seattle?"
+      }
+    ])";
+
+  // OpenAI format tools - the template expects this exact format and does tool.function internally
+  std::string tools_json = R"(
+    [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get current weather for a location.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string",
+                "description": "The city name"
+              }
+            },
+            "required": ["location"]
+          }
+        }
+      }
+    ])";
+
+  auto err = OrtxApplyChatTemplate(
+    tokenizer.get(), nullptr,
+    messages_json.c_str(), tools_json.c_str(),
+    templated_text.ToBeAssigned(), true, false);
+  ASSERT_EQ(err, kOrtxOK) << "Error: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensor> tensor;
+  OrtxTensorResultGetAt(templated_text.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(tensor.Code(), kOrtxOK);
+  const char* text_ptr = nullptr;
+  OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
+
+  std::string output(text_ptr);
+
+  // Verify tools are rendered in TypeScript namespace format (proving template accessed tool.function correctly)
+  EXPECT_NE(output.find("namespace functions {"), std::string::npos)
+      << "Missing TypeScript namespace declaration - tools not rendered correctly";
+  EXPECT_NE(output.find("// Get current weather for a location."), std::string::npos)
+      << "Missing tool description in TypeScript format";
+  EXPECT_NE(output.find("type get_weather = ("), std::string::npos)
+      << "Missing tool type declaration";
+  EXPECT_NE(output.find("location"), std::string::npos)
+      << "Missing parameter name";
+  EXPECT_NE(output.find("} // namespace functions"), std::string::npos)
+      << "Missing namespace closing";
+
+  // Verify the tools section is in the developer message
+  EXPECT_NE(output.find("<|start|>developer<|message|>"), std::string::npos)
+      << "Tools should be in developer message";
+  EXPECT_NE(output.find("# Tools"), std::string::npos)
+      << "Missing '# Tools' header";
+
+  // Verify user message and generation prompt are still correct
+  EXPECT_NE(output.find("<|start|>user<|message|>What's the weather in Seattle?<|end|>"), std::string::npos)
+      << "Missing user message";
+  EXPECT_NE(output.find("<|start|>assistant"), std::string::npos)
+      << "Missing generation prompt";
+}
+
+/*
+  Test GPT-OSS (Harmony) chat template with tool calls in assistant messages.
+  Verifies the full tool-calling conversation flow:
+  1. User asks a question
+  2. Assistant responds with a tool_call (rendered with Harmony tool call tokens)
+  3. Tool returns a response (rendered with Harmony tool response format)
+  4. Assistant gives final answer
+*/
+TEST(OrtxTokenizerTest, GptOssChatTemplateWithToolCalls) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/gpt-oss");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << "Failed to create GPT-OSS tokenizer: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensorResult> templated_text;
+
+  // Full tool-calling conversation:
+  // user -> assistant (with tool_call) -> tool (response) -> assistant (final answer)
+  std::string messages_json = R"(
+    [
+      {
+        "role": "user",
+        "content": "What's the weather in Seattle?"
+      },
+      {
+        "role": "assistant",
+        "content": "I'll check the weather for you.",
+        "tool_calls": [
+          {
+            "name": "get_weather",
+            "arguments": {"location": "Seattle", "unit": "celsius"}
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "content": "{\"temperature\": 15, \"condition\": \"cloudy\"}"
+      },
+      {
+        "role": "assistant",
+        "content": "The weather in Seattle is 15 degrees C and cloudy."
+      }
+    ])";
+
+  // Also provide tools definition so the template renders the namespace
+  std::string tools_json = R"JSON(
+    [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get current weather for a location.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string",
+                "description": "The city name"
+              },
+              "unit": {
+                "type": "string",
+                "description": "Temperature unit (celsius or fahrenheit)"
+              }
+            },
+            "required": ["location"]
+          }
+        }
+      }
+    ])JSON";
+
+  auto err = OrtxApplyChatTemplate(
+    tokenizer.get(), nullptr,
+    messages_json.c_str(), tools_json.c_str(),
+    templated_text.ToBeAssigned(), false, false);
+  ASSERT_EQ(err, kOrtxOK) << "Error: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensor> tensor;
+  OrtxTensorResultGetAt(templated_text.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(tensor.Code(), kOrtxOK);
+  const char* text_ptr = nullptr;
+  OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
+
+  std::string output(text_ptr);
+
+  // Verify assistant message with tool call uses Harmony tool call format:
+  // <|start|>assistant<|channel|>analysis<|message|>{content}<|end|>
+  // <|start|>assistant to=functions.{name}<|channel|>commentary json<|message|>{args}<|end|>
+  EXPECT_NE(output.find("<|start|>assistant<|channel|>analysis<|message|>I'll check the weather for you."), std::string::npos)
+      << "Missing assistant analysis channel with content before tool call";
+  EXPECT_NE(output.find("<|start|>assistant to=functions.get_weather<|channel|>commentary json<|message|>"), std::string::npos)
+      << "Missing tool call routing header";
+
+  // Verify tool call arguments are serialized
+  EXPECT_NE(output.find("location"), std::string::npos)
+      << "Missing tool call argument 'location'";
+  EXPECT_NE(output.find("Seattle"), std::string::npos)
+      << "Missing tool call argument value 'Seattle'";
+
+  // Verify tool response uses Harmony format:
+  // <|start|>functions.{name} to=assistant<|channel|>commentary<|message|>{content}<|end|>
+  EXPECT_NE(output.find("<|start|>functions.get_weather to=assistant<|channel|>commentary<|message|>"), std::string::npos)
+      << "Missing tool response routing header";
+
+  // Verify final assistant message
+  EXPECT_NE(output.find("<|start|>assistant<|message|>The weather in Seattle is"), std::string::npos)
+      << "Missing final assistant message";
+}
+
+/*
+  Test GPT-OSS (Harmony) chat template with multiple tools.
+  Verifies that multiple tool definitions are all rendered correctly in the namespace.
+*/
+TEST(OrtxTokenizerTest, GptOssChatTemplateMultipleTools) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/gpt-oss");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << "Failed to create GPT-OSS tokenizer: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensorResult> templated_text;
+  std::string messages_json = R"(
+    [
+      {
+        "role": "user",
+        "content": "Help me plan a trip."
+      }
+    ])";
+
+  // Multiple tools in OpenAI format
+  std::string tools_json = R"(
+    [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get current weather for a location.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string",
+                "description": "The city name"
+              }
+            },
+            "required": ["location"]
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "search_flights",
+          "description": "Search for available flights.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "origin": {
+                "type": "string",
+                "description": "Departure city"
+              },
+              "destination": {
+                "type": "string",
+                "description": "Arrival city"
+              }
+            },
+            "required": ["origin", "destination"]
+          }
+        }
+      }
+    ])";
+
+  auto err = OrtxApplyChatTemplate(
+    tokenizer.get(), nullptr,
+    messages_json.c_str(), tools_json.c_str(),
+    templated_text.ToBeAssigned(), true, false);
+  ASSERT_EQ(err, kOrtxOK) << "Error: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensor> tensor;
+  OrtxTensorResultGetAt(templated_text.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(tensor.Code(), kOrtxOK);
+  const char* text_ptr = nullptr;
+  OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
+
+  std::string output(text_ptr);
+
+  // Both tools should be rendered in the namespace
+  EXPECT_NE(output.find("type get_weather = ("), std::string::npos)
+      << "Missing first tool (get_weather)";
+  EXPECT_NE(output.find("// Get current weather for a location."), std::string::npos)
+      << "Missing first tool description";
+  EXPECT_NE(output.find("type search_flights = ("), std::string::npos)
+      << "Missing second tool (search_flights)";
+  EXPECT_NE(output.find("// Search for available flights."), std::string::npos)
+      << "Missing second tool description";
+
+  // Verify parameters are rendered for both tools
+  EXPECT_NE(output.find("location"), std::string::npos)
+      << "Missing get_weather parameter";
+  EXPECT_NE(output.find("origin"), std::string::npos)
+      << "Missing search_flights origin parameter";
+  EXPECT_NE(output.find("destination"), std::string::npos)
+      << "Missing search_flights destination parameter";
+
+  // Verify single namespace wraps both
+  EXPECT_NE(output.find("namespace functions {"), std::string::npos)
+      << "Missing namespace opening";
+  EXPECT_NE(output.find("} // namespace functions"), std::string::npos)
+      << "Missing namespace closing";
+}
+
+/*
+  Test that the skip_tool_normalization detection does not affect non-GPT-OSS templates.
+  Qwen2.5 template does NOT contain "tool.function" so normalization should still occur.
+  This is a regression test to ensure existing behavior is preserved.
+*/
+TEST(OrtxTokenizerTest, Qwen2_5_NormalizationStillApplies) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/qwen2.5");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << "Failed to create Qwen tokenizer: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensorResult> templated_text;
+  std::string messages_json = R"(
+    [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant."
+      },
+      {
+        "role": "user",
+        "content": "What time is it?"
+      }
+    ])";
+
+  // OpenAI type:function format - should be normalized for Qwen
+  std::string tools_json = R"(
+    [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_time",
+          "description": "Get the current time.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "timezone": {
+                "type": "string",
+                "description": "The timezone"
+              }
+            },
+            "required": ["timezone"]
+          }
+        }
+      }
+    ])";
+
+  auto err = OrtxApplyChatTemplate(
+    tokenizer.get(), nullptr,
+    messages_json.c_str(), tools_json.c_str(),
+    templated_text.ToBeAssigned(), true, false);
+  ASSERT_EQ(err, kOrtxOK) << "Error: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensor> tensor;
+  OrtxTensorResultGetAt(templated_text.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(tensor.Code(), kOrtxOK);
+  const char* text_ptr = nullptr;
+  OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
+
+  std::string output(text_ptr);
+
+  // Qwen renders normalized tools (flat format, no "type":"function" wrapper)
+  // The tool should appear as {"name": "get_time", ...} inside <tools></tools> tags
+  EXPECT_NE(output.find("<tools>"), std::string::npos)
+      << "Qwen should render tools in <tools> XML tags";
+  EXPECT_NE(output.find("\"name\": \"get_time\""), std::string::npos)
+      << "Tool name should be in normalized flat format";
+  EXPECT_NE(output.find("\"description\": \"Get the current time.\""), std::string::npos)
+      << "Tool description should be preserved";
+}
+
+// ============================================================================
 // Transformers v5 format tests
 // ============================================================================
 

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -1663,6 +1663,172 @@ TEST(OrtxTokenizerTest, Qwen2_5_NormalizationStillApplies) {
       << "Tool description should be preserved";
 }
 
+/*
+  Test GPT-OSS tools with an EXPLICIT template_str parameter (matches genai Python code path).
+  GenAI reads chat_template.jinja and passes it as template_str to OrtxApplyChatTemplate,
+  whereas our earlier tests used template_str=nullptr (uses the built-in from tokenizer_config.json).
+  This test verifies skip_tool_normalization works when template_str is explicitly provided.
+*/
+TEST(OrtxTokenizerTest, GptOssToolsWithExplicitTemplateStr) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/gpt-oss");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << "Failed to create GPT-OSS tokenizer: " << OrtxGetLastErrorMessage();
+
+  // Read chat_template.jinja file (same as what genai does)
+  std::ifstream jinja_file("data/gpt-oss/chat_template.jinja");
+  ASSERT_TRUE(jinja_file.is_open()) << "Could not open data/gpt-oss/chat_template.jinja";
+  std::string template_str((std::istreambuf_iterator<char>(jinja_file)),
+                            std::istreambuf_iterator<char>());
+  ASSERT_FALSE(template_str.empty()) << "Template file is empty";
+  ASSERT_NE(template_str.find("tool.function"), std::string::npos)
+      << "GPT-OSS template should contain 'tool.function'";
+
+  OrtxObjectPtr<OrtxTensorResult> templated_text;
+  std::string messages_json = R"(
+    [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant."
+      },
+      {
+        "role": "user",
+        "content": "What's the weather in Seattle?"
+      }
+    ])";
+
+  std::string tools_json = R"(
+    [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get current weather for a location.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string",
+                "description": "The city name"
+              }
+            },
+            "required": ["location"]
+          }
+        }
+      }
+    ])";
+
+  // KEY DIFFERENCE: pass template_str explicitly (not nullptr)
+  auto err = OrtxApplyChatTemplate(
+    tokenizer.get(), template_str.c_str(),
+    messages_json.c_str(), tools_json.c_str(),
+    templated_text.ToBeAssigned(), true, false);
+  ASSERT_EQ(err, kOrtxOK) << "Error: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensor> tensor;
+  OrtxTensorResultGetAt(templated_text.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(tensor.Code(), kOrtxOK);
+  const char* text_ptr = nullptr;
+  OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
+
+  std::string output(text_ptr);
+
+  // Same expectations as GptOssChatTemplateWithTools - tools should render as TypeScript namespace
+  EXPECT_NE(output.find("namespace functions {"), std::string::npos)
+      << "Missing TypeScript namespace declaration.\nFull output:\n" << output;
+  EXPECT_NE(output.find("// Get current weather for a location."), std::string::npos)
+      << "Missing tool description in TypeScript format.\nFull output:\n" << output;
+  EXPECT_NE(output.find("type get_weather = ("), std::string::npos)
+      << "Missing tool type declaration.\nFull output:\n" << output;
+  EXPECT_NE(output.find("location"), std::string::npos)
+      << "Missing parameter name.\nFull output:\n" << output;
+  EXPECT_NE(output.find("} // namespace functions"), std::string::npos)
+      << "Missing namespace closing.\nFull output:\n" << output;
+}
+
+/*
+  Test that tools JSON is passed through RAW (not normalized) when skip_tool_normalization fires.
+  Uses a minimal template that dumps the tools JSON so we can inspect the keys directly.
+  This is the definitive test: if tools are raw, tool[0] will have keys "type" and "function".
+  If normalized, tool[0] will have keys "name", "description", "parameters" (no "type"/"function").
+*/
+TEST(OrtxTokenizerTest, GptOssToolsNotNormalized) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/gpt-oss");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << "Failed to create GPT-OSS tokenizer: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensorResult> templated_text;
+  std::string messages_json = R"([{"role":"user","content":"hi"}])";
+  std::string tools_json = R"([{"type":"function","function":{"name":"foo","description":"bar","parameters":{"type":"object","properties":{}}}}])";
+
+  // Minimal template that contains "tool.function" to trigger skip_normalization,
+  // and dumps the first tool's keys so we can verify they're raw
+  std::string minimal_template = R"({% for tool in tools %}{% for k, v in tool.items() %}KEY={{k}} {% endfor %}{% endfor %}<!-- tool.function -->)";
+
+  auto err = OrtxApplyChatTemplate(
+    tokenizer.get(), minimal_template.c_str(),
+    messages_json.c_str(), tools_json.c_str(),
+    templated_text.ToBeAssigned(), true, false);
+  ASSERT_EQ(err, kOrtxOK) << "Error: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensor> tensor;
+  OrtxTensorResultGetAt(templated_text.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(tensor.Code(), kOrtxOK);
+  const char* text_ptr = nullptr;
+  OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
+
+  std::string output(text_ptr);
+
+  // If skip_normalization works, tools are raw: keys should be "type" and "function"
+  EXPECT_NE(output.find("KEY=type"), std::string::npos)
+      << "Raw tools should have 'type' key. Output: " << output;
+  EXPECT_NE(output.find("KEY=function"), std::string::npos)
+      << "Raw tools should have 'function' key. Output: " << output;
+  // Should NOT have normalized keys at top level
+  EXPECT_EQ(output.find("KEY=description"), std::string::npos)
+      << "Raw tools should NOT have 'description' at top level (it's inside .function). Output: " << output;
+}
+
+/*
+  Counterpart: verify tools ARE normalized when template does NOT contain "tool.function".
+  Uses same minimal template approach but without the "tool.function" marker.
+*/
+TEST(OrtxTokenizerTest, ToolsNormalizedWhenNoToolDotFunction) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/gpt-oss");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << "Failed to create GPT-OSS tokenizer: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensorResult> templated_text;
+  std::string messages_json = R"([{"role":"user","content":"hi"}])";
+  std::string tools_json = R"([{"type":"function","function":{"name":"foo","description":"bar","parameters":{"type":"object","properties":{}}}}])";
+
+  // Template WITHOUT "tool.function" - normalization SHOULD happen
+  std::string minimal_template = R"({% for tool in tools %}{% for k, v in tool.items() %}KEY={{k}} {% endfor %}{% endfor %})";
+
+  auto err = OrtxApplyChatTemplate(
+    tokenizer.get(), minimal_template.c_str(),
+    messages_json.c_str(), tools_json.c_str(),
+    templated_text.ToBeAssigned(), true, false);
+  ASSERT_EQ(err, kOrtxOK) << "Error: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensor> tensor;
+  OrtxTensorResultGetAt(templated_text.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(tensor.Code(), kOrtxOK);
+  const char* text_ptr = nullptr;
+  OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
+
+  std::string output(text_ptr);
+
+  // Normalization should have unwrapped: keys should be "name", "description", "parameters"
+  EXPECT_NE(output.find("KEY=name"), std::string::npos)
+      << "Normalized tools should have 'name' key. Output: " << output;
+  EXPECT_NE(output.find("KEY=description"), std::string::npos)
+      << "Normalized tools should have 'description' key. Output: " << output;
+  EXPECT_NE(output.find("KEY=parameters"), std::string::npos)
+      << "Normalized tools should have 'parameters' key. Output: " << output;
+  // Should NOT have the wrapper keys
+  EXPECT_EQ(output.find("KEY=type"), std::string::npos)
+      << "Normalized tools should NOT have 'type' key. Output: " << output;
+  EXPECT_EQ(output.find("KEY=function"), std::string::npos)
+      << "Normalized tools should NOT have 'function' key. Output: " << output;
+}
+
 // ============================================================================
 // Transformers v5 format tests
 // ============================================================================


### PR DESCRIPTION
Skip tool normalization for GPT-OSS/Harmony chat templates

## Summary

GPT-OSS (Harmony) models use chat templates that access `tool.function` directly, expecting the raw OpenAI tool format. The existing `NormalizeTools()` logic unwraps the `function` object from tools, which breaks these templates. This PR adds auto-detection to skip normalization when the template expects the original OpenAI structure.

## Problem

When tools are passed to `ApplyChatTemplate`, they go through `NormalizeTools()` which flattens the OpenAI `{type: "function", function: {name, description, parameters}}` format into a simpler structure. This works for Phi-4 and Qwen templates which expect flattened tools, but **breaks GPT-OSS/Harmony templates** which iterate over `tool.function.name`, `tool.function.description`, etc. directly.

## Solution

Added a template-content-based heuristic in `chat_template.cc`:
- Scan the activated template string for `"tool.function"` references
- Exclude false positives from `"tool_call.function"` (which is a different pattern)
- If found, set `skip_tool_normalization = true` and pass tools as raw JSON without unwrapping

This is backward-compatible — existing Phi-4 and Qwen templates don't match the heuristic and continue to use `NormalizeTools()` as before.

## Files Changed

| File | Change |
|------|--------|
| `shared/api/chat_template.cc` | Skip `NormalizeTools()` for templates that access `tool.function` directly |
| `test/pp_api_test/test_tokenizer_chat.cc` | Comprehensive test cases for Harmony tool calling (template rendering, multi-tool, tool results) |

## Testing

- **Unit tests**: Added test cases in `test_tokenizer_chat.cc` covering single tool, multi-tool, and tool result round-trip scenarios with a Harmony-style chat template
- **E2E validation**: Full tool-calling round-trip tested against `gpt-oss-20b-generic-cpu` in Foundry Local with the corresponding server-side `ToolCallConfig` changes to be published in upcoming PR(s):
  1. User sends chat completion request with tools → model generates Harmony-format tool call → server parses and returns OpenAI-format `tool_calls` response
  2. Tool result fed back → model generates natural language final answer
  - Both calls completed successfully, validating the full pipeline from tokenizer template rendering through GenAI inference to response parsing
