### PR TITLE
Support Jinja defined and undefined predicates

### DIFF
--- a/shared/api/chat_template.cc
+++ b/shared/api/chat_template.cc
@@ -285,6 +285,10 @@ static json NormalizeTools(const char* tools_str) {
   }
 
   json raw_tools = json::parse(tools_str);
+  if (raw_tools.is_null()) {
+    return raw_tools;
+  }
+
   json normalized = json::array();
 
   for (auto& tool : raw_tools) {

--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -58,17 +58,38 @@ namespace minja
     using FilterType = std::function<Value(const std::shared_ptr<Context> &, ArgumentsValue &)>;
 
   private:
-    using ObjectType = nlohmann::ordered_map<json, Value>; // Only contains primitive keys
+    // Contains hashable Minja keys. Undefined uses an internal object-shaped sentinel that is converted at the
+    // Value boundary and cannot be constructed as a user key.
+    using ObjectType = nlohmann::ordered_map<json, Value>;
     using ArrayType = std::vector<Value>;
 
     std::shared_ptr<ArrayType> array_;
     std::shared_ptr<ObjectType> object_;
     std::shared_ptr<CallableType> callable_;
     json primitive_;
+    bool undefined_ = true;
 
-    Value(const std::shared_ptr<ArrayType> &array) : array_(array) {}
-    Value(const std::shared_ptr<ObjectType> &object) : object_(object) {}
-    Value(const std::shared_ptr<CallableType> &callable) : object_(std::make_shared<ObjectType>()), callable_(callable) {}
+    Value(const std::shared_ptr<ArrayType> &array) : array_(array), undefined_(false) {}
+    Value(const std::shared_ptr<ObjectType> &object) : object_(object), undefined_(false) {}
+    Value(const std::shared_ptr<CallableType> &callable) : object_(std::make_shared<ObjectType>()), callable_(callable), undefined_(false) {}
+
+    static const json &undefined_object_key()
+    {
+      // Objects and arrays are not hashable Minja values, so this object-shaped sentinel cannot collide with a
+      // valid user key while keeping the existing JSON-backed ordered map representation.
+      static const json undefined_key = json::object({{"__minja_undefined_key__", true}});
+      return undefined_key;
+    }
+
+    const json &object_key() const
+    {
+      return undefined_ ? undefined_object_key() : primitive_;
+    }
+
+    static Value from_object_key(const json &key)
+    {
+      return key == undefined_object_key() ? Value() : Value(key);
+    }
 
     /* Python-style string repr */
     static void dump_string(const json &primitive, std::ostringstream &out, char string_quote = '\'')
@@ -180,14 +201,14 @@ namespace minja
 
   public:
     Value() {}
-    Value(const bool &v) : primitive_(v) {}
-    Value(const int64_t &v) : primitive_(v) {}
-    Value(const double &v) : primitive_(v) {}
-    Value(const std::nullptr_t &) {}
-    Value(const std::string &v) : primitive_(v) {}
-    Value(const char *v) : primitive_(std::string(v)) {}
+    Value(const bool &v) : primitive_(v), undefined_(false) {}
+    Value(const int64_t &v) : primitive_(v), undefined_(false) {}
+    Value(const double &v) : primitive_(v), undefined_(false) {}
+    Value(const std::nullptr_t &) : undefined_(false) {}
+    Value(const std::string &v) : primitive_(v), undefined_(false) {}
+    Value(const char *v) : primitive_(std::string(v)), undefined_(false) {}
 
-    Value(const json &v)
+    Value(const json &v) : undefined_(false)
     {
       if (v.is_object())
       {
@@ -220,7 +241,7 @@ namespace minja
       std::vector<Value> res;
       for (const auto &item : *object_)
       {
-        res.push_back(item.first);
+        res.push_back(from_object_key(item.first));
       }
       return res;
     }
@@ -297,7 +318,7 @@ namespace minja
       {
         if (!index.is_hashable())
           throw std::runtime_error("Unashable type: " + index.dump());
-        auto it = object_->find(index.primitive_);
+        auto it = object_->find(index.object_key());
         if (it == object_->end())
           throw std::runtime_error("Key not found: " + index.dump());
         auto ret = it->second;
@@ -317,14 +338,19 @@ namespace minja
         {
           return Value();
         }
-        auto index = key.get<int>();
-        return array_->at(index < 0 ? array_->size() + index : index);
+        auto index = key.get<int64_t>();
+        const auto array_size = static_cast<int64_t>(array_->size());
+        if (index < 0)
+          index += array_size;
+        if (index < 0 || index >= array_size)
+          return Value();
+        return array_->at(static_cast<size_t>(index));
       }
       else if (object_)
       {
         if (!key.is_hashable())
           throw std::runtime_error("Unashable type: " + dump());
-        auto it = object_->find(key.primitive_);
+        auto it = object_->find(key.object_key());
         if (it == object_->end())
           return Value();
         return it->second;
@@ -337,7 +363,7 @@ namespace minja
         throw std::runtime_error("Value is not an object: " + dump());
       if (!key.is_hashable())
         throw std::runtime_error("Unashable type: " + dump());
-      (*object_)[key.primitive_] = value;
+      (*object_)[key.object_key()] = value;
     }
     Value call(const std::shared_ptr<Context> &context, ArgumentsValue &args) const
     {
@@ -350,6 +376,7 @@ namespace minja
     bool is_array() const { return !!array_; }
     bool is_callable() const { return !!callable_; }
     bool is_null() const { return !object_ && !array_ && primitive_.is_null() && !callable_; }
+    bool is_undefined() const { return undefined_; }
     bool is_boolean() const { return primitive_.is_boolean(); }
     bool is_number_integer() const { return primitive_.is_number_integer(); }
     bool is_number_float() const { return primitive_.is_number_float(); }
@@ -388,7 +415,7 @@ namespace minja
       {
         for (auto &item : *object_)
         {
-          Value key(item.first);
+          Value key = from_object_key(item.first);
           callback(key);
         }
       }
@@ -469,6 +496,8 @@ namespace minja
 
     bool operator==(const Value &other) const
     {
+      if (undefined_ || other.undefined_)
+        return undefined_ && other.undefined_;
       if (callable_ || other.callable_)
       {
         if (callable_.get() != other.callable_.get())
@@ -482,7 +511,7 @@ namespace minja
           return false;
         for (size_t i = 0; i < array_->size(); ++i)
         {
-          if (!(*array_)[i].to_bool() || !(*other.array_)[i].to_bool() || (*array_)[i] != (*other.array_)[i])
+          if ((*array_)[i] != (*other.array_)[i])
             return false;
         }
         return true;
@@ -495,7 +524,8 @@ namespace minja
           return false;
         for (const auto &item : *object_)
         {
-          if (!item.second.to_bool() || !other.object_->count(item.first) || item.second != other.object_->at(item.first))
+          auto other_item = other.object_->find(item.first);
+          if (other_item == other.object_->end() || item.second != other_item->second)
             return false;
         }
         return true;
@@ -531,7 +561,7 @@ namespace minja
       {
         for (const auto &item : *array_)
         {
-          if (item.to_bool() && item == value)
+          if (item == value)
             return true;
         }
         return false;
@@ -540,7 +570,7 @@ namespace minja
       {
         if (!value.is_hashable())
           throw std::runtime_error("Unashable type: " + value.dump());
-        return object_->find(value.primitive_) != object_->end();
+        return object_->find(value.object_key()) != object_->end();
       }
       else
       {
@@ -568,9 +598,17 @@ namespace minja
       if (!index.is_hashable())
         throw std::runtime_error("Unashable type: " + dump());
       if (is_array())
-        return array_->at(index.get<int>());
+      {
+        auto array_index = index.get<int64_t>();
+        const auto array_size = static_cast<int64_t>(array_->size());
+        if (array_index < 0)
+          array_index += array_size;
+        if (array_index < 0 || array_index >= array_size)
+          throw std::out_of_range("Array index out of range: " + index.dump());
+        return array_->at(static_cast<size_t>(array_index));
+      }
       if (is_object())
-        return object_->at(index.primitive_);
+        return object_->at(index.object_key());
       throw std::runtime_error("Value is not an array or object: " + dump());
     }
     const Value &at(size_t index) const
@@ -1856,7 +1894,7 @@ namespace minja
           {
             const auto &name = t->get_name();
             if (name == "none")
-              return l.is_null();
+              return l.is_null() && !l.is_undefined();
             if (name == "boolean")
               return l.is_boolean();
             if (name == "integer")
@@ -1874,7 +1912,9 @@ namespace minja
             if (name == "sequence")
               return l.is_array();
             if (name == "defined")
-              return !l.is_null();
+              return !l.is_undefined();
+            if (name == "undefined")
+              return l.is_undefined();
             throw std::runtime_error("Unknown type for 'is' operator: " + name);
           };
           auto value = eval();
@@ -1933,7 +1973,7 @@ namespace minja
         case Op::In:
           return (r.is_array() || r.is_object()) && r.contains(l);
         case Op::NotIn:
-          return !(r.is_array() && r.contains(l));
+          return !((r.is_array() || r.is_object()) && r.contains(l));
         default:
           break;
         }
@@ -2474,7 +2514,7 @@ namespace minja
           return std::make_shared<Value>(*str);
         }
       }
-      static std::regex prim_tok(R"(true\b|True\b|false\b|False\b|None\b)");
+      static std::regex prim_tok(R"(true\b|True\b|false\b|False\b|none\b|None\b)");
       auto token = consumeToken(prim_tok);
       if (!token.empty())
       {
@@ -2482,7 +2522,7 @@ namespace minja
           return std::make_shared<Value>(true);
         if (token == "false" || token == "False")
           return std::make_shared<Value>(false);
-        if (token == "None")
+        if (token == "none" || token == "None")
           return std::make_shared<Value>(nullptr);
         throw std::runtime_error("Unknown constant token: " + token);
       }
@@ -2953,7 +2993,7 @@ namespace minja
 
         static std::regex null_regex(R"(null\b)");
         if (!consumeToken(null_regex).empty())
-          return std::make_shared<LiteralExpr>(location, Value());
+          return std::make_shared<LiteralExpr>(location, Value(nullptr));
 
         auto identifier = parseIdentifier();
         if (identifier)
@@ -3705,7 +3745,7 @@ namespace minja
         boolean = bv.get<bool>();
       }
     }
-    return boolean ? (value.to_bool() ? value : default_value) : value.is_null() ? default_value : value; }));
+    return boolean ? (value.to_bool() ? value : default_value) : value.is_undefined() ? default_value : value; }));
     auto escape = simple_function("escape", {"text"}, [](const std::shared_ptr<Context> &, Value &args)
                                   { return Value(html_escape(args.at("text").get<std::string>())); });
     globals.set("e", escape);
