### PR TITLE
Add missing .replace, .upper, .lower string methods to vendored minja

### DIFF
--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -2197,6 +2197,43 @@ namespace minja
           }
           return res;
         }
+        else if (method->get_name() == "upper")
+        {
+          vargs.expectArgs("upper method", {0, 0}, {0, 0});
+          auto res = str;
+          std::transform(res.begin(), res.end(), res.begin(),
+                         [](unsigned char c) { return std::toupper(c); });
+          return Value(res);
+        }
+        else if (method->get_name() == "lower")
+        {
+          vargs.expectArgs("lower method", {0, 0}, {0, 0});
+          auto res = str;
+          std::transform(res.begin(), res.end(), res.begin(),
+                         [](unsigned char c) { return std::tolower(c); });
+          return Value(res);
+        }
+        else if (method->get_name() == "replace")
+        {
+          vargs.expectArgs("replace method", {2, 3}, {0, 0});
+          auto before = vargs.args[0].get<std::string>();
+          auto after = vargs.args[1].get<std::string>();
+          auto res = str;
+          if (before.empty())
+          {
+            return Value(res);
+          }
+          auto count = vargs.args.size() == 3 ? vargs.args[2].get<int64_t>()
+                                              : static_cast<int64_t>(res.length());
+          size_t start_pos = 0;
+          while ((start_pos = res.find(before, start_pos)) != std::string::npos &&
+                 count-- > 0)
+          {
+            res.replace(start_pos, before.length(), after);
+            start_pos += after.length();
+          }
+          return Value(res);
+        }
       }
       throw std::runtime_error("Unknown method: " + method->get_name());
     }

--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -2200,17 +2200,24 @@ namespace minja
         else if (method->get_name() == "upper")
         {
           vargs.expectArgs("upper method", {0, 0}, {0, 0});
+          // ASCII-only case mapping for deterministic, locale-independent
+          // behavior. Matches upstream minja in practice for ASCII inputs;
+          // non-ASCII bytes are passed through unchanged. Full Unicode
+          // case folding is out of scope for the parser.
           auto res = str;
-          std::transform(res.begin(), res.end(), res.begin(),
-                         [](unsigned char c) { return std::toupper(c); });
+          for (char& c : res) {
+            if (c >= 'a' && c <= 'z') c = static_cast<char>(c - ('a' - 'A'));
+          }
           return Value(res);
         }
         else if (method->get_name() == "lower")
         {
           vargs.expectArgs("lower method", {0, 0}, {0, 0});
+          // ASCII-only case mapping; see .upper() comment above.
           auto res = str;
-          std::transform(res.begin(), res.end(), res.begin(),
-                         [](unsigned char c) { return std::tolower(c); });
+          for (char& c : res) {
+            if (c >= 'A' && c <= 'Z') c = static_cast<char>(c + ('a' - 'A'));
+          }
           return Value(res);
         }
         else if (method->get_name() == "replace")
@@ -2223,8 +2230,18 @@ namespace minja
           {
             return Value(res);
           }
-          auto count = vargs.args.size() == 3 ? vargs.args[2].get<int64_t>()
-                                              : static_cast<int64_t>(res.length());
+          // Python str.replace semantics: count < 0 means "replace all";
+          // count >= 0 limits the number of replacements; omitted argument
+          // also means "replace all".
+          int64_t count = static_cast<int64_t>(res.length());
+          if (vargs.args.size() == 3)
+          {
+            auto requested = vargs.args[2].get<int64_t>();
+            if (requested >= 0)
+            {
+              count = requested;
+            }
+          }
           size_t start_pos = 0;
           while ((start_pos = res.find(before, start_pos)) != std::string::npos &&
                  count-- > 0)

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -2218,11 +2218,14 @@ void ExpectTemplateRenders(OrtxTokenizer* tokenizer,
                           << " err: " << OrtxGetLastErrorMessage();
 
   OrtxObjectPtr<OrtxTensor> tensor;
-  OrtxTensorResultGetAt(result.get(), 0, tensor.ToBeAssigned());
+  err = OrtxTensorResultGetAt(result.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(err, kOrtxOK) << "OrtxTensorResultGetAt failed for template: " << tmpl;
   ASSERT_EQ(tensor.Code(), kOrtxOK);
   const char* text = nullptr;
-  OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text),
-                    nullptr, nullptr);
+  err = OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text),
+                          nullptr, nullptr);
+  ASSERT_EQ(err, kOrtxOK) << "OrtxGetTensorData failed for template: " << tmpl;
+  ASSERT_NE(text, nullptr) << "OrtxGetTensorData returned null data for template: " << tmpl;
   EXPECT_STREQ(text, expected.c_str()) << "template: " << tmpl;
 }
 
