### PR TITLE
Fix input validation in image resampling and transform pipelines

### DIFF
--- a/shared/api/image_resample.c
+++ b/shared/api/image_resample.c
@@ -716,6 +716,7 @@ precompute_coeffs(
     /* check for overflow using size_t arithmetic to avoid signed int overflow
        in the check itself */
     if (ksize <= 0 ||
+        (size_t)ksize > SIZE_MAX / sizeof(double) ||
         (size_t)outSize > SIZE_MAX / ((size_t)ksize * sizeof(double))) {
         ImagingError_MemoryError();
         return 0;
@@ -1066,6 +1067,10 @@ ImagingResample(Imaging imIn, int xsize, int ysize, int filter, float box[4]) {
     }
 
     /* Validate box coordinates: must be finite, properly ordered, and within image bounds */
+    if (!isfinite(box[0]) || !isfinite(box[1]) ||
+        !isfinite(box[2]) || !isfinite(box[3])) {
+        return (Imaging)ImagingError_ValueError("invalid box (non-finite)");
+    }
     if (box[0] >= box[2] || box[1] >= box[3]) {
         return (Imaging)ImagingError_ValueError("invalid box coordinates");
     }

--- a/shared/api/image_resample.c
+++ b/shared/api/image_resample.c
@@ -705,25 +705,32 @@ precompute_coeffs(
     /* determine support size (length of resampling filter) */
     support = filterp->support * filterscale;
 
-    /* maximum number of coeffs */
+    /* maximum number of coeffs - guard against support values that would
+       overflow int when computing ksize */
+    if (support >= (double)(INT_MAX / 2)) {
+        ImagingError_MemoryError();
+        return 0;
+    }
     ksize = (int)ceil(support) * 2 + 1;
 
-    // check for overflow
-    if (outSize > INT_MAX / (ksize * (int)sizeof(double))) {
+    /* check for overflow using size_t arithmetic to avoid signed int overflow
+       in the check itself */
+    if (ksize <= 0 ||
+        (size_t)outSize > SIZE_MAX / ((size_t)ksize * sizeof(double))) {
         ImagingError_MemoryError();
         return 0;
     }
 
     /* coefficient buffer */
     /* malloc check ok, overflow checked above */
-    kk = malloc(outSize * ksize * sizeof(double));
+    kk = malloc((size_t)outSize * (size_t)ksize * sizeof(double));
     if (!kk) {
         ImagingError_MemoryError();
         return 0;
     }
 
     /* malloc check ok, ksize*sizeof(double) > 2*sizeof(int) */
-    bounds = malloc(outSize * 2 * sizeof(int));
+    bounds = malloc((size_t)outSize * 2 * sizeof(int));
     if (!bounds) {
         free(kk);
         ImagingError_MemoryError();
@@ -1052,6 +1059,20 @@ ImagingResample(Imaging imIn, int xsize, int ysize, int filter, float box[4]) {
     struct filter *filterp;
     ResampleFunction ResampleHorizontal;
     ResampleFunction ResampleVertical;
+
+    /* Validate output size */
+    if (xsize <= 0 || ysize <= 0) {
+        return (Imaging)ImagingError_ValueError("invalid output size");
+    }
+
+    /* Validate box coordinates: must be finite, properly ordered, and within image bounds */
+    if (box[0] >= box[2] || box[1] >= box[3]) {
+        return (Imaging)ImagingError_ValueError("invalid box coordinates");
+    }
+    if (box[0] < 0 || box[1] < 0 ||
+        box[2] > (float)imIn->xsize || box[3] > (float)imIn->ysize) {
+        return (Imaging)ImagingError_ValueError("box exceeds image bounds");
+    }
 
     if (strcmp(imIn->mode, "P") == 0 || strcmp(imIn->mode, "1") == 0) {
         return (Imaging)ImagingError_ModeError();

--- a/shared/api/image_transforms.hpp
+++ b/shared/api/image_transforms.hpp
@@ -189,6 +189,9 @@ struct Resize {
 
     auto output_image = ImagingResample(rgb_image, static_cast<int>(width), static_cast<int>(height), interp, box);
     ImagingDelete(rgb_image);
+    if (output_image == nullptr) {
+      return {kOrtxErrorOutOfMemory, "[Resize]: Failed to resample image"};
+    }
 
     auto* p_output_image = output.Allocate({height, width, c});
     for (auto i = height - height; i < height; ++i) {

--- a/shared/api/image_transforms.hpp
+++ b/shared/api/image_transforms.hpp
@@ -190,7 +190,7 @@ struct Resize {
     auto output_image = ImagingResample(rgb_image, static_cast<int>(width), static_cast<int>(height), interp, box);
     ImagingDelete(rgb_image);
     if (output_image == nullptr) {
-      return {kOrtxErrorOutOfMemory, "[Resize]: Failed to resample image"};
+      return {kOrtxErrorInvalidArgument, "[Resize]: ImagingResample failed (invalid parameters, unsupported mode, or out of memory)"};
     }
 
     auto* p_output_image = output.Allocate({height, width, c});

--- a/shared/api/image_transforms_phi_3.hpp
+++ b/shared/api/image_transforms_phi_3.hpp
@@ -183,6 +183,10 @@ inline OrtxStatus phi3_hd_transform(const ortc::Tensor<uint8_t>& input, ortc::Te
   int32_t h = static_cast<int32_t>(dimensions[0]);
   int32_t w = static_cast<int32_t>(dimensions[1]);
   int32_t c = static_cast<int32_t>(dimensions[2]);
+  if (c != 3) {
+    return {kOrtxErrorInvalidArgument,
+            "[phi3_hd_transform]: Expected 3-channel RGB input, got " + std::to_string(c) + " channels"};
+  }
   // std::vector<int32_t> height_x_width{static_cast<int32_t>(h),   // H
   //                                     static_cast<int32_t>(w)};  // W
 

--- a/shared/api/image_transforms_phi_4.hpp
+++ b/shared/api/image_transforms_phi_4.hpp
@@ -293,7 +293,7 @@ class Phi4VisionDynamicPreprocess {
     auto output_image = ImagingResample(image, static_cast<int>(new_size.first), static_cast<int>(new_size.second),
                                         IMAGING_TRANSFORM_BILINEAR, box);
     if (output_image == nullptr) {
-      return {kOrtxErrorOutOfMemory, "[Phi4VisionProcessor]: Failed to resample image"};
+      return {kOrtxErrorInvalidArgument, "[Phi4VisionProcessor]: ImagingResample failed (invalid parameters, unsupported mode, or out of memory)"};
     }
 
     /*

--- a/shared/api/image_transforms_phi_4.hpp
+++ b/shared/api/image_transforms_phi_4.hpp
@@ -292,6 +292,9 @@ class Phi4VisionDynamicPreprocess {
     float box[4] = {0.0f, 0.0f, static_cast<float>(image->xsize), static_cast<float>(image->ysize)};
     auto output_image = ImagingResample(image, static_cast<int>(new_size.first), static_cast<int>(new_size.second),
                                         IMAGING_TRANSFORM_BILINEAR, box);
+    if (output_image == nullptr) {
+      return {kOrtxErrorOutOfMemory, "[Phi4VisionProcessor]: Failed to resample image"};
+    }
 
     /*
       resized_img = torchvision.transforms.functional.pad(


### PR DESCRIPTION
## Fix input validation issues in image resampling and transform pipelines

### Summary

This PR adds missing input validation to the image processing pipeline to prevent crashes and out-of-bounds memory access from malformed inputs.

### Changes

**`shared/api/image_resample.c`**
- Fix integer overflow in `precompute_coeffs()`: the overflow-protection check itself used `int` arithmetic that could wrap on extreme resize ratios (e.g., 50M pixels → 1 pixel). Replaced with `size_t` arithmetic and added an early guard on `support` before computing `ksize`.
- Add box coordinate validation in `ImagingResample()`: reject reversed coordinates (`left >= right` or `top >= bottom`), out-of-image-bounds boxes, and non-positive output dimensions. Previously, reversed box values caused undersized buffer allocations leading to out-of-bounds reads.

**`shared/api/image_transforms.hpp`**
- Add NULL check on `ImagingResample()` return value in `Resize::Compute()`. The function can return NULL on error (unsupported mode, allocation failure, invalid parameters) but the result was dereferenced unconditionally.

**`shared/api/image_transforms_phi_4.hpp`**
- Add NULL check on `ImagingResample()` return value in the Phi-4 vision resize path (same issue as above).

**`shared/api/image_transforms_phi_3.hpp`**
- Add channel count validation in `phi3_hd_transform()`. The function reads the channel count from the input tensor shape but allocates the output buffer with a hardcoded 3-channel layout. A non-3-channel input would cause writes past the allocated buffer. This matches the existing validation already present in the Phi-4 transform.

### Testing

These fixes are pure input-validation guards. The overflow path requires a ~50-million-pixel image, the NULL deref requires an allocation failure or unsupported mode (which upstream decoders already reject), and the channel mismatch requires bypassing the RGB decoder that hardcodes 3 channels. All are defense-in-depth checks.
