### PR TITLE
Fix Minja OOB & Parser Recursion Vulnerabilities

### DIFF
--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -2281,6 +2281,18 @@ namespace minja
   private:
     using CharIterator = std::string::const_iterator;
 
+    static constexpr size_t MAX_PARSE_DEPTH = 100;
+    size_t parse_depth_ = 0;
+
+    struct DepthGuard {
+      size_t& depth;
+      DepthGuard(size_t& d, size_t max) : depth(d) {
+        if (++depth > max)
+          throw std::runtime_error("Template parsing exceeded maximum nesting depth");
+      }
+      ~DepthGuard() { --depth; }
+    };
+
     std::shared_ptr<std::string> template_str;
     CharIterator start, end, it;
     Options options;
@@ -2535,6 +2547,7 @@ namespace minja
 
     std::shared_ptr<Expression> parseExpression(bool allow_if_expr = true)
     {
+      DepthGuard guard(parse_depth_, MAX_PARSE_DEPTH);
       auto left = parseLogicalOr();
       if (it == end)
         return left;

--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -1708,7 +1708,14 @@ namespace minja
         if (target_value.is_string())
         {
           std::string s = target_value.get<std::string>();
-          
+          int64_t n = static_cast<int64_t>(s.size());
+          // Clamp start/end to valid range per Python slice semantics.
+          auto clamp = [](int64_t i, int64_t lo, int64_t hi) -> int64_t {
+            return std::max(lo, std::min(i, hi));
+          };
+          start = clamp(start, step > 0 ? (int64_t)0 : (int64_t)-1, step > 0 ? n : n - 1);
+          end   = clamp(end,   step > 0 ? (int64_t)0 : (int64_t)-1, step > 0 ? n : n - 1);
+
           std::string result;
           if (start < end && step == 1) {
             result = s.substr(start, end - start);

--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -12,6 +12,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include <algorithm>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -1710,13 +1711,8 @@ namespace minja
           std::string s = target_value.get<std::string>();
           int64_t n = static_cast<int64_t>(s.size());
           // Clamp start/end to valid range per Python slice semantics.
-          auto clamp = [](int64_t i, int64_t lo, int64_t hi) -> int64_t {
-            if (i < lo) return lo;
-            if (i > hi) return hi;
-            return i;
-          };
-          start = clamp(start, step > 0 ? (int64_t)0 : (int64_t)-1, step > 0 ? n : n - 1);
-          end   = clamp(end,   step > 0 ? (int64_t)0 : (int64_t)-1, step > 0 ? n : n - 1);
+          start = std::clamp(start, step > 0 ? (int64_t)0 : (int64_t)-1, step > 0 ? n : n - 1);
+          end   = std::clamp(end,   step > 0 ? (int64_t)0 : (int64_t)-1, step > 0 ? n : n - 1);
 
           std::string result;
           if (start < end && step == 1) {

--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -1711,7 +1711,9 @@ namespace minja
           int64_t n = static_cast<int64_t>(s.size());
           // Clamp start/end to valid range per Python slice semantics.
           auto clamp = [](int64_t i, int64_t lo, int64_t hi) -> int64_t {
-            return std::max(lo, std::min(i, hi));
+            if (i < lo) return lo;
+            if (i > hi) return hi;
+            return i;
           };
           start = clamp(start, step > 0 ? (int64_t)0 : (int64_t)-1, step > 0 ? n : n - 1);
           end   = clamp(end,   step > 0 ? (int64_t)0 : (int64_t)-1, step > 0 ? n : n - 1);

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -1588,3 +1588,25 @@ TEST(OrtxTokenizerTest, MinjaStringSliceOOBClamped) {
     EXPECT_STREQ(text, "ab");
   }
 }
+
+TEST(OrtxTokenizerTest, MinjaParserRecursionDepthLimit) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK);
+
+  std::string messages_json = R"([{"role":"user","content":"hi"}])";
+
+  // A deeply nested template that would previously cause a stack overflow.
+  // Generate ~200 levels of nesting via repeated '{' dictionary openers.
+  std::string deep_template = "{{ ";
+  for (int i = 0; i < 200; ++i) {
+    deep_template += "{";
+  }
+  deep_template += " }}";
+
+  OrtxObjectPtr<OrtxTensorResult> result;
+  auto err = OrtxApplyChatTemplate(
+      tokenizer.get(), deep_template.c_str(),
+      messages_json.c_str(), nullptr, result.ToBeAssigned(), false, false);
+  // Should fail gracefully with an error, not crash with a stack overflow.
+  EXPECT_NE(err, kOrtxOK);
+}

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -1527,3 +1527,64 @@ TEST(OrtxTokenizerTest, Gemma4ChatTemplate) {
   OrtxDetokenize(tokenizer.get(), token_ids2.get(), decoded_text2.ToBeAssigned());
   EXPECT_EQ(decoded_text2.Code(), kOrtxOK);
 }
+
+// Test that string slicing with step != 1 and out-of-range indices does not
+// read out of bounds (previously caused a heap-buffer-overflow read).
+TEST(OrtxTokenizerTest, MinjaStringSliceOOBClamped) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK);
+
+  std::string messages_json = R"([{"role":"user","content":"hi"}])";
+
+  // Slice with step=2 and end far beyond string length.
+  // Previously this would read past the string buffer.
+  {
+    OrtxObjectPtr<OrtxTensorResult> result;
+    auto err = OrtxApplyChatTemplate(
+        tokenizer.get(), "{{ 'abc'[0:65536:2] }}",
+        messages_json.c_str(), nullptr, result.ToBeAssigned(), false, false);
+    ASSERT_EQ(err, kOrtxOK) << OrtxGetLastErrorMessage();
+
+    OrtxObjectPtr<OrtxTensor> tensor;
+    OrtxTensorResultGetAt(result.get(), 0, tensor.ToBeAssigned());
+    ASSERT_EQ(tensor.Code(), kOrtxOK);
+    const char* text = nullptr;
+    OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text), nullptr, nullptr);
+    // Python: 'abc'[0:65536:2] == 'ac'
+    EXPECT_STREQ(text, "ac");
+  }
+
+  // Negative step with start beyond string length.
+  {
+    OrtxObjectPtr<OrtxTensorResult> result;
+    auto err = OrtxApplyChatTemplate(
+        tokenizer.get(), "{{ 'abc'[100:0:-1] }}",
+        messages_json.c_str(), nullptr, result.ToBeAssigned(), false, false);
+    ASSERT_EQ(err, kOrtxOK) << OrtxGetLastErrorMessage();
+
+    OrtxObjectPtr<OrtxTensor> tensor;
+    OrtxTensorResultGetAt(result.get(), 0, tensor.ToBeAssigned());
+    ASSERT_EQ(tensor.Code(), kOrtxOK);
+    const char* text = nullptr;
+    OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text), nullptr, nullptr);
+    // Python: 'abc'[100:0:-1] == 'cb'
+    EXPECT_STREQ(text, "cb");
+  }
+
+  // Negative index wrapping that would remain negative without clamping.
+  {
+    OrtxObjectPtr<OrtxTensorResult> result;
+    auto err = OrtxApplyChatTemplate(
+        tokenizer.get(), "{{ 'abc'[-100:2:1] }}",
+        messages_json.c_str(), nullptr, result.ToBeAssigned(), false, false);
+    ASSERT_EQ(err, kOrtxOK) << OrtxGetLastErrorMessage();
+
+    OrtxObjectPtr<OrtxTensor> tensor;
+    OrtxTensorResultGetAt(result.get(), 0, tensor.ToBeAssigned());
+    ASSERT_EQ(tensor.Code(), kOrtxOK);
+    const char* text = nullptr;
+    OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text), nullptr, nullptr);
+    // Python: 'abc'[-100:2:1] == 'ab'
+    EXPECT_STREQ(text, "ab");
+  }
+}


