### PR TITLE
Fix OOB heap read in Gemma4LogMel per-bin normalization

### DIFF
--- a/shared/api/gemma4_audio_features.hpp
+++ b/shared/api/gemma4_audio_features.hpp
@@ -8,6 +8,7 @@
 #include <complex>
 #include <algorithm>
 #include <numeric>
+#include <string>
 
 #include "ext_status.h"
 #include "op_def_struct.h"
@@ -298,6 +299,26 @@ class Gemma4LogMel {
         return {kOrtxErrorInvalidArgument,
                 "[Gemma4LogMel]: unknown attribute '" + key + "'"};
       }
+    }
+
+    // Validate that optional per-bin normalization vectors match feature_size_.
+    // Compute() indexes these by m in [0, feature_size_) guarded only by
+    // !empty(), so a shorter vector would cause an out-of-bounds heap read.
+    if (!per_bin_mean_.empty() &&
+        per_bin_mean_.size() != static_cast<size_t>(feature_size_)) {
+      return {kOrtxErrorInvalidArgument,
+              "[Gemma4LogMel]: per_bin_mean length (" +
+              std::to_string(per_bin_mean_.size()) +
+              ") must equal feature_size (" +
+              std::to_string(feature_size_) + ")"};
+    }
+    if (!per_bin_stddev_.empty() &&
+        per_bin_stddev_.size() != static_cast<size_t>(feature_size_)) {
+      return {kOrtxErrorInvalidArgument,
+              "[Gemma4LogMel]: per_bin_stddev length (" +
+              std::to_string(per_bin_stddev_.size()) +
+              ") must equal feature_size (" +
+              std::to_string(feature_size_) + ")"};
     }
 
     // Derive sample-domain lengths from millisecond config.

--- a/test/pp_api_test/test_feature_extraction.cc
+++ b/test/pp_api_test/test_feature_extraction.cc
@@ -447,3 +447,100 @@ TEST(ExtractorTest, TestGemma4AudioFeatureExtractionMultiFile) {
   ASSERT_EQ(mask_dims, 2ULL);
   ASSERT_EQ(mask_shape[0], 2);
 }
+
+// Regression test: a Gemma4LogMel config whose per_bin_mean / per_bin_stddev
+// length does not match feature_size must be rejected at Init time. Previously
+// Compute() indexed these vectors by m in [0, feature_size_) guarded only by
+// !empty(), causing an out-of-bounds heap read (and heap disclosure through the
+// output tensor) for every audio frame.
+TEST(ExtractorTest, TestGemma4LogMelRejectsMismatchedNormalizationLength) {
+  // feature_size = 128 but per_bin_mean has a single element.
+  const char* mismatched_mean_def = R"({
+    "feature_extraction": {
+      "sequence": [
+        {
+          "operation": {
+            "name": "gemma4_log_mel",
+            "type": "Gemma4LogMel",
+            "attrs": {
+              "feature_size": 128,
+              "sampling_rate": 16000,
+              "frame_length_ms": 20.0,
+              "hop_length_ms": 10.0,
+              "per_bin_mean": [0.0],
+              "per_bin_stddev": [1.0]
+            }
+          }
+        }
+      ]
+    }
+  })";
+
+  OrtxFeatureExtractor* extractor = nullptr;
+  extError_t err = OrtxCreateSpeechFeatureExtractor(&extractor, mismatched_mean_def);
+  EXPECT_NE(err, kOrtxOK) << "Init should reject per_bin_mean length != feature_size";
+  EXPECT_EQ(extractor, nullptr);
+  if (extractor != nullptr) {
+    OrtxDisposeOnly(extractor);
+  }
+
+  // feature_size = 128, per_bin_mean matches but per_bin_stddev is too short.
+  const char* mismatched_stddev_def = R"({
+    "feature_extraction": {
+      "sequence": [
+        {
+          "operation": {
+            "name": "gemma4_log_mel",
+            "type": "Gemma4LogMel",
+            "attrs": {
+              "feature_size": 3,
+              "sampling_rate": 16000,
+              "frame_length_ms": 20.0,
+              "hop_length_ms": 10.0,
+              "per_bin_mean": [0.0, 0.0, 0.0],
+              "per_bin_stddev": [1.0]
+            }
+          }
+        }
+      ]
+    }
+  })";
+
+  extractor = nullptr;
+  err = OrtxCreateSpeechFeatureExtractor(&extractor, mismatched_stddev_def);
+  EXPECT_NE(err, kOrtxOK) << "Init should reject per_bin_stddev length != feature_size";
+  EXPECT_EQ(extractor, nullptr);
+  if (extractor != nullptr) {
+    OrtxDisposeOnly(extractor);
+  }
+
+  // Sanity check: a correctly-sized config is accepted.
+  const char* matched_def = R"({
+    "feature_extraction": {
+      "sequence": [
+        {
+          "operation": {
+            "name": "gemma4_log_mel",
+            "type": "Gemma4LogMel",
+            "attrs": {
+              "feature_size": 3,
+              "sampling_rate": 16000,
+              "frame_length_ms": 20.0,
+              "hop_length_ms": 10.0,
+              "per_bin_mean": [0.0, 0.0, 0.0],
+              "per_bin_stddev": [1.0, 1.0, 1.0]
+            }
+          }
+        }
+      ]
+    }
+  })";
+
+  extractor = nullptr;
+  err = OrtxCreateSpeechFeatureExtractor(&extractor, matched_def);
+  EXPECT_EQ(err, kOrtxOK) << "Init should accept matching normalization lengths";
+  EXPECT_NE(extractor, nullptr);
+  if (extractor != nullptr) {
+    OrtxDisposeOnly(extractor);
+  }
+}


### PR DESCRIPTION
## Summary
Gemma4LogMel::Compute iterates m over [0, feature_size_) and reads per_bin_mean_[m] / per_bin_stddev_[m], but Init() populates `feature_size_` and the two vectors from independent JSON config attributes with no size cross-check. A config with e.g.  feature_size: 128 and per_bin_mean: [0.0] causes out-of-bounds std::vector<float>::operator[] reads past the allocation for every audio frame.).

## Fix
Validate the size invariant in Gemma4LogMel::Init immediately after the attribute loop: if per_bin_mean / per_bin_stddev is non-empty, its length must equal eature_size, otherwise return kOrtxErrorInvalidArgument. Rejecting the malformed config is preferable to a partial (semantically wrong) normalization.

## Details
- shared/api/gemma4_audio_features.hpp: added post-parse size validation for per_bin_mean_ and per_bin_stddev_.
- Added #include <string> for std::to_string.