### PR TITLE
Fix audio decoder overflow issue

### DIFF
--- a/operators/audio/audio_decoder.cc
+++ b/operators/audio/audio_decoder.cc
@@ -34,7 +34,8 @@ OrtStatusPtr AudioDecoder::OnModelAttach(const OrtApi& api, const OrtKernelInfo&
   return status;
 }
 
-AudioDecoder::AudioStreamType AudioDecoder::ReadStreamFormat(const uint8_t* p_data, const std::string& str_format,
+AudioDecoder::AudioStreamType AudioDecoder::ReadStreamFormat(const uint8_t* p_data, size_t data_size,
+                                                             const std::string& str_format,
                                                              OrtxStatus& status) const {
   const std::map<std::string, AudioStreamType> format_mapping = {{"default", AudioStreamType::kDefault},
                                                                  {"wav", AudioStreamType::kWAV},
@@ -53,6 +54,10 @@ AudioDecoder::AudioStreamType AudioDecoder::ReadStreamFormat(const uint8_t* p_da
   }
 
   if (stream_format == AudioStreamType::kDefault) {
+    if (data_size < 4) {
+      status = {kOrtxErrorInvalidArgument, "[AudioDecoder]: Audio data too short to detect format"};
+      return stream_format;
+    }
     auto p_stream = reinterpret_cast<char const*>(p_data);
     std::string_view marker(p_stream, 4);
     if (marker == "fLaC") {
@@ -105,7 +110,7 @@ OrtxStatus AudioDecoder::ComputeInternal(const ortc::Tensor<uint8_t>& input, con
   if (format) {
     str_format = *format;
   }
-  auto stream_format = ReadStreamFormat(p_data, str_format, status);
+  auto stream_format = ReadStreamFormat(p_data, input.NumberOfElement(), str_format, status);
   if (!status.IsOk()) {
     return status;
   }

--- a/operators/audio/audio_decoder.h
+++ b/operators/audio/audio_decoder.h
@@ -41,7 +41,7 @@ struct AudioDecoder {
 
   enum class AudioStreamType { kDefault = 0, kWAV, kMP3, kFLAC };
 
-  AudioStreamType ReadStreamFormat(const uint8_t* p_data, const std::string& str_format, OrtxStatus& status) const;
+  AudioStreamType ReadStreamFormat(const uint8_t* p_data, size_t data_size, const std::string& str_format, OrtxStatus& status) const;
 
   OrtxStatus ComputeInternal(const ortc::Tensor<uint8_t>& input,
                              const std::optional<std::string> format,

--- a/test/pp_api_test/test_decode_audio.cc
+++ b/test/pp_api_test/test_decode_audio.cc
@@ -274,7 +274,8 @@ TEST(DecodeAudioTest, GarbageBytes) {
 TEST(DecodeAudioTest, TooShortForFormatDetection) {
   for (size_t len = 0; len <= 3; ++len) {
     std::vector<uint8_t> tiny(len, 0x42);
-    const void* data_ptrs[1] = {tiny.empty() ? nullptr : tiny.data()};
+    static const uint8_t kDummy = 0;
+    const void* data_ptrs[1] = {tiny.empty() ? static_cast<const void*>(&kDummy) : tiny.data()};
     int64_t sizes[1] = {static_cast<int64_t>(len)};
     ort_extensions::OrtxObjectPtr<OrtxRawAudios> raw_audios;
     ASSERT_EQ(OrtxCreateRawAudios(raw_audios.ToBeAssigned(), data_ptrs, sizes, 1), kOrtxOK);

--- a/test/pp_api_test/test_decode_audio.cc
+++ b/test/pp_api_test/test_decode_audio.cc
@@ -269,6 +269,22 @@ TEST(DecodeAudioTest, GarbageBytes) {
   ASSERT_NE(OrtxDecodeAudio(raw_audios.get(), 0, 0, /*stereo_to_mono=*/1, result.ToBeAssigned()), kOrtxOK);
 }
 
+// Audio data shorter than the 4-byte format magic must be rejected gracefully
+// (regression test for heap-buffer-overflow in ReadStreamFormat).
+TEST(DecodeAudioTest, TooShortForFormatDetection) {
+  for (size_t len = 0; len <= 3; ++len) {
+    std::vector<uint8_t> tiny(len, 0x42);
+    const void* data_ptrs[1] = {tiny.empty() ? nullptr : tiny.data()};
+    int64_t sizes[1] = {static_cast<int64_t>(len)};
+    ort_extensions::OrtxObjectPtr<OrtxRawAudios> raw_audios;
+    ASSERT_EQ(OrtxCreateRawAudios(raw_audios.ToBeAssigned(), data_ptrs, sizes, 1), kOrtxOK);
+
+    ort_extensions::OrtxObjectPtr<OrtxTensorResult> result;
+    EXPECT_NE(OrtxDecodeAudio(raw_audios.get(), 0, 0, /*stereo_to_mono=*/1, result.ToBeAssigned()), kOrtxOK)
+        << "Expected failure for " << len << "-byte input";
+  }
+}
+
 // MP3 input via the existing test asset. Verifies that the magic-byte format detector
 // in AudioDecoder works through this entry point.
 TEST(DecodeAudioTest, DecodeMp3FromFile) {


### PR DESCRIPTION
This pull request improves the robustness of the audio decoder by adding input validation to prevent buffer overflows when detecting audio formats, and introduces a regression test to ensure this behavior. The main changes are as follows:

**Audio Decoder Input Validation:**

* The `ReadStreamFormat` method in `AudioDecoder` now takes a `data_size` parameter and checks that the input audio data is at least 4 bytes long before attempting to detect the format, returning an error if it is too short. This prevents a potential heap-buffer-overflow. [[1]](diffhunk://#diff-08390b7f241260344c129ac4c6bacbf4787511d6655e6bbebc4ca0cded5e0769L37-R38) [[2]](diffhunk://#diff-08390b7f241260344c129ac4c6bacbf4787511d6655e6bbebc4ca0cded5e0769R57-R60) [[3]](diffhunk://#diff-390d650ec8953da3b49abdeb4d315b847272bbe2cd08780a0ac1428ec57f00e7L44-R44) [[4]](diffhunk://#diff-08390b7f241260344c129ac4c6bacbf4787511d6655e6bbebc4ca0cded5e0769L108-R113)

**Testing Improvements:**

* Added a new test case `TooShortForFormatDetection` in `test_decode_audio.cc` to verify that audio data shorter than 4 bytes is rejected gracefully, preventing regressions related to buffer overflows in format detection.