### PR TITLE
Fix division by zero issue

### DIFF
--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -1910,9 +1910,14 @@ namespace minja
         case Op::MulMul:
           return std::pow(l.get<double>(), r.get<double>());
         case Op::DivDiv:
-          return l.get<int64_t>() / r.get<int64_t>();
+        {
+          const auto denom = r.get<int64_t>();
+          if (denom == 0)
+            throw std::runtime_error("Division by zero");
+          return l.get<int64_t>() / denom;
+        }
         case Op::Mod:
-          return l.get<int64_t>() % r.get<int64_t>();
+          return l % r;
         case Op::Eq:
           return l == r;
         case Op::Ne:

--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -682,20 +682,23 @@ namespace minja
     Value operator/(const Value &rhs) const
     {
       if (is_number_integer() && rhs.is_number_integer()) {
-        if (rhs.get<int64_t>() == 0)
+        const auto denom = rhs.get<int64_t>();
+        if (denom == 0)
           throw std::runtime_error("Division by zero");
-        return get<int64_t>() / rhs.get<int64_t>();
+        return get<int64_t>() / denom;
       } else {
-        if (rhs.get<double>() == 0.0)
+        const auto denom = rhs.get<double>();
+        if (denom == 0.0)
           throw std::runtime_error("Division by zero");
-        return get<double>() / rhs.get<double>();
+        return get<double>() / denom;
       }
     }
     Value operator%(const Value &rhs) const
     {
-      if (rhs.get<int64_t>() == 0)
+      const auto denom = rhs.get<int64_t>();
+      if (denom == 0)
         throw std::runtime_error("Modulo by zero");
-      return get<int64_t>() % rhs.get<int64_t>();
+      return get<int64_t>() % denom;
     }
   };
 

--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -681,13 +681,20 @@ namespace minja
     }
     Value operator/(const Value &rhs) const
     {
-      if (is_number_integer() && rhs.is_number_integer())
+      if (is_number_integer() && rhs.is_number_integer()) {
+        if (rhs.get<int64_t>() == 0)
+          throw std::runtime_error("Division by zero");
         return get<int64_t>() / rhs.get<int64_t>();
-      else
+      } else {
+        if (rhs.get<double>() == 0.0)
+          throw std::runtime_error("Division by zero");
         return get<double>() / rhs.get<double>();
+      }
     }
     Value operator%(const Value &rhs) const
     {
+      if (rhs.get<int64_t>() == 0)
+        throw std::runtime_error("Modulo by zero");
       return get<int64_t>() % rhs.get<int64_t>();
     }
   };

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -2197,3 +2197,28 @@ TEST(OrtxTokenizerTest, MinjaParserRecursionDepthLimit) {
   // Should fail gracefully with an error, not crash with a stack overflow.
   EXPECT_NE(err, kOrtxOK);
 }
+
+TEST(OrtxTokenizerTest, ChatTemplateDivisionByZero) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << "Failed to create tokenizer, stopping the test.";
+
+  std::string messages_json = R"([{"role":"user","content":"hi"}])";
+
+  // Division by zero should fail gracefully, not crash with SIGFPE.
+  {
+    OrtxObjectPtr<OrtxTensorResult> result;
+    auto err = OrtxApplyChatTemplate(
+        tokenizer.get(), "{{ 1/0 }}",
+        messages_json.c_str(), nullptr, result.ToBeAssigned(), false, false);
+    EXPECT_NE(err, kOrtxOK);
+  }
+
+  // Modulo by zero should fail gracefully, not crash with SIGFPE.
+  {
+    OrtxObjectPtr<OrtxTensorResult> result;
+    auto err = OrtxApplyChatTemplate(
+        tokenizer.get(), "{{ 2%0 }}",
+        messages_json.c_str(), nullptr, result.ToBeAssigned(), false, false);
+    EXPECT_NE(err, kOrtxOK);
+  }
+}

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -2210,7 +2210,7 @@ TEST(OrtxTokenizerTest, ChatTemplateDivisionByZero) {
     auto err = OrtxApplyChatTemplate(
         tokenizer.get(), "{{ 1/0 }}",
         messages_json.c_str(), nullptr, result.ToBeAssigned(), false, false);
-    EXPECT_NE(err, kOrtxOK);
+    EXPECT_NE(err, kOrtxOK) << "Expected division by zero to return an error.";
   }
 
   // Modulo by zero should fail gracefully, not crash with SIGFPE.
@@ -2219,6 +2219,6 @@ TEST(OrtxTokenizerTest, ChatTemplateDivisionByZero) {
     auto err = OrtxApplyChatTemplate(
         tokenizer.get(), "{{ 2%0 }}",
         messages_json.c_str(), nullptr, result.ToBeAssigned(), false, false);
-    EXPECT_NE(err, kOrtxOK);
+    EXPECT_NE(err, kOrtxOK) << "Expected modulo by zero to return an error.";
   }
 }


### PR DESCRIPTION
This pull request adds explicit error handling for division and modulo by zero in the `Value` class and introduces corresponding tests to ensure the application fails gracefully instead of crashing. The changes improve the robustness of mathematical operations and add tests to verify correct error handling.

**Error handling improvements:**

* Added explicit checks in the `Value` class's division (`operator/`) and modulo (`operator%`) operators to throw a `std::runtime_error` when attempting to divide or modulo by zero, preventing undefined behavior and crashes.

**Testing enhancements:**

* Added a new test, `ChatTemplateDivisionByZero`, to verify that division and modulo by zero in chat templates return an error code instead of causing a crash (e.g., SIGFPE).