### PR DESCRIPTION
## Fix OOB read in minja string slice + stack overflow in recursive parser

### Summary

Two security fixes for the minja template engine used by `OrtxApplyChatTemplate`:

1. **Heap OOB read** — `SubscriptExpr::do_evaluate` string slice with `step != 1` and out-of-range indices could read past the string buffer, leaking adjacent memory into rendered output.
2. **Stack overflow** — The recursive descent parser (`parseExpression` chain) had no depth limit, allowing a crafted template as small as 8 bytes to exhaust the call stack.

### Problem 1: String slice OOB read

When a chat template applies a slice with `step != 1` to a string (e.g. `'abc'[0:65536:2]`), `SubscriptExpr::do_evaluate` uses a loop that indexes the string via `std::string::operator[]`. The `wrap()` helper only adjusts negative indices by adding `len`, but never clamps indices to `[0, len)`. This means:

- Positive indices exceeding the string length pass through unchanged
- Negative indices where `|i| > len` remain negative after adjustment

The `step == 1` fast-path safely uses `substr`, but any `step >= 2` or negative step bypasses it and hits the unchecked `s[i]` loop — reading out-of-bounds memory.

### Problem 2: Parser recursion stack overflow

The `minja::Parser` class implements expression parsing as a chain of ~12 mutually recursive functions (`parseExpression` → `parseLogicalOr` → ... → `parseValueExpression` → `parseDictionary` → `parseExpression`) with no recursion depth limit. A crafted template containing nested delimiters causes unbounded recursion, exhausting the stack and crashing the process.

### Fix

**Slice OOB** — Added Python-style slice endpoint clamping in the string branch of `SubscriptExpr::do_evaluate`:

```cpp
int64_t n = static_cast<int64_t>(s.size());
auto clamp = [](int64_t i, int64_t lo, int64_t hi) -> int64_t {
    if (i < lo) return lo;
    if (i > hi) return hi;
    return i;
};
start = clamp(start, step > 0 ? (int64_t)0 : (int64_t)-1, step > 0 ? n : n - 1);
end   = clamp(end,   step > 0 ? (int64_t)0 : (int64_t)-1, step > 0 ? n : n - 1);
```

**Stack overflow** — Added a recursion depth counter with RAII guard to the `Parser` class, checked at the entry of `parseExpression`:

```cpp
static constexpr size_t MAX_PARSE_DEPTH = 100;
size_t parse_depth_ = 0;

struct DepthGuard {
    size_t& depth;
    DepthGuard(size_t& d, size_t max) : depth(d) {
        if (++depth > max)
            throw std::runtime_error("Template parsing exceeded maximum nesting depth");
    }
    ~DepthGuard() { --depth; }
};
```

### Files changed

- `shared/api/minja.hpp` — clamp slice endpoints before the indexing loop; add recursion depth guard to parser
- `test/pp_api_test/test_tokenizer_chat.cc` — new tests `MinjaStringSliceOOBClamped` and `MinjaParserRecursionDepthLimit`

### Testing

New tests:
- **`MinjaStringSliceOOBClamped`** — verifies three cases that previously caused OOB reads:
  - `'abc'[0:65536:2]` → `"ac"` (positive step, end far beyond length)
  - `'abc'[100:0:-1]` → `"cb"` (negative step, start beyond length)
  - `'abc'[-100:2:1]` → `"ab"` (negative index that remains negative after wrap)
- **`MinjaParserRecursionDepthLimit`** — verifies that a deeply nested template (200 levels of `{`) returns an error instead of crashing with a stack overflow.

All `pp_api_test` chat template tests pass.
