### PR TITLE
Use authenticated package sources in packaging pipelines

### DIFF
--- a/.pipelines/java_packaging.yml
+++ b/.pipelines/java_packaging.yml
@@ -13,6 +13,8 @@ stages:
     pool: {name: 'onnxruntime-Win-CPU-2022'}
 
     steps:
+    - template: templates/setup-maven-feed.yml
+
     - task: PowerShell@2
       displayName: 'Set version'
       inputs:
@@ -62,6 +64,8 @@ stages:
     pool: {name: 'Azure-Pipelines-EO-Ubuntu-2004-aiinfra'}
 
     steps:
+    - template: templates/setup-maven-feed.yml
+
     - task: PowerShell@2
       displayName: 'Set version'
       inputs:
@@ -110,6 +114,8 @@ stages:
       vmImage: 'macOS-14'
 
     steps:
+    - template: templates/setup-maven-feed.yml
+
     - task: PowerShell@2
       displayName: 'Set version'
       inputs:

--- a/.pipelines/templates/onebranch-windows-build-stage.yml
+++ b/.pipelines/templates/onebranch-windows-build-stage.yml
@@ -49,6 +49,9 @@ stages:
       displayName: 'locate vsdevcmd via vswhere'
 
     - task: UsePythonVersion@0
+
+    - template: setup-python-feed.yml
+
     - script: |
         call $(vsdevcmd) -arch=amd64
         set PYTHONPATH=

