### PR TITLE
Fix out-of-bounds reads in CenterCrop and LoadCharsMap

### DIFF
--- a/operators/tokenizer/ugm_kernels.hpp
+++ b/operators/tokenizer/ugm_kernels.hpp
@@ -93,9 +93,13 @@ struct SpmUgmTokenizer {
 
       // First four bytes of precompiled_charsmap contains length of binary
       // blob containing XOR-compressed compact double array (XCDA) entries
-      uint32_t xcda_blob_size = *(const uint32_t*)&charsmap_data_[0];
+      if (charsmap_data_.size() < sizeof(uint32_t)) {
+        return OrtxStatus(extError_t::kOrtxErrorCorruptData, "Invalid charsmap header size");
+      }
+      uint32_t xcda_blob_size;
+      memcpy(&xcda_blob_size, charsmap_data_.data(), sizeof(uint32_t));
       charsmap_offset += sizeof(xcda_blob_size);
-      if (xcda_blob_size + charsmap_offset >= charsmap_data_.size()) {
+      if (xcda_blob_size > charsmap_data_.size() - charsmap_offset) {
         return OrtxStatus(extError_t::kOrtxErrorCorruptData, "Index out of array bounds in precompiled charsmap!");
       }
 

--- a/shared/api/image_transforms.hpp
+++ b/shared/api/image_transforms.hpp
@@ -406,6 +406,10 @@ struct CenterCrop {
     auto w = dimensions[1];
     auto c = dimensions[2];
 
+    if (target_h_ > h || target_w_ > w) {
+      return {kOrtxErrorInvalidArgument, "[CenterCrop]: target dimensions exceed input image size"};
+    }
+
     auto* p_output_image = output.Allocate({target_h_, target_w_, c});
     auto s_h = (h - target_h_) / 2;
     auto s_w = (w - target_w_) / 2;


### PR DESCRIPTION
## Fix out-of-bounds reads in image crop and tokenizer charsmap parsing

### Summary

This PR adds missing bounds checks to prevent out-of-bounds memory reads from malformed inputs in two code paths.

### Changes

**`shared/api/image_transforms.hpp`**
- Fix OOB read in `CenterCrop::Compute()`: when `target_h_` or `target_w_` exceeds the input image dimensions, the crop offset calculation underflows (unsigned subtraction wrap-around), causing reads far outside the image buffer. Added an early check that rejects inputs where target dimensions exceed the source image size.

**`operators/tokenizer/ugm_kernels.hpp`**
- Fix OOB read in `SpmUgmTokenizer::LoadCharsMap()`: the precompiled charsmap binary blob is read without first verifying it contains at least 4 bytes for the header. A too-short blob causes an out-of-bounds read on the first `uint32_t` access.
- Fix integer overflow in the subsequent bounds check: the original check `xcda_blob_size + charsmap_offset >= size` can overflow on 32-bit platforms when `xcda_blob_size` is near `UINT32_MAX`, wrapping to a small value and bypassing the guard. Replaced with overflow-safe subtraction form: `xcda_blob_size > size - charsmap_offset`.
- Replaced type-punning pointer cast with `memcpy` to avoid potential undefined behavior from unaligned reads.