@@ -2248,6 +2251,16 @@ TEST(OrtxTokenizerTest, MinjaStringReplace) {
   ExpectTemplateRenders(tokenizer.get(),
                         "{{ 'aaaa'.replace('a', 'X', 2) }}",
                         "XXaa");
+
+  // Python str.replace semantics: count < 0 means "replace all".
+  ExpectTemplateRenders(tokenizer.get(),
+                        "{{ 'aaaa'.replace('a', 'X', -1) }}",
+                        "XXXX");
+
+  // Python str.replace semantics: count == 0 means no replacements.
+  ExpectTemplateRenders(tokenizer.get(),
+                        "{{ 'aaaa'.replace('a', 'X', 0) }}",
+                        "aaaa");
 
   // Replace with empty `before` is a no-op (matches upstream minja behavior).
   ExpectTemplateRenders(tokenizer.get(),

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -2197,3 +2197,78 @@ TEST(OrtxTokenizerTest, MinjaParserRecursionDepthLimit) {
   // Should fail gracefully with an error, not crash with a stack overflow.
   EXPECT_NE(err, kOrtxOK);
 }
+
+// Regression tests for missing string methods (.replace, .upper, .lower) in
+// the vendored minja parser. Chat templates from popular HF models (e.g.
+// smollm3-3b) call these on string values; previously they failed with
+// "Unknown method: <name>". See:
+// - microsoft/onnxruntime-extensions#1081
+// - microsoft/Foundry-Local#800
+namespace {
+
+void ExpectTemplateRenders(OrtxTokenizer* tokenizer,
+                           const std::string& tmpl,
+                           const std::string& expected) {
+  std::string messages_json = R"([{"role":"user","content":"hi"}])";
+  OrtxObjectPtr<OrtxTensorResult> result;
+  auto err = OrtxApplyChatTemplate(
+      tokenizer, tmpl.c_str(), messages_json.c_str(), nullptr,
+      result.ToBeAssigned(), false, false);
+  ASSERT_EQ(err, kOrtxOK) << "template: " << tmpl
+                          << " err: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensor> tensor;
+  OrtxTensorResultGetAt(result.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(tensor.Code(), kOrtxOK);
+  const char* text = nullptr;
+  OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text),
+                    nullptr, nullptr);
+  EXPECT_STREQ(text, expected.c_str()) << "template: " << tmpl;
+}
+
+}  // namespace
+
+TEST(OrtxTokenizerTest, MinjaStringReplace) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK);
+
+  // Single replacement.
+  ExpectTemplateRenders(tokenizer.get(),
+                        "{{ 'foo and foo'.replace('foo', 'bar') }}",
+                        "bar and bar");
+
+  // Chained replace + rstrip, exactly the pattern smollm3-3b uses.
+  ExpectTemplateRenders(
+      tokenizer.get(),
+      "{{ 'be helpful /no_think and /think  '"
+      ".replace('/no_think', '').replace('/think', '').rstrip() }}",
+      "be helpful  and");
+
+  // Replace with optional count argument (Python str.replace semantics).
+  ExpectTemplateRenders(tokenizer.get(),
+                        "{{ 'aaaa'.replace('a', 'X', 2) }}",
+                        "XXaa");
+
+  // Replace with empty `before` is a no-op (matches upstream minja behavior).
+  ExpectTemplateRenders(tokenizer.get(),
+                        "{{ 'abc'.replace('', 'X') }}",
+                        "abc");
+
+  // No match: original string returned unchanged.
+  ExpectTemplateRenders(tokenizer.get(),
+                        "{{ 'abc'.replace('z', 'X') }}",
+                        "abc");
+}
+
+TEST(OrtxTokenizerTest, MinjaStringUpperLower) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK);
+
+  ExpectTemplateRenders(tokenizer.get(), "{{ 'Hello, World!'.upper() }}",
+                        "HELLO, WORLD!");
+  ExpectTemplateRenders(tokenizer.get(), "{{ 'Hello, World!'.lower() }}",
+                        "hello, world!");
+  // Idempotent on already-cased strings.
+  ExpectTemplateRenders(tokenizer.get(), "{{ 'ABC'.upper() }}", "ABC");
+  ExpectTemplateRenders(tokenizer.get(), "{{ 'abc'.lower() }}", "abc");
+}