--- a/.pipelines/templates/setup-maven-feed.yml
+++ b/.pipelines/templates/setup-maven-feed.yml
@@ -1,0 +1,79 @@
+parameters:
+- name: artifactFeed
+  type: string
+  default: 'Lotus'
+
+- name: feedUrl
+  type: string
+  default: 'https://pkgs.dev.azure.com/aiinfra/_packaging/Lotus/maven/v1'
+
+steps:
+- task: MavenAuthenticate@0
+  displayName: 'Authenticate Maven feed'
+  inputs:
+    artifactsFeeds: ${{ parameters.artifactFeed }}
+
+- task: PowerShell@2
+  displayName: 'Configure Gradle feed isolation'
+  env:
+    ORT_EXTENSIONS_MAVEN_FEED_NAME: ${{ parameters.artifactFeed }}
+    ORT_EXTENSIONS_MAVEN_FEED_URL: ${{ parameters.feedUrl }}
+  inputs:
+    targetType: 'inline'
+    script: |
+      $gradleInitDir = Join-Path $HOME '.gradle/init.d'
+      New-Item -ItemType Directory -Force -Path $gradleInitDir | Out-Null
+
+      $initScript = @'
+      import groovy.xml.XmlSlurper
+      import org.gradle.api.GradleException
+      import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+
+      def feedName = System.getenv('ORT_EXTENSIONS_MAVEN_FEED_NAME')
+      def feedUrl = System.getenv('ORT_EXTENSIONS_MAVEN_FEED_URL')
+      def settingsFile = new File(System.getProperty('user.home'), '.m2/settings.xml')
+      if (!settingsFile.exists()) {
+          throw new GradleException("Maven settings file was not created: ${settingsFile}")
+      }
+
+      def server = new XmlSlurper().parse(settingsFile).servers.server.find {
+          it.id.text() == feedName
+      }
+      if (!server) {
+          throw new GradleException("Credentials for Maven feed '${feedName}' were not found")
+      }
+
+      def feedUsername = server.username.text()
+      def feedPassword = server.password.text()
+      def configureRepository = { repository ->
+          if (repository instanceof MavenArtifactRepository) {
+              repository.setUrl(feedUrl)
+              repository.credentials {
+                  username = feedUsername
+                  password = feedPassword
+              }
+          }
+      }
+
+      gradle.settingsEvaluated { settings ->
+          settings.pluginManagement.repositories.clear()
+          settings.pluginManagement.repositories.maven {
+              name = feedName
+              url = uri(feedUrl)
+              credentials {
+                  username = feedUsername
+                  password = feedPassword
+              }
+          }
+      }
+
+      gradle.beforeProject { project ->
+          [project.buildscript.repositories, project.repositories].each { repositories ->
+              repositories.all(configureRepository)
+              repositories.whenObjectAdded(configureRepository)
+          }
+      }
+      '@
+
+      Set-Content -Path (Join-Path $gradleInitDir 'package-feed.init.gradle') `
+        -Value $initScript -Encoding utf8

--- a/.pipelines/templates/setup-python-feed.yml
+++ b/.pipelines/templates/setup-python-feed.yml
@@ -38,7 +38,6 @@ steps:
       $nugetConfigDir = Join-Path $env:APPDATA 'NuGet'
       New-Item -ItemType Directory -Force -Path $nugetConfigDir | Out-Null
       $nugetConfig = @"
-      <?xml version="1.0" encoding="utf-8"?>
       <configuration>
         <packageSources>
           <clear />
@@ -49,4 +48,4 @@ steps:
         </disabledPackageSources>
       </configuration>
       "@
-      Set-Content -Path (Join-Path $nugetConfigDir 'NuGet.Config') -Value $nugetConfig
+      Set-Content -Path (Join-Path $nugetConfigDir 'NuGet.Config') -Value $nugetConfig -Encoding utf8

--- a/.pipelines/templates/setup-python-feed.yml
+++ b/.pipelines/templates/setup-python-feed.yml
@@ -1,0 +1,52 @@
+parameters:
+- name: artifactFeed
+  type: string
+  default: 'Lotus'
+
+- name: nugetFeedUrl
+  type: string
+  default: 'https://pkgs.dev.azure.com/aiinfra/_packaging/Lotus/nuget/v3/index.json'
+
+steps:
+- task: PipAuthenticate@1
+  displayName: 'Authenticate Python package feed'
+  inputs:
+    artifactFeeds: ${{ parameters.artifactFeed }}
+    onlyAddExtraIndex: false
+
+- task: NuGetAuthenticate@1
+  displayName: 'Authenticate NuGet package feed'
+
+- task: PowerShell@2
+  displayName: 'Configure cibuildwheel package isolation'
+  env:
+    ORT_EXTENSIONS_NUGET_FEED_URL: ${{ parameters.nugetFeedUrl }}
+  inputs:
+    targetType: 'inline'
+    script: |
+      $ErrorActionPreference = 'Stop'
+      if (-not $env:PIP_INDEX_URL) {
+        throw 'PIP_INDEX_URL is not configured by PipAuthenticate.'
+      }
+
+      $nuget = Get-Command nuget.exe -ErrorAction Stop
+      $cibwCache = Join-Path '$(Agent.TempDirectory)' 'cibuildwheel-cache'
+      New-Item -ItemType Directory -Force -Path $cibwCache | Out-Null
+      Copy-Item -Force -Path $nuget.Source -Destination (Join-Path $cibwCache 'nuget.exe')
+      Write-Host "##vso[task.setvariable variable=CIBW_CACHE_PATH]$cibwCache"
+
+      $nugetConfigDir = Join-Path $env:APPDATA 'NuGet'
+      New-Item -ItemType Directory -Force -Path $nugetConfigDir | Out-Null
+      $nugetConfig = @"
+      <?xml version="1.0" encoding="utf-8"?>
+      <configuration>
+        <packageSources>
+          <clear />
+          <add key="Package Feed" value="$env:ORT_EXTENSIONS_NUGET_FEED_URL" />
+        </packageSources>
+        <disabledPackageSources>
+          <clear />
+        </disabledPackageSources>
+      </configuration>
+      "@
+      Set-Content -Path (Join-Path $nugetConfigDir 'NuGet.Config') -Value $nugetConfig

--- a/tools/ci_build/github/azure-pipeline/java_packaging.yml
+++ b/tools/ci_build/github/azure-pipeline/java_packaging.yml
@@ -40,6 +40,8 @@ extends:
             artifact: WindowsBinaries
 
         steps:
+        - template: /.pipelines/templates/setup-maven-feed.yml@self
+
         - task: PowerShell@2
           displayName: 'Set version'
           inputs:
@@ -92,6 +94,8 @@ extends:
             artifact: LinuxBinaries
 
         steps:
+        - template: /.pipelines/templates/setup-maven-feed.yml@self
+
         - task: PowerShell@2
           displayName: 'Set version'
           inputs:
@@ -150,6 +154,8 @@ extends:
             artifact: drop-onnxruntime-extensions-java-cpu
 
         steps:
+        - template: /.pipelines/templates/setup-maven-feed.yml@self
+
         - task: PowerShell@2
           displayName: 'Set version'
           inputs:

--- a/tools/ci_build/github/azure-pipeline/templates/windows-build-stage.yml
+++ b/tools/ci_build/github/azure-pipeline/templates/windows-build-stage.yml
@@ -63,6 +63,8 @@ stages:
         versionSpec: '3.13'
         addToPath: true
 
+    - template: /.pipelines/templates/setup-python-feed.yml@self
+
     - script: |
         call $(vsdevcmd) -arch=amd64
         set PYTHONPATH=


### PR DESCRIPTION
## Summary
- add reusable package-source setup for Java packaging jobs
- configure Windows wheel builds to use authenticated Python and NuGet sources
- seed the wheel build cache with the agent-provided package client to avoid ad hoc bootstrap downloads
- apply the setup consistently across current and legacy pipeline entry points

## Testing
- parsed the updated YAML files
- ran `git diff --check`