### PR TITLE
Support Jinja2 implicit adjacent string-literal concatenation in minja

### DIFF
--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -2463,7 +2463,16 @@ namespace minja
       {
         auto str = parseString();
         if (str)
+        {
+          // Jinja2 (like Python) implicitly concatenates adjacent string
+          // literals, e.g. {{ "foo" "bar" }} -> "foobar". parseString()
+          // skips leading whitespace and returns nullptr when the next
+          // token is not a string literal, so loop to merge any run of
+          // consecutive literals into a single constant.
+          for (auto next = parseString(); next; next = parseString())
+            *str += *next;
           return std::make_shared<Value>(*str);
+        }
       }
       static std::regex prim_tok(R"(true\b|True\b|false\b|False\b|None\b)");
       auto token = consumeToken(prim_tok);

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -1829,6 +1829,40 @@ TEST(OrtxTokenizerTest, ToolsNormalizedWhenNoToolDotFunction) {
       << "Normalized tools should NOT have 'function' key. Output: " << output;
 }
 
+/*
+  Verify that minja supports Jinja2 implicit concatenation of adjacent string
+  literals, e.g. {{ "foo" "bar" }} -> "foobar". This mirrors Python/Jinja2
+  semantics and is used by real templates (e.g. google/gemma-4-E2B-it's
+  chat_template.jinja splits a long raise_exception() message across adjacent
+  string literals). Without this support, minja::Parser::parse() throws and the
+  whole template becomes unusable.
+*/
+TEST(OrtxTokenizerTest, AdjacentStringLiteralConcatenation) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/gpt-oss");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << "Failed to create GPT-OSS tokenizer: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensorResult> templated_text;
+  std::string messages_json = R"([{"role":"user","content":"hi"}])";
+
+  // Adjacent literals on one line, across a newline, and with mixed quotes.
+  std::string tmpl = "{{ \"Hello, \" \"world\" '!' }}"
+                     "{{ \"a\"\n\"b\"\n\"c\" }}";
+
+  auto err = OrtxApplyChatTemplate(
+    tokenizer.get(), tmpl.c_str(),
+    messages_json.c_str(), nullptr,
+    templated_text.ToBeAssigned(), true, false);
+  ASSERT_EQ(err, kOrtxOK) << "Adjacent string literals should parse. Error: " << OrtxGetLastErrorMessage();
+
+  OrtxObjectPtr<OrtxTensor> tensor;
+  OrtxTensorResultGetAt(templated_text.get(), 0, tensor.ToBeAssigned());
+  ASSERT_EQ(tensor.Code(), kOrtxOK);
+  const char* text_ptr = nullptr;
+  OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text_ptr), nullptr, nullptr);
+
+  ASSERT_EQ(std::string(text_ptr), "Hello, world!abc");
+}
+
 // ============================================================================
 // Transformers v5 format tests
 // ============================================================================


### PR DESCRIPTION
## Problem

Jinja2 (like Python) implicitly concatenates adjacent string literals, e.g. `{{ "foo" "bar" }}` renders as `foobar`. minja's `parseConstant` only consumed a **single** string literal, so it threw `Expected closing parenthesis in call args` whenever a template placed two string literals next to each other.

This breaks real, valid templates. For example [`google/gemma-4-E2B-it`](https://huggingface.co/google/gemma-4-E2B-it)'s `chat_template.jinja` splits a long `raise_exception(...)` message across adjacent string literals:

```jinja
{{- raise_exception("chat_template: tool_calls[].function.arguments must be a "
                    "JSON object (mapping), not a string. Deserialize arguments "
                    "before passing to the template.") -}}
```

`minja::Parser::parse()` fails at that line, so the entire template is rejected and `OrtxApplyChatTemplate` (used by onnxruntime-genai) becomes unusable for the model.

**Before** (parsing the Gemma-4 template):
```
PARSE FAILED: Expected closing parenthesis in call args at row 259, column 29
```
**After:** `PARSE OK`.

## Fix

In `parseConstant`, after reading a string literal, loop and merge any run of consecutive string literals into a single constant — matching Jinja2/Python semantics. `parseString()` already skips leading whitespace and returns `nullptr` when the next token is not a string literal, so the loop terminates naturally and does not affect any other expression form.

## Test

Adds `OrtxTokenizerTest.AdjacentStringLiteralConcatenation`, covering single-line (`"Hello, " "world" '!'`), cross-newline, and mixed-quote concatenation. Also verified existing behavior is unaffected (explicit `~` concat, numbers, conditionals) via a standalone render harness.