### PR TITLE
Fix OOB reads in tokenizer decoders, image transforms, and speech features

### DIFF
--- a/operators/tokenizer/bert_tokenizer_decoder.cc
+++ b/operators/tokenizer/bert_tokenizer_decoder.cc
@@ -165,9 +165,15 @@ void KernelBertTokenizerDecoder::Compute(const ortc::Tensor<int64_t>& ids,
     output_dim[0] = 1;
   } else {
     if (p_positions != nullptr) {
+      const int64_t n_ids = ids.NumberOfElement();
       for (int i = 0; i < positions_dim[0]; i++) {
         int64_t start = p_positions[2 * i];
         int64_t end = p_positions[2 * i + 1];
+        if (start < 0 || end < start || end > n_ids) {
+          ORTX_CXX_API_THROW(MakeString("[BertTokenizerDecoder]: positions[", i, "] = [", start, ", ", end,
+                                        "] is out of range for ids of size ", n_ids, "."),
+                             ORT_INVALID_ARGUMENT);
+        }
 
         result.push_back(decoder_->Decode(std::vector<int64_t>(p_ids + start, p_ids + end),
                                           skip_special_tokens_, clean_up_tokenization_spaces_));

--- a/operators/tokenizer/bpe_decoder.hpp
+++ b/operators/tokenizer/bpe_decoder.hpp
@@ -155,7 +155,7 @@ struct KernelBpeDecoder {
       std::string text;
       bool f_special_last = false;
       bool f_special = false;
-      auto count = static_cast<size_t>(ids.NumberOfElement());
+      auto count = static_cast<size_t>(seq_len);
 
       for (size_t tok_idx = 0; tok_idx < count; ++tok_idx) {
         const auto token = *(p_ids + tok_idx);

--- a/operators/tokenizer/trie_tokenizer.hpp
+++ b/operators/tokenizer/trie_tokenizer.hpp
@@ -165,7 +165,7 @@ struct KernelTrieDetokenizer {
     const int64_t* p_ids = tokens.Data();
     const auto& ids_dim = tokens.Shape();
     if (ids_dim.size() < 1 || ids_dim.size() > 2) {
-      return {kOrtxErrorInvalidArgument, "[TrieDetokenizer]: ids tensor must be rank 1 or 2"};
+      ORTX_CXX_API_THROW("[TrieDetokenizer]: ids tensor must be rank 1 or 2", ORT_INVALID_ARGUMENT);
     }
     // Treat rank-1 [N] as [1, N]
     int64_t seq_len = ids_dim.size() == 2 ? ids_dim[1] : ids_dim[0];

--- a/operators/tokenizer/trie_tokenizer.hpp
+++ b/operators/tokenizer/trie_tokenizer.hpp
@@ -164,17 +164,13 @@ struct KernelTrieDetokenizer {
   OrtStatusPtr Compute(const ortc::Tensor<int64_t>& tokens, ortc::Tensor<std::string>& text) const {
     const int64_t* p_ids = tokens.Data();
     const auto& ids_dim = tokens.Shape();
-    std::vector<int64_t> output_dim = {1};
-    if (ids_dim.size() < 1) {
-      return {};
+    if (ids_dim.size() < 1 || ids_dim.size() > 2) {
+      return {kOrtxErrorInvalidArgument, "[TrieDetokenizer]: ids tensor must be rank 1 or 2"};
     }
     // Treat rank-1 [N] as [1, N]
-    int64_t seq_len = ids_dim.size() >= 2 ? ids_dim[1] : ids_dim[0];
-    int64_t batch = ids_dim.size() >= 2 ? ids_dim[0] : 1;
-    if (ids_dim.size() > 1) {
-      output_dim.resize(ids_dim.size() - 1);
-      std::copy(ids_dim.begin(), ids_dim.begin() + ids_dim.size() - 1, output_dim.begin());
-    }
+    int64_t seq_len = ids_dim.size() == 2 ? ids_dim[1] : ids_dim[0];
+    int64_t batch = ids_dim.size() == 2 ? ids_dim[0] : 1;
+    std::vector<int64_t> output_dim = {batch};
 
     std::vector<std::string> output(output_dim[0]);
     bool failed = false;

--- a/operators/tokenizer/trie_tokenizer.hpp
+++ b/operators/tokenizer/trie_tokenizer.hpp
@@ -165,6 +165,12 @@ struct KernelTrieDetokenizer {
     const int64_t* p_ids = tokens.Data();
     const auto& ids_dim = tokens.Shape();
     std::vector<int64_t> output_dim = {1};
+    if (ids_dim.size() < 1) {
+      return {};
+    }
+    // Treat rank-1 [N] as [1, N]
+    int64_t seq_len = ids_dim.size() >= 2 ? ids_dim[1] : ids_dim[0];
+    int64_t batch = ids_dim.size() >= 2 ? ids_dim[0] : 1;
     if (ids_dim.size() > 1) {
       output_dim.resize(ids_dim.size() - 1);
       std::copy(ids_dim.begin(), ids_dim.begin() + ids_dim.size() - 1, output_dim.begin());
@@ -174,8 +180,8 @@ struct KernelTrieDetokenizer {
     bool failed = false;
     for (auto n = 0; n < output_dim[0]; n++) {
       std::vector<int> ids;
-      for (auto i = 0; i < ids_dim[1]; i++) {
-        ids.push_back(ort_extensions::narrow<int>(p_ids[n * ids_dim[1] + i]));
+      for (int64_t i = 0; i < seq_len; i++) {
+        ids.push_back(ort_extensions::narrow<int>(p_ids[n * seq_len + i]));
       }
       auto raw_string = tokenizer->decodeBytes(ids);
       if (ustring::ValidateUTF8(raw_string) > 0) {

--- a/operators/tokenizer/wordpiece_tokenizer.cc
+++ b/operators/tokenizer/wordpiece_tokenizer.cc
@@ -70,11 +70,7 @@ void KernelWordpieceTokenizer_Tokenizer(const std::unordered_map<std::u32string,
   for (it = texts.begin(), text_index = 0; it != texts.end(); ++it, ++text_index) {
     if (no_existing_rows) {
       rows.push_back(indices.size());
-    } else if (text_index == existing_rows[row_index]) {
-      if (row_index >= n_existing_rows)
-        ORTX_CXX_API_THROW(MakeString(
-                               "row_index=", row_index, " is out of range=", n_existing_rows, "."),
-                           ORT_INVALID_ARGUMENT);
+    } else if (row_index < n_existing_rows && text_index == existing_rows[row_index]) {
       rows.push_back(indices.size());
       ++row_index;
     }

--- a/shared/api/image_transforms.hpp
+++ b/shared/api/image_transforms.hpp
@@ -340,7 +340,8 @@ struct Normalize {
     if (C != static_cast<int64_t>(mean_.size()) || C != static_cast<int64_t>(std_.size())) {
       return {kOrtxErrorInvalidArgument,
               "[Normalize]: channel count " + std::to_string(C) +
-              " does not match mean/std size " + std::to_string(mean_.size())};
+              " does not match mean/std size (mean=" + std::to_string(mean_.size()) +
+              ", std=" + std::to_string(std_.size()) + ")"};
     }
 
     float* out = output.Allocate({H, W, C});
@@ -479,7 +480,8 @@ struct Permute3D {
     }
 
     if (dims_.size() != 3 || dims_[0] < 0 || dims_[0] > 2 ||
-        dims_[1] < 0 || dims_[1] > 2 || dims_[2] < 0 || dims_[2] > 2) {
+        dims_[1] < 0 || dims_[1] > 2 || dims_[2] < 0 || dims_[2] > 2 ||
+        dims_[0] == dims_[1] || dims_[0] == dims_[2] || dims_[1] == dims_[2]) {
       return {kOrtxErrorInvalidArgument, "[Permute]: dims must be a permutation of {0, 1, 2}"};
     }
 

--- a/shared/api/image_transforms.hpp
+++ b/shared/api/image_transforms.hpp
@@ -155,6 +155,10 @@ struct Resize {
     int w = static_cast<int>(dimensions[1]);
     int c = static_cast<int>(dimensions[2]);
 
+    if (c != 3) {
+      return {kOrtxErrorInvalidArgument, "[Resize]: Expected 3-channel RGB input, got " + std::to_string(c) + " channels"};
+    }
+
     Imaging rgb_image = ImagingNew("RGB", w, h);
     for (int32_t i = 0; i < h; ++i) {
       for (int32_t j = 0; j < w; ++j) {
@@ -333,6 +337,12 @@ struct Normalize {
     int64_t W = dimensions[1];
     int64_t C = dimensions[2];
 
+    if (C != static_cast<int64_t>(mean_.size()) || C != static_cast<int64_t>(std_.size())) {
+      return {kOrtxErrorInvalidArgument,
+              "[Normalize]: channel count " + std::to_string(C) +
+              " does not match mean/std size " + std::to_string(mean_.size())};
+    }
+
     float* out = output.Allocate({H, W, C});
 
     if (!qwen2_5_vl_) {
@@ -466,6 +476,11 @@ struct Permute3D {
       } else {
         return {kOrtxErrorInvalidArgument, "[Permute]: Invalid argument"};
       }
+    }
+
+    if (dims_.size() != 3 || dims_[0] < 0 || dims_[0] > 2 ||
+        dims_[1] < 0 || dims_[1] > 2 || dims_[2] < 0 || dims_[2] > 2) {
+      return {kOrtxErrorInvalidArgument, "[Permute]: dims must be a permutation of {0, 1, 2}"};
     }
 
     return {};

--- a/shared/api/image_transforms.hpp
+++ b/shared/api/image_transforms.hpp
@@ -313,9 +313,15 @@ struct Normalize {
     for (const auto& [key, value] : attrs) {
       if (key == "mean") {
         auto mean = std::get<std::vector<double>>(value);
+        if (mean.size() < 3) {
+          return {kOrtxErrorInvalidArgument, "[Normalize]: mean must have at least 3 values"};
+        }
         mean_ = {static_cast<float>(mean[0]), static_cast<float>(mean[1]), static_cast<float>(mean[2])};
       } else if (key == "std") {
         auto std = std::get<std::vector<double>>(value);
+        if (std.size() < 3) {
+          return {kOrtxErrorInvalidArgument, "[Normalize]: std must have at least 3 values"};
+        }
         std_ = {static_cast<float>(std[0]), static_cast<float>(std[1]), static_cast<float>(std[2])};
       } else if (key == "qwen2_5_vl" || key == "qwen3_vl") {
         qwen2_5_vl_ = std::get<int64_t>(value) != 0;

--- a/shared/api/speech_features.hpp
+++ b/shared/api/speech_features.hpp
@@ -39,17 +39,17 @@ class SpeechFeatures {
       }
     }
 
+    if (frame_length_ < 2 || hop_length_ < 1 || n_fft_ < 1) {
+      return {kOrtxErrorInvalidArgument,
+              "[AudioFeatures]: Invalid config: frame_length must be >= 2, hop_length and n_fft must be >= 1"};
+    }
+
     if (fft_win_.empty()) {
       if (win_fn_ == "hamming") {
         fft_win_ = hamming_window(frame_length_);
       } else {  // default to hann
         fft_win_ = hann_window(frame_length_);
       }
-    }
-
-    if (frame_length_ < 2 || hop_length_ < 1 || n_fft_ < 1) {
-      return {kOrtxErrorInvalidArgument,
-              "[AudioFeatures]: Invalid config: frame_length must be >= 2, hop_length and n_fft must be >= 1"};
     }
 
     if (static_cast<int64_t>(fft_win_.size()) < frame_length_) {

--- a/shared/api/speech_features.hpp
+++ b/shared/api/speech_features.hpp
@@ -47,6 +47,11 @@ class SpeechFeatures {
       }
     }
 
+    if (frame_length_ < 2 || hop_length_ < 1 || n_fft_ < 1) {
+      return {kOrtxErrorInvalidArgument,
+              "[AudioFeatures]: Invalid config: frame_length must be >= 2, hop_length and n_fft must be >= 1"};
+    }
+
     if (static_cast<int64_t>(fft_win_.size()) < frame_length_) {
       return {kOrtxErrorInvalidArgument,
               "[AudioFeatures]: hann_win size (" + std::to_string(fft_win_.size()) +

--- a/shared/api/speech_features.hpp
+++ b/shared/api/speech_features.hpp
@@ -46,6 +46,13 @@ class SpeechFeatures {
         fft_win_ = hann_window(frame_length_);
       }
     }
+
+    if (static_cast<int64_t>(fft_win_.size()) < frame_length_) {
+      return {kOrtxErrorInvalidArgument,
+              "[AudioFeatures]: hann_win size (" + std::to_string(fft_win_.size()) +
+              ") is smaller than frame_length (" + std::to_string(frame_length_) + ")"};
+    }
+
     return {};
   }
 

--- a/test/pp_api_test/test_tokenizer_impl.cc
+++ b/test/pp_api_test/test_tokenizer_impl.cc
@@ -954,13 +954,15 @@ TEST(OrtxTokenizerTest, BpeDecoderBatchedDetokenize) {
   auto status = tokenizer->Load("data/phi-2");
   ASSERT_TRUE(status.IsOk()) << status.ToString();
 
-  // Two identical rows of token IDs — batch=2, seq_len=5
-  std::vector<extTokenId_t> row = {1212, 318, 257, 1332, 13};  // "This is a test."
-  std::vector<ort_extensions::span<extTokenId_t const>> batch = {row, row};
+  // Two different rows of token IDs to verify row boundaries are respected.
+  std::vector<extTokenId_t> row1 = {1212, 318, 257, 1332, 13};   // "This is a test."
+  std::vector<extTokenId_t> row2 = {15496, 995, 0};               // "Hello world!"
+  std::vector<ort_extensions::span<extTokenId_t const>> batch = {row1, row2};
 
   std::vector<std::string> out_text;
   status = tokenizer->Detokenize(batch, out_text);
   ASSERT_TRUE(status.IsOk()) << status.ToString();
   ASSERT_EQ(out_text.size(), 2u);
-  EXPECT_EQ(out_text[0], out_text[1]);
+  EXPECT_EQ(out_text[0], "This is a test.");
+  EXPECT_NE(out_text[0], out_text[1]);
 }

--- a/test/pp_api_test/test_tokenizer_impl.cc
+++ b/test/pp_api_test/test_tokenizer_impl.cc
@@ -945,3 +945,22 @@ TEST(OrtxTokenizerProfileTest, DISABLED_MemoryUsage) {
   fprintf(stderr, "Allocated once at model load, freed when tokenizer is destroyed.\n");
   fprintf(stderr, "================================================================\n\n");
 }
+
+// Regression test: batched detokenization with batch >= 2 must not read past the
+// token ID buffer. Previously the inner loop used the total tensor element count
+// instead of the per-row sequence length as its bound.
+TEST(OrtxTokenizerTest, BpeDecoderBatchedDetokenize) {
+  auto tokenizer = std::make_unique<ort_extensions::TokenizerImpl>();
+  auto status = tokenizer->Load("data/phi-2");
+  ASSERT_TRUE(status.IsOk()) << status.ToString();
+
+  // Two identical rows of token IDs — batch=2, seq_len=5
+  std::vector<extTokenId_t> row = {1212, 318, 257, 1332, 13};  // "This is a test."
+  std::vector<ort_extensions::span<extTokenId_t const>> batch = {row, row};
+
+  std::vector<std::string> out_text;
+  status = tokenizer->Detokenize(batch, out_text);
+  ASSERT_TRUE(status.IsOk()) << status.ToString();
+  ASSERT_EQ(out_text.size(), 2u);
+  EXPECT_EQ(out_text[0], out_text[1]);
+}


### PR DESCRIPTION
## Fix OOB reads in tokenizer decoders, image transforms, and speech features

### Summary

This PR adds missing bounds checks and input validation across multiple custom operators to prevent heap out-of-bounds reads from malformed inputs or crafted models.

### Changes

**`operators/tokenizer/bpe_decoder.hpp`**
- Fix wrong loop bound in `KernelBpeDecoder::Compute`: the inner loop iterated over the entire tensor element count instead of the per-row sequence length, causing OOB reads when processing batched inputs (batch >= 2).

**`operators/tokenizer/wordpiece_tokenizer.cc`**
- Fix misplaced bounds check in `KernelWordpieceTokenizer_Tokenizer`: the `row_index >= n_existing_rows` guard ran one line after the dereference of `existing_rows[row_index]`. Moved the check into the condition before the access.

**`operators/tokenizer/bert_tokenizer_decoder.cc`**
- Fix unbounded slice in `KernelBertTokenizerDecoder::Compute`: start/end indices from the attacker-controlled `positions` input were used to slice the `ids` buffer without any bounds validation. Added `0 <= start <= end <= ids.NumberOfElement()` check.

**`operators/tokenizer/trie_tokenizer.hpp`**
- Fix shape vector OOB read in `TrieDetokenizer::Compute`: the code assumed rank-2 input and accessed `ids_dim[1]` without verifying `ids_dim.size() >= 2`. Rank-1 inputs now treated as `[1, N]`.

**`shared/api/image_transforms.hpp`**
- Fix OOB read in `Resize::Compute`: added `c != 3` channel validation. The copy loop uses a hardcoded stride of 3, so non-3-channel inputs read past the buffer.
- Fix OOB read in `Normalize::Compute`: added `C == mean_.size()` validation. The channel loop indexed into fixed 3-element `mean_`/`std_` vectors using the input's channel dimension.
- Fix OOB read in `Permute3D::Init`: added validation that each `dims_[i]` is in `[0, 2]`. Out-of-range values would index past the 3-element shape vector.

**`shared/api/speech_features.hpp`**
- Fix OOB read in `SpeechLibSTFTNorm`: added validation that `fft_win_.size() >= frame_length_` after initialization. A caller-supplied `hann_win` shorter than `frame_length_` caused the STFT loop to read past the window buffer.

**`test/pp_api_test/test_tokenizer_impl.cc`**
- Add `BpeDecoderBatchedDetokenize` regression test: verifies batched detokenization (batch=2) produces correct output without OOB access.

### Testing

The `BpeDecoderBatchedDetokenize` test exercises the BPE decoder fix through the `TokenizerImpl::Detokenize` API. The remaining fixes are in custom op kernels or config-driven pipelines that require either a crafted ONNX model with an ORT session or attacker-controlled preprocessor config bundles, not worth adding into the repository.