### PR TITLE
Fix out-of-bounds issue

### DIFF
--- a/operators/math/segment_sum.cc
+++ b/operators/math/segment_sum.cc
@@ -21,7 +21,13 @@ OrtStatusPtr segment_sum(const ortc::Tensor<float>& data,
   const int64_t* p_segment_ids = segment_ids.Data();
   const float* p_data = data.Data();
 
+  if (p_segment_ids[0] < 0)
+    return OrtW::CreateStatus("segment_ids must not contain negative values.", ORT_INVALID_ARGUMENT);
+
   int64_t last_seg = p_segment_ids[dim_seg[0] - 1];
+  if (last_seg < 0)
+    return OrtW::CreateStatus("segment_ids must not contain negative values.", ORT_INVALID_ARGUMENT);
+
   std::vector<int64_t> dim_out = dim_data;
   dim_out[0] = last_seg + 1;
 
@@ -42,6 +48,12 @@ OrtStatusPtr segment_sum(const ortc::Tensor<float>& data,
       return OrtW::CreateStatus(MakeString("segment_ids must be increasing but found ",
                                         *(p_seg - 1), " and ", *p_seg, " at position ",
                                         std::distance(p_segment_ids, p_seg), ".").c_str(),
+                             ORT_RUNTIME_EXCEPTION);
+    }
+    if (*p_seg < 0 || *p_seg > last_seg) {
+      return OrtW::CreateStatus(MakeString("segment_ids value ", *p_seg, " at position ",
+                                        std::distance(p_segment_ids, p_seg),
+                                        " is out of range [0, ", last_seg, "].").c_str(),
                              ORT_RUNTIME_EXCEPTION);
     }
     p_out = p_output + *p_seg * in_stride;

--- a/operators/math/segment_sum.cc
+++ b/operators/math/segment_sum.cc
@@ -21,11 +21,12 @@ OrtStatusPtr segment_sum(const ortc::Tensor<float>& data,
   const int64_t* p_segment_ids = segment_ids.Data();
   const float* p_data = data.Data();
 
-  if (p_segment_ids[0] < 0)
-    return OrtW::CreateStatus("segment_ids must not contain negative values.", ORT_INVALID_ARGUMENT);
+  if (dim_seg[0] == 0) {
+    return OrtW::CreateStatus("segment_ids must not be empty.", ORT_INVALID_ARGUMENT);
+  }
 
   int64_t last_seg = p_segment_ids[dim_seg[0] - 1];
-  if (last_seg < 0)
+  if (p_segment_ids[0] < 0 || last_seg < 0)
     return OrtW::CreateStatus("segment_ids must not contain negative values.", ORT_INVALID_ARGUMENT);
 
   std::vector<int64_t> dim_out = dim_data;
@@ -54,7 +55,7 @@ OrtStatusPtr segment_sum(const ortc::Tensor<float>& data,
       return OrtW::CreateStatus(MakeString("segment_ids value ", *p_seg, " at position ",
                                         std::distance(p_segment_ids, p_seg),
                                         " is out of range [0, ", last_seg, "].").c_str(),
-                             ORT_RUNTIME_EXCEPTION);
+                             ORT_INVALID_ARGUMENT);
     }
     p_out = p_output + *p_seg * in_stride;
     p_out_end = p_out + in_stride;

--- a/test/test_math_ops.py
+++ b/test/test_math_ops.py
@@ -60,6 +60,17 @@ class TestMathOpString(unittest.TestCase):
         self.assertEqual(exp.shape, txout[0].shape)
         self.assertEqual(exp.tolist(), txout[0].tolist())
 
+    def test_segment_sum_cc_negative_segment_ids(self):
+        so = _ort.SessionOptions()
+        so.register_custom_ops_library(_get_library_path())
+        onnx_model = _create_test_model_segment_sum("")
+        sess = _ort.InferenceSession(onnx_model.SerializeToString(), so, providers=['CPUExecutionProvider'])
+        data = np.array([[1.0], [2.0]], dtype=np.float32)
+        segment_ids = np.array([-1, 0], dtype=np.int64)
+        with self.assertRaises(Exception) as ctx:
+            sess.run(None, {"data": data, "segment_ids": segment_ids})
+        self.assertIn("negative", str(ctx.exception).lower())
+
     def test_segment_sum_python(self):
         so = _ort.SessionOptions()
         so.register_custom_ops_library(_get_library_path())


### PR DESCRIPTION
This pull request adds input validation to the `segment_sum` operator to ensure that `segment_ids` does not contain negative values and that all values are within the valid range. It also introduces a test to verify that negative `segment_ids` are correctly rejected.

Input validation improvements:

* Added checks in `segment_sum` (in `operators/math/segment_sum.cc`) to return an error if any value in `segment_ids` is negative, including the first and last elements.
* Added a check to ensure all `segment_ids` values are within the range `[0, last_seg]`, returning an error if out of bounds.

Testing:

* Added a unit test `test_segment_sum_cc_negative_segment_ids` in `test/test_math_ops.py` to verify that the operator raises an exception when `segment_ids` contains negative values.