### PR TITLE
windows: open files via std::filesystem::path so libc++ accepts wide paths

### DIFF
--- a/base/file_sys.h
+++ b/base/file_sys.h
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <fstream>
+#include <filesystem>
 
 
 namespace ort_extensions {
@@ -51,7 +52,12 @@ class path {
   std::ifstream open(ios_base::openmode mode = ios_base::in) const {
     // if Windows, need to convert the string to UTF-16
 #ifdef _WIN32
-    return std::ifstream(w_path_, mode);
+    // libc++ (the Windows clang toolchain) provides no std::ifstream ctor
+    // taking a std::wstring -- that overload is an MSVC-STL extension. Route
+    // the wide path through std::filesystem::path, whose basic_ifstream ctor
+    // overload is standard C++17 and is honoured by libc++/libstdc++/MSVC STL
+    // alike, while still preserving the UTF-16 path. (microsoft/onnxruntime-extensions#1071)
+    return std::ifstream(std::filesystem::path(w_path_), mode);
 #else
     return std::ifstream(path_, mode);
 #endif  // _WIN32


### PR DESCRIPTION
`base/file_sys.h`'s `path::open()` constructs a `std::ifstream` directly from the `std::wstring w_path_` on Windows:

```cpp
#ifdef _WIN32
    return std::ifstream(w_path_, mode);
```

That `basic_ifstream` overload taking a wide string is a **Microsoft-STL extension**. **libc++** (the clang Windows toolchain) does not provide it, so the header fails to compile:

```
error: no matching constructor for initialization of 'std::ifstream'
   54 |     return std::ifstream(w_path_, mode);
   note: no known conversion from 'const std::wstring' to 'const char *'
```

This fixes it by constructing a `std::filesystem::path` from the wide string and using `basic_ifstream`'s `filesystem::path` constructor, which is **standard C++17** and honoured by libc++, libstdc++ and MSVC STL alike — while still preserving the UTF-16 path for Unicode filenames.

Fixes #1071 (and the earlier #985).