### PR TITLE
Fix out-of-bounds error

### DIFF
--- a/operators/text/op_ragged_tensor.cc
+++ b/operators/text/op_ragged_tensor.cc
@@ -60,6 +60,23 @@ OrtStatusPtr KernelRaggedTensoroDense::Compute(const ortc::Tensor<int64_t>& inpu
   const int64_t* p_indices = input3.Data();
 
   int64_t size = input3.NumberOfElement();
+  int64_t n_values = input1.NumberOfElement();
+
+  if (size < 1)
+    return OrtW::CreateStatus("Offsets tensor must not be empty.", ORT_INVALID_ARGUMENT);
+
+  for (int64_t k = 0; k < size; ++k) {
+    if (p_indices[k] < 0 || p_indices[k] > n_values)
+      return OrtW::CreateStatus(
+          MakeString("Offset ", p_indices[k], " at index ", k, " is out of bounds for values tensor of size ", n_values, ".").c_str(),
+          ORT_INVALID_ARGUMENT);
+  }
+
+  for (int64_t k = 1; k < size; ++k) {
+    if (p_indices[k] < p_indices[k - 1])
+      return OrtW::CreateStatus("Offsets tensor must be monotonic non-decreasing.", ORT_INVALID_ARGUMENT);
+  }
+
   int64_t max_col = GetMaxRaggedTensorCol(size, p_indices);
 
   std::vector<int64_t> shape_out{size - 1, max_col};

--- a/operators/text/op_ragged_tensor.cc
+++ b/operators/text/op_ragged_tensor.cc
@@ -68,13 +68,20 @@ OrtStatusPtr KernelRaggedTensoroDense::Compute(const ortc::Tensor<int64_t>& inpu
   for (int64_t k = 0; k < size; ++k) {
     if (p_indices[k] < 0 || p_indices[k] > n_values)
       return OrtW::CreateStatus(
-          MakeString("Offset ", p_indices[k], " at index ", k, " is out of bounds for values tensor of size ", n_values, ".").c_str(),
+          MakeString("Offset ", p_indices[k], " at index ", k,
+                     " is out of valid range [0, ", n_values, "] for values tensor with ", n_values, " elements.")
+              .c_str(),
           ORT_INVALID_ARGUMENT);
   }
 
   for (int64_t k = 1; k < size; ++k) {
-    if (p_indices[k] < p_indices[k - 1])
-      return OrtW::CreateStatus("Offsets tensor must be monotonic non-decreasing.", ORT_INVALID_ARGUMENT);
+    if (p_indices[k] < p_indices[k - 1]) {
+      return OrtW::CreateStatus(
+          MakeString("Offsets tensor must be monotonic non-decreasing, but offsets[", k - 1, "]=", p_indices[k - 1],
+                     " > offsets[", k, "]=", p_indices[k], ".")
+              .c_str(),
+          ORT_INVALID_ARGUMENT);
+    }
   }
 
   int64_t max_col = GetMaxRaggedTensorCol(size, p_indices);

--- a/test/test_math_ops.py
+++ b/test/test_math_ops.py
@@ -92,5 +92,64 @@ class TestMathOpString(unittest.TestCase):
         np.testing.assert_allclose(inv_mat, act_mat, rtol=1.e-2, atol=1.e-3)
 
 
+class TestRaggedTensorToDenseValidation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        nodes = [
+            helper.make_node(
+                "RaggedTensorToDense",
+                inputs=["unused", "values", "default_value", "offsets"],
+                outputs=["out"],
+                domain="ai.onnx.contrib",
+            ),
+        ]
+        inputs = [
+            helper.make_tensor_value_info("unused", onnx_proto.TensorProto.INT64, [0]),
+            helper.make_tensor_value_info("values", onnx_proto.TensorProto.INT64, [None]),
+            helper.make_tensor_value_info("default_value", onnx_proto.TensorProto.INT64, [1]),
+            helper.make_tensor_value_info("offsets", onnx_proto.TensorProto.INT64, [None]),
+        ]
+        output = helper.make_tensor_value_info("out", onnx_proto.TensorProto.INT64, [None])
+        graph = helper.make_graph(nodes, "test_ragged", inputs, [output])
+        cls.model = make_onnx_model(graph)
+
+        so = _ort.SessionOptions()
+        so.register_custom_ops_library(_get_library_path())
+        cls.so = so
+
+    def _run(self, values, offsets):
+        sess = _ort.InferenceSession(self.model.SerializeToString(), self.so, providers=["CPUExecutionProvider"])
+        return sess.run(None, {
+            "unused": np.array([], dtype=np.int64),
+            "values": np.array(values, dtype=np.int64),
+            "default_value": np.array([-1], dtype=np.int64),
+            "offsets": np.array(offsets, dtype=np.int64),
+        })
+
+    def test_empty_offsets(self):
+        with self.assertRaises(Exception) as ctx:
+            self._run([1, 2, 3], [])
+        self.assertIn("must not be empty", str(ctx.exception))
+
+    def test_out_of_range_offset(self):
+        with self.assertRaises(Exception) as ctx:
+            self._run([1, 2, 3], [0, 10])
+        self.assertIn("out of valid range", str(ctx.exception))
+
+    def test_negative_offset(self):
+        with self.assertRaises(Exception) as ctx:
+            self._run([1, 2, 3], [0, -1, 3])
+        self.assertIn("out of valid range", str(ctx.exception))
+
+    def test_non_monotonic_offsets(self):
+        with self.assertRaises(Exception) as ctx:
+            self._run([1, 2, 3], [0, 3, 1])
+        self.assertIn("monotonic non-decreasing", str(ctx.exception))
+
+    def test_valid_offsets(self):
+        result = self._run([10, 20, 30], [0, 2, 3])
+        self.assertEqual(result[0].shape[0], 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request adds input validation to the `KernelRaggedTensoroDense::Compute` function to ensure the correctness of the offsets tensor before further processing. The new checks help prevent out-of-bounds errors and guarantee that the offsets tensor is properly formed.

Input validation improvements:

* Added a check to ensure the offsets tensor (`input3`) is not empty, returning an error if it is.
* Added a check to ensure all offset values are within the valid range for the values tensor (`input1`), returning an error if any are out of bounds.
* Added a check to ensure the offsets tensor is monotonic non-decreasing, returning an error if it is not.