### PR TITLE
Fix Marian Unicode case restoration

### DIFF
--- a/operators/tokenizer/ugm_kernels.hpp
+++ b/operators/tokenizer/ugm_kernels.hpp
@@ -14,8 +14,6 @@
 #include <cstring>
 #include <functional>
 #include <unordered_map>
-#include <cwctype>
-#include <locale>
 
 #include "ortx_tokenizer.h"
 #include "ext_status.h"
@@ -27,6 +25,7 @@
 #include "trietree.hpp"
 #include "tokenizer_jsconfig.hpp"
 #include "case_encoder.h"
+#include "unicode.h"
 
 namespace ort_extensions {
 
@@ -807,7 +806,7 @@ class SpmUgmDecoder {
   }
 
   // Helper: Decode first UTF-8 codepoint
-  bool DecodeFirstUTF8Codepoint(const std::string& utf8, wchar_t& codepoint, size_t& char_len) const {
+  bool DecodeFirstUTF8Codepoint(const std::string& utf8, char32_t& codepoint, size_t& char_len) const {
     unsigned char lead = static_cast<unsigned char>(utf8[0]);
     if (lead < 0x80) {
       codepoint = lead;
@@ -835,12 +834,11 @@ class SpmUgmDecoder {
     return true;
   }
 
-  // Helper: Encode a wchar_t as UTF-8
-  std::string EncodeUTF8(wchar_t wc) const {
+  // Helper: Encode a Unicode codepoint as UTF-8
+  std::string EncodeUTF8(char32_t codepoint) const {
     std::string out;
 
-    // Promote wchar_t to uint32_t to avoid data loss from shift operations and silence warning C4333
-    uint32_t u = static_cast<uint32_t>(wc);
+    uint32_t u = static_cast<uint32_t>(codepoint);
 
     if (u < 0x80) {
       out += static_cast<char>(u);
@@ -865,19 +863,12 @@ class SpmUgmDecoder {
   void TitlecaseFirstCharacter(std::string& token) const {
     if (token.empty()) return;
 
-    wchar_t codepoint;
+    char32_t codepoint;
     size_t char_len = 0;
 
     if (!DecodeFirstUTF8Codepoint(token, codepoint, char_len)) return;
 
-    // Unicode-aware titlecasing for Cyrillic
-    if (codepoint >= L'а' && codepoint <= L'я') {
-      codepoint = codepoint - (L'а' - L'А');  // Convert to uppercase
-    } else if (codepoint == L'ё') {
-      codepoint = L'Ё';  // Special case
-    } else {
-      codepoint = std::towupper(codepoint);  // Fallback (Latin, etc.)
-    }
+    codepoint = ufal::unilib::unicode::titlecase(codepoint);
 
     std::string prefix = EncodeUTF8(codepoint);
     std::string suffix = token.substr(char_len);
@@ -940,19 +931,11 @@ class SpmUgmDecoder {
 
     auto uppercase_codepoint = [this](std::string& cp_utf8) {
       if (cp_utf8.empty()) return;
-      wchar_t codepoint = 0;
+      char32_t codepoint = 0;
       size_t char_len = 0;
       if (!DecodeFirstUTF8Codepoint(cp_utf8, codepoint, char_len)) return;
       (void)char_len;
-      // Match TitlecaseFirstCharacter's special-cases.
-      if (codepoint >= L'\u0430' && codepoint <= L'\u044f') {
-        codepoint = codepoint - (L'\u0430' - L'\u0410');
-      } else if (codepoint == L'\u0451') {
-        codepoint = L'\u0401';
-      } else {
-        codepoint = static_cast<wchar_t>(
-            std::towupper(static_cast<wint_t>(codepoint)));
-      }
+      codepoint = ufal::unilib::unicode::uppercase(codepoint);
       cp_utf8 = EncodeUTF8(codepoint);
     };
 
@@ -1005,7 +988,7 @@ class SpmUgmDecoder {
 
       // Real codepoint: use DecodeFirstUTF8Codepoint for robust byte-
       // length detection (handles malformed / truncated sequences).
-      wchar_t codepoint = 0;
+      char32_t codepoint = 0;
       size_t cp_len = 0;
       std::string remaining = piece.substr(i);
       if (!DecodeFirstUTF8Codepoint(remaining, codepoint, cp_len) || cp_len == 0) {
@@ -1015,7 +998,9 @@ class SpmUgmDecoder {
         continue;
       }
 
-      const bool is_letter = std::iswalpha(static_cast<wint_t>(codepoint)) != 0;
+      const bool is_letter =
+          (ufal::unilib::unicode::category(codepoint) &
+           ufal::unilib::unicode::L) != 0;
 
       if (is_letter && (mode == normalizer::cTitlecase ||
                         mode == normalizer::cUppercase ||

--- a/test/pp_api_test/test_tokenizer_capi.cc
+++ b/test/pp_api_test/test_tokenizer_capi.cc
@@ -373,6 +373,22 @@ TEST_F(MarianId2TokenTest, CombinedBugs) {
             "THIS iPhone costs PPV-mp only");
 }
 
+// Non-ASCII letters must not depend on the process locale. Hosted Linux and
+// Windows test environments commonly use the C locale, where iswalpha and
+// towupper only handle ASCII reliably.
+TEST_F(MarianId2TokenTest, UnicodeCaseRestoration) {
+  ASSERT_EQ(tokenizer_.Code(), kOrtxOK) << "Failed to create tokenizer.";
+  EXPECT_EQ(RoundTrip(u8"Башҡортостан Республикаһы"),
+            u8"Башҡортостан Республикаһы");
+  EXPECT_EQ(RoundTrip(u8"École Über"), u8"École Über");
+}
+
+TEST_F(MarianId2TokenTest, UnicodeCasePreservesUnmarkedText) {
+  ASSERT_EQ(tokenizer_.Code(), kOrtxOK) << "Failed to create tokenizer.";
+  EXPECT_EQ(RoundTrip(u8"башҡорт теле; école über; 中文 123"),
+            u8"башҡорт теле; école über; 中文 123");
+}
+
 // ============================================================================
 // Transformers v5 format tests
 // ============================================================================

--- a/test/pp_api_test/test_tokenizer_capi.cc
+++ b/test/pp_api_test/test_tokenizer_capi.cc
@@ -4,7 +4,7 @@
 #include <memory>
 #include <string>
 #include <fstream>
-#include <locale>
+#include <locale.h>
 #include <algorithm>
 #include "gtest/gtest.h"
 
@@ -302,6 +302,64 @@ TEST(OrtxTokenizerTest, MarianTokenizer2) {
 // Marian Id2Token bug-fix regression tests
 // ============================================================================
 
+class ScopedCTypeCLocale {
+ public:
+  ScopedCTypeCLocale() {
+#ifdef _WIN32
+    previous_thread_locale_mode_ = _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+    if (previous_thread_locale_mode_ == -1) {
+      return;
+    }
+    const char* previous_locale = ::setlocale(LC_CTYPE, nullptr);
+    if (previous_locale == nullptr) {
+      return;
+    }
+    previous_locale_ = previous_locale;
+    valid_ = ::setlocale(LC_CTYPE, "C") != nullptr;
+#else
+    c_locale_ = newlocale(LC_CTYPE_MASK, "C", nullptr);
+    if (c_locale_ == static_cast<locale_t>(0)) {
+      return;
+    }
+    previous_locale_ = uselocale(c_locale_);
+    valid_ = previous_locale_ != static_cast<locale_t>(0);
+#endif
+  }
+
+  ~ScopedCTypeCLocale() {
+#ifdef _WIN32
+    if (!previous_locale_.empty()) {
+      ::setlocale(LC_CTYPE, previous_locale_.c_str());
+    }
+    if (previous_thread_locale_mode_ != -1) {
+      _configthreadlocale(previous_thread_locale_mode_);
+    }
+#else
+    if (previous_locale_ != static_cast<locale_t>(0)) {
+      uselocale(previous_locale_);
+    }
+    if (c_locale_ != static_cast<locale_t>(0)) {
+      freelocale(c_locale_);
+    }
+#endif
+  }
+
+  ScopedCTypeCLocale(const ScopedCTypeCLocale&) = delete;
+  ScopedCTypeCLocale& operator=(const ScopedCTypeCLocale&) = delete;
+
+  bool IsValid() const { return valid_; }
+
+ private:
+  bool valid_ = false;
+#ifdef _WIN32
+  int previous_thread_locale_mode_ = -1;
+  std::string previous_locale_;
+#else
+  locale_t c_locale_ = static_cast<locale_t>(0);
+  locale_t previous_locale_ = static_cast<locale_t>(0);
+#endif
+};
+
 // Fixture: shares a single NMT tokenizer instance and provides a helper
 // that tokenizes + detokenizes a string, returning the round-tripped text.
 class MarianId2TokenTest : public ::testing::Test {
@@ -378,6 +436,8 @@ TEST_F(MarianId2TokenTest, CombinedBugs) {
 // towupper only handle ASCII reliably.
 TEST_F(MarianId2TokenTest, UnicodeCaseRestoration) {
   ASSERT_EQ(tokenizer_.Code(), kOrtxOK) << "Failed to create tokenizer.";
+  ScopedCTypeCLocale locale;
+  ASSERT_TRUE(locale.IsValid()) << "Failed to activate the per-thread C locale.";
   EXPECT_EQ(RoundTrip(u8"Башҡортостан Республикаһы"),
             u8"Башҡортостан Республикаһы");
   EXPECT_EQ(RoundTrip(u8"École Über"), u8"École Über");
@@ -385,6 +445,8 @@ TEST_F(MarianId2TokenTest, UnicodeCaseRestoration) {
 
 TEST_F(MarianId2TokenTest, UnicodeCasePreservesUnmarkedText) {
   ASSERT_EQ(tokenizer_.Code(), kOrtxOK) << "Failed to create tokenizer.";
+  ScopedCTypeCLocale locale;
+  ASSERT_TRUE(locale.IsValid()) << "Failed to activate the per-thread C locale.";
   EXPECT_EQ(RoundTrip(u8"башҡорт теле; école über; 中文 123"),
             u8"башҡорт теле; école über; 中文 123");
 }


### PR DESCRIPTION
## Problem

Marian tokenization through ORT Extensions produces the same token IDs as SentencePiece, but detokenization can lose capitalization for non-ASCII scripts. In downstream translation package validation, all 36 language directions matched SentencePiece token IDs exactly (553/553 cases per direction), while decoded text was lowercased where SentencePiece restored the original capitalization. This blocks the strict tokenizer quality gate and would otherwise ship visibly degraded translation output.

For example, Marian's case encoder lowercases text and records the original casing with `T`, `U`, and `A` markers. The decoder sees those markers, but currently decides whether to apply them with `std::iswalpha` and maps case with `std::towupper`. Those APIs depend on the process locale. Under the C locale commonly used by hosted Linux and Windows environments, Bashkir and other non-ASCII letters may not be recognized as letters, so the marker is ignored and the output remains lowercase.

## Fix

- classify letters with ORT Extensions' locale-independent Unicode category table
- restore uppercase and titlecase with its Unicode case mappings
- use `char32_t` for decoded codepoints so behavior does not depend on the platform width of `wchar_t`
- preserve the existing Marian marker state machine and leave non-Marian UGM decoding unchanged

This does not change encoded token IDs. It fixes Marian decoding so its case markers are applied consistently across locales and scripts.

## Regression coverage

- verifies Bashkir and accented Latin capitalization is restored
- verifies unmarked lowercase Bashkir and Latin remain lowercase
- verifies uncased text, punctuation, and digits remain unchanged
- retains the existing cross-piece, mid-piece, and marker-reset regressions

## Testing

- `pp_api_test.exe --gtest_filter=MarianId2TokenTest.*` (6 passed)
- `pp_api_test.exe --gtest_filter=*Tokenizer*:*Ugm*:*UGM*` (61 passed)