@@ -3855,7 +3895,7 @@ namespace minja
       for (size_t i = 0, n = items.size(); i < n; i++) {
         auto & item = items.at(i);
         auto attr = item.get(attr_name);
-        res.push_back(attr.is_null() ? default_value : attr);
+        res.push_back(attr.is_undefined() ? default_value : attr);
       }
     } else if (args.kwargs.empty() && args.args.size() >= 2) {
       auto fn = context->get(args.args[1]);

--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -167,6 +167,8 @@ namespace minja
         {
           if (it != begin)
             print_sub_sep();
+          if (to_json && it->first == undefined_object_key())
+            throw std::runtime_error("Undefined values cannot be serialized as object keys");
           if (it->first.is_string())
           {
             dump_string(it->first, out, string_quote);
@@ -2132,7 +2134,7 @@ namespace minja
         {
           vargs.expectArgs("append method", {1, 1}, {0, 0});
           obj.push_back(vargs.args[0]);
-          return Value();
+          return Value(nullptr);
         }
         else if (method->get_name() == "pop")
         {
@@ -2146,7 +2148,7 @@ namespace minja
           if (index < 0 || index > (int64_t)obj.size())
             throw std::runtime_error("Index out of range for insert method");
           obj.insert(index, vargs.args[1]);
-          return Value();
+          return Value(nullptr);
         }
       }
       else if (obj.is_object())

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -2370,3 +2370,180 @@ TEST(OrtxTokenizerTest, LegacyChatTemplateApiMatchesNullTemplateKwargs) {
             kOrtxOK);
   EXPECT_STREQ(legacy_text, options_text);
 }
+
+namespace {
+std::string RenderMinjaExpr(OrtxTokenizer* tokenizer, const std::string& template_str,
+                            const char* template_kwargs = nullptr) {
+  const std::string messages_json = R"([{"role":"user","content":"hi"}])";
+  OrtxObjectPtr<OrtxTensorResult> result;
+  auto err = OrtxApplyChatTemplateWithOptions(
+      tokenizer, template_str.c_str(), messages_json.c_str(), nullptr, template_kwargs, result.ToBeAssigned(), false,
+      false);
+  EXPECT_EQ(err, kOrtxOK) << OrtxGetLastErrorMessage();
+  if (err != kOrtxOK) {
+    return {};
+  }
+
+  OrtxObjectPtr<OrtxTensor> tensor;
+  auto tensor_status = OrtxTensorResultGetAt(result.get(), 0, tensor.ToBeAssigned());
+  EXPECT_EQ(tensor_status, kOrtxOK);
+  if (tensor_status != kOrtxOK) {
+    return {};
+  }
+  const char* text = nullptr;
+  auto data_status = OrtxGetTensorData(tensor.get(), reinterpret_cast<const void**>(&text), nullptr, nullptr);
+  EXPECT_EQ(data_status, kOrtxOK);
+  if (data_status != kOrtxOK) {
+    return {};
+  }
+  return text != nullptr ? std::string(text) : std::string();
+}
+}  // namespace
+
+TEST(OrtxTokenizerTest, MinjaIsDefinedUndefinedPredicates) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ tools is defined }}"), "False");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ tools is undefined }}"), "True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ tools is not defined }}"), "True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ tools is not undefined }}"), "False");
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ messages is defined }}"), "True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ messages is undefined }}"), "False");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ messages is not defined }}"), "False");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ messages is not undefined }}"), "True");
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ messages[0].nonexistent_field is defined }}"), "False");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ messages[0].nonexistent_field is undefined }}"), "True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ messages[0].nonexistent_field is not defined }}"), "True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ messages[0].nonexistent_field is not undefined }}"), "False");
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ messages[0].role is defined }}"), "True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ messages[0].role is undefined }}"), "False");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ messages[0].role is not defined }}"), "False");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ messages[0].role is not undefined }}"), "True");
+}
+
+TEST(OrtxTokenizerTest, MinjaDefinedDistinguishesNullFromUndefinedKwargs) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ value is defined }}|{{ value is undefined }}|{{ value is none }}"),
+            "False|True|False");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ value is defined }}|{{ value is undefined }}|{{ value is none }}",
+                            R"({"value":null})"),
+            "True|False|True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ value is defined }}|{{ value is undefined }}|{{ value is none }}",
+                            R"({"value":"set"})"),
+            "True|False|False");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(),
+                            "{{ value.child is defined }}|{{ value.child is undefined }}|{{ value.child is none }}",
+                            R"({"value":{"child":null}})"),
+            "True|False|True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(),
+                            "{{ value.missing is defined }}|{{ value.missing is undefined }}",
+                            R"({"value":{"child":null}})"),
+            "False|True");
+}
+
+TEST(OrtxTokenizerTest, MinjaUndefinedWorksInControlFlow) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{% if tools is undefined %}no tools{% else %}tools{% endif %}"),
+            "no tools");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{% if value is undefined %}missing{% else %}present{% endif %}",
+                            R"({"value":null})"),
+            "present");
+}
+
+TEST(OrtxTokenizerTest, MinjaNoneAndNullLiteralsAreDefinedNullValues) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ none is defined }}|{{ none is undefined }}|{{ none is none }}"),
+            "True|False|True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ None is defined }}|{{ None is undefined }}|{{ None is none }}"),
+            "True|False|True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ null is defined }}|{{ null is undefined }}|{{ null is none }}"),
+            "True|False|True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(),
+                            "{% set value = none %}{{ value is defined }}|{{ value is undefined }}|"
+                            "{{ value is none }}"),
+            "True|False|True");
+}
+
+TEST(OrtxTokenizerTest, MinjaUndefinedAwareFiltersPreserveExplicitNull) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ missing | default('fallback') }}"), "fallback");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ value | default('fallback') }}", R"({"value":null})"), "");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(),
+                            "{{ values | map(attribute='value', default='fallback') | list }}",
+                            R"({"values":[{"value":null},{}]})"),
+            "[null, 'fallback']");
+}
+
+TEST(OrtxTokenizerTest, MinjaUndefinedAndFalseyValuesWorkInCollections) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ [missing] == [missing] }}"), "True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ [none] == [none] }}"), "True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ [false, 0, ''] == [false, 0, ''] }}"), "True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ none in [none] }}"), "True");
+}
+
+TEST(OrtxTokenizerTest, MinjaOutOfRangeArraySubscriptIsUndefined) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ values[1] }}|{{ values[-1] }}", R"({"values":["a","b"]})"),
+            "b|b");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ values[99] is undefined }}|{{ values[-99] is undefined }}",
+                            R"({"values":["a","b"]})"),
+            "True|True");
+}
+
+TEST(OrtxTokenizerTest, MinjaUndefinedAndNullRemainDistinctObjectKeys) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ missing in {none: 1} }}"), "False");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ {none: 1}[missing] is undefined }}"), "True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ missing in {missing: 1} }}"), "True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ {missing: 1}[missing] }}"), "1");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ {missing: 1} == {none: 1} }}"), "False");
+}
+
+TEST(OrtxTokenizerTest, MinjaNotInSupportsObjectMembership) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ 'x' in {'x': 1} }}"), "True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ 'x' not in {'x': 1} }}"), "False");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ 'y' not in {'x': 1} }}"), "True");
+}
+
+TEST(OrtxTokenizerTest, MinjaUndefinedObjectKeysSurviveEnumeration) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(),
+                            "{% for key in {missing: 1} %}{{ key is undefined }}{% endfor %}"),
+            "True");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(),
+                            "{% for key, value in {missing: 1}.items() %}"
+                            "{{ key is undefined }}={{ value }}{% endfor %}"),
+            "True=1");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(),
+                            "{% for pair in items({missing: 1}) %}"
+                            "{{ pair[0] is undefined }}={{ pair[1] }}{% endfor %}"),
+            "True=1");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(),
+                            "{% for pair in {missing: 1} | dictsort %}"
+                            "{{ pair[0] is undefined }}={{ pair[1] }}{% endfor %}"),
+            "True=1");
+}

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -2373,11 +2373,11 @@ TEST(OrtxTokenizerTest, LegacyChatTemplateApiMatchesNullTemplateKwargs) {
 
 namespace {
 std::string RenderMinjaExpr(OrtxTokenizer* tokenizer, const std::string& template_str,
-                            const char* template_kwargs = nullptr) {
+                            const char* template_kwargs = nullptr, const char* tools = nullptr) {
   const std::string messages_json = R"([{"role":"user","content":"hi"}])";
   OrtxObjectPtr<OrtxTensorResult> result;
   auto err = OrtxApplyChatTemplateWithOptions(
-      tokenizer, template_str.c_str(), messages_json.c_str(), nullptr, template_kwargs, result.ToBeAssigned(), false,
+      tokenizer, template_str.c_str(), messages_json.c_str(), tools, template_kwargs, result.ToBeAssigned(), false,
       false);
   EXPECT_EQ(err, kOrtxOK) << OrtxGetLastErrorMessage();
   if (err != kOrtxOK) {
@@ -2447,6 +2447,15 @@ TEST(OrtxTokenizerTest, MinjaDefinedDistinguishesNullFromUndefinedKwargs) {
             "False|True");
 }
 
+TEST(OrtxTokenizerTest, MinjaDefinedDistinguishesNullFromUndefinedTools) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  const std::string expression = "{{ tools is defined }}|{{ tools is undefined }}|{{ tools is none }}";
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), expression), "False|True|False");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), expression, nullptr, "null"), "True|False|True");
+}
+
 TEST(OrtxTokenizerTest, MinjaUndefinedWorksInControlFlow) {
   OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
   ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
@@ -2456,6 +2465,22 @@ TEST(OrtxTokenizerTest, MinjaUndefinedWorksInControlFlow) {
   EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{% if value is undefined %}missing{% else %}present{% endif %}",
                             R"({"value":null})"),
             "present");