### PR DESCRIPTION
## Summary

Adds the three missing string-method handlers — `.replace`, `.upper`, `.lower` — to the vendored minja parser at `shared/api/minja.hpp`. These are standard Jinja2 string methods that Hugging Face `transformers` chat templates rely on, and the most impactful gap (`.replace`) currently breaks any model whose `chat_template.jinja` uses it — most visibly `smollm3-3b`, where `OrtxApplyChatTemplate` throws:

```
Unknown method: replace at row 23, column 48:
{%- set custom_instructions = system_message.replace("/no_think", "").replace("/think", "").rstrip() -%}
                                               ^
```

Fixes #1081
Refs microsoft/Foundry-Local#800

## Diff against upstream

Comparing `shared/api/minja.hpp` against current upstream `google/minja`:

| String method | Upstream minja | Before this PR | After this PR |
|---|---|---|---|
| `.strip` / `.rstrip` / `.lstrip` | ✅ | ✅ | ✅ |
| `.split` | ✅ | ✅ | ✅ |
| `.title` | ✅ | ✅ | ✅ |
| `.endswith` / `.startswith` / `.capitalize` | ✅ | ✅ | ✅ |
| `.replace` | ✅ | ❌ | ✅ |
| `.upper` | ✅ | ❌ | ✅ |
| `.lower` | ✅ | ❌ | ✅ |

(Note: `lower` was already available as a global filter — `{{ x \| lower }}` — but not as the method form `x.lower()` that HF templates actually use.)

## Implementation notes

Handlers were added in `MethodCallExpr::do_evaluate` next to the existing string-method dispatch:

- `.replace(before, after[, count])` — left-to-right substring replacement matching Python's `str.replace` and upstream minja. Defaults to all occurrences when `count` is omitted. Empty `before` returns the string unchanged (matches upstream behavior; avoids an infinite loop).
- `.upper()` / `.lower()` — `std::transform` with an `unsigned char`-typed lambda around `std::toupper` / `std::tolower` to avoid undefined behavior on signed-char platforms.

I deliberately limited the scope of this PR to the methods needed to unblock real HF templates today; a full re-sync of `minja.hpp` against current upstream would also be reasonable but is out of scope here.

## Tests

Adds two regression tests in `test/pp_api_test/test_tokenizer_chat.cc`, following the inline-`template_str` pattern introduced in #1070 (`MinjaStringSliceOOBClamped`):

- `MinjaStringReplace` — single replace, chained replace + rstrip (the exact smollm3-3b pattern), three-arg `count`, empty `before`, no-match.
- `MinjaStringUpperLower` — `.upper()` and `.lower()` on mixed-case input, plus idempotent cases.

## Local verification

I verified the fix end-to-end with a small standalone harness that compiles `shared/api/minja.hpp` directly and renders the exact failing line from `smollm3-3b`'s `chat_template.jinja`:

```
template:  {% set custom_instructions = system_message.replace('/no_think', '').replace('/think', '').rstrip() %}{{ custom_instructions }}
context:   { "system_message": "You are helpful /no_think.   " }

before this PR: ERROR: Unknown method: replace at row 1, column 6
after  this PR: OK: "You are helpful ."
```

I did not build the full `pp_api_test` binary locally (would require ORT + sentencepiece + onnxruntime-extensions deps setup on macOS); the new gtest cases are written to existing conventions and will run in CI.

## Follow-up (out of scope here)

It would be worth adding a periodic re-sync of `shared/api/minja.hpp` with current upstream `google/minja`, and/or a regression suite that renders the chat templates of a handful of popular HF models (SmolLM3, Qwen3, Llama-3.x, Phi-4) against `OrtxApplyChatTemplate`, to catch this kind of drift earlier. I'm happy to follow up with that in a separate PR if maintainers want.
