### PR TITLE
Skip container registry cache for fork builds

### DIFF
--- a/tools/ci_build/github/azure-pipeline/templates/get-docker-image-steps.yml
+++ b/tools/ci_build/github/azure-pipeline/templates/get-docker-image-steps.yml
@@ -33,16 +33,37 @@ steps:
     docker system df
   displayName: Check Docker Images
 
-- template: with-container-registry-steps.yml
-  parameters:
-    Steps:
-    - script: |
-        python ${{ parameters.ScriptName }} \
-          --dockerfile "${{ parameters.Dockerfile }}" \
-          --context "${{ parameters.Context }}" \
-          --docker-build-args "${{ parameters.DockerBuildArgs }}" \
-          --container-registry onnxruntimebuildcache \
-          --repository "${{ parameters.Repository }}"
-      displayName: "Get ${{ parameters.Repository }} image for ${{ parameters.Dockerfile }}"
-    ContainerRegistry: onnxruntimebuildcache_token
+- task: Docker@2
+  inputs:
+    containerRegistry: onnxruntimebuildcache_token
+    command: login
+    addPipelineData: false
+  displayName: Log in to container registry
+  condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
 
+- script: |
+    python ${{ parameters.ScriptName }} \
+      --dockerfile "${{ parameters.Dockerfile }}" \
+      --context "${{ parameters.Context }}" \
+      --docker-build-args "${{ parameters.DockerBuildArgs }}" \
+      --container-registry onnxruntimebuildcache \
+      --repository "${{ parameters.Repository }}"
+  displayName: "Get ${{ parameters.Repository }} image for ${{ parameters.Dockerfile }}"
+  condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'True'))
+
+- script: |
+    python ${{ parameters.ScriptName }} \
+      --dockerfile "${{ parameters.Dockerfile }}" \
+      --context "${{ parameters.Context }}" \
+      --docker-build-args "${{ parameters.DockerBuildArgs }}" \
+      --repository "${{ parameters.Repository }}"
+  displayName: "Build ${{ parameters.Repository }} image locally"
+  condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'True'))
+
+- task: Docker@2
+  inputs:
+    containerRegistry: onnxruntimebuildcache_token
+    command: logout
+    addPipelineData: false
+  displayName: Log out of container registry
+  condition: and(always(), ne(variables['System.PullRequest.IsFork'], 'True'))

--- a/tools/ci_build/github/azure-pipeline/templates/get-docker-image-steps.yml
+++ b/tools/ci_build/github/azure-pipeline/templates/get-docker-image-steps.yml
@@ -44,5 +44,5 @@ steps:
           --container-registry onnxruntimebuildcache \
           --repository "${{ parameters.Repository }}"
       displayName: "Get ${{ parameters.Repository }} image for ${{ parameters.Dockerfile }}"
-    ContainerRegistry: onnxruntimebuildcache
+    ContainerRegistry: onnxruntimebuildcache_newtoken
 

--- a/tools/ci_build/github/azure-pipeline/templates/get-docker-image-steps.yml
+++ b/tools/ci_build/github/azure-pipeline/templates/get-docker-image-steps.yml
@@ -44,5 +44,5 @@ steps:
           --container-registry onnxruntimebuildcache \
           --repository "${{ parameters.Repository }}"
       displayName: "Get ${{ parameters.Repository }} image for ${{ parameters.Dockerfile }}"
-    ContainerRegistry: onnxruntimebuildcache_newtoken
+    ContainerRegistry: onnxruntimebuildcache_token
 


### PR DESCRIPTION
Fork pull-request builds cannot access the authenticated container registry service connection. Build the required Docker image locally when `System.PullRequest.IsFork` is true, while preserving the registry-backed cache for trusted builds.

This draft PR is also intended to validate the fork-build path.