+}
+
+TEST(OrtxTokenizerTest, MinjaMutatorsReturnDefinedNone) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  EXPECT_EQ(RenderMinjaExpr(
+                tokenizer.get(),
+                "{% set values = [] %}{% set result = values.append(1) %}"
+                "{{ result is defined }}|{{ result is undefined }}|{{ result is none }}"),
+            "True|False|True");
+  EXPECT_EQ(RenderMinjaExpr(
+                tokenizer.get(),
+                "{% set values = [] %}{% set result = values.insert(0, 1) %}"
+                "{{ result is defined }}|{{ result is undefined }}|{{ result is none }}"),
+            "True|False|True");
 }
 
 TEST(OrtxTokenizerTest, MinjaNoneAndNullLiteralsAreDefinedNullValues) {
@@ -2546,4 +2571,19 @@ TEST(OrtxTokenizerTest, MinjaUndefinedObjectKeysSurviveEnumeration) {
                             "{% for pair in {missing: 1} | dictsort %}"
                             "{{ pair[0] is undefined }}={{ pair[1] }}{% endfor %}"),
             "True=1");
+}
+
+TEST(OrtxTokenizerTest, MinjaToJsonRejectsUndefinedObjectKeys) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  const std::string messages_json = R"([{"role":"user","content":"hi"}])";
+  OrtxObjectPtr<OrtxTensorResult> result;
+  auto err = OrtxApplyChatTemplateWithOptions(
+      tokenizer.get(), "{{ {missing: 1} | tojson }}", messages_json.c_str(), nullptr, nullptr, result.ToBeAssigned(),
+      false, false);
+
+  EXPECT_NE(err, kOrtxOK);
+  EXPECT_NE(std::string(OrtxGetLastErrorMessage()).find("Undefined values cannot be serialized as object keys"),
+            std::string::npos);
 }


### PR DESCRIPTION
Adds standard Jinja `is defined` and `is undefined` semantics to the vendored Minja implementation used by tokenizer chat templates.
 
Minja previously represented both a missing value and an explicit JSON `null` with the same state. As a result, templates could not reliably distinguish an omitted variable from a variable explicitly set to `null`, and common model templates using `is defined` / `is undefined` failed to render.
 
 This change:
 
 - tracks undefined values separately from explicit null values;
 - implements `is defined`, `is undefined`, and their negated forms;
 - treats `none`, `None`, and `null` as defined null values;
 - preserves undefined semantics through object and array lookup, iteration, `items`, and `dictsort`;
 - makes `default` and `map(default=...)` apply to missing values without replacing explicit nulls;
 - returns undefined for out-of-range array access;
 - fixes equality and membership behavior for falsey collection values;
 - supports `not in` for object membership.
 
 This enables chat templates such as:
 
 ```jinja2
 {% if tools is defined and tools is not none %}
 ...
 {% endif %}
```

while preserving the distinction between an omitted  tools  value and  "tools": null .

Fixes #1107.
