### PR TITLE
adds jinja sort filter

### DIFF
--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -3788,8 +3788,10 @@ namespace minja
     }
     auto attribute = args.get<std::string>("attribute", "");
     std::stable_sort(result.begin(), result.end(), [&attribute](const Value &left, const Value &right) {
-      Value left_key = attribute.empty() ? left : left.get(attribute);
-      Value right_key = attribute.empty() ? right : right.get(attribute);
+      Value left_item = left;
+      Value right_item = right;
+      Value left_key = attribute.empty() ? left_item : left_item.get(attribute);
+      Value right_key = attribute.empty() ? right_item : right_item.get(attribute);
       return left_key < right_key;
     });
     if (args.get<bool>("reverse", false)) {

--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -3777,6 +3777,25 @@ namespace minja
       res.push_back(Value::array({key, value.at(key)}));
     }
     return res; }));
+    globals.set("sort", simple_function("sort", {"items", "reverse", "case_sensitive", "attribute"}, [](const std::shared_ptr<Context> &, Value &args)
+                                        {
+    auto & items = args.at("items");
+    if (!items.is_array()) throw std::runtime_error("sort expects an array");
+    std::vector<Value> result;
+    result.reserve(items.size());
+    for (size_t i = 0; i < items.size(); ++i) {
+      result.push_back(items.at(i));
+    }
+    auto attribute = args.get<std::string>("attribute", "");
+    std::stable_sort(result.begin(), result.end(), [&attribute](const Value &left, const Value &right) {
+      Value left_key = attribute.empty() ? left : left.get(attribute);
+      Value right_key = attribute.empty() ? right : right.get(attribute);
+      return left_key < right_key;
+    });
+    if (args.get<bool>("reverse", false)) {
+      std::reverse(result.begin(), result.end());
+    }
+    return Value::array(result); }));
     globals.set("join", simple_function("join", {"items", "d"}, [](const std::shared_ptr<Context> &, Value &args)
                                         {
     auto do_join = [](Value & items, const std::string & sep) {

--- a/shared/api/minja.hpp
+++ b/shared/api/minja.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cctype>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -3780,23 +3781,38 @@ namespace minja
     globals.set("sort", simple_function("sort", {"items", "reverse", "case_sensitive", "attribute"}, [](const std::shared_ptr<Context> &, Value &args)
                                         {
     auto & items = args.at("items");
-    if (!items.is_array()) throw std::runtime_error("sort expects an array");
+    if (!items.is_array()) throw std::runtime_error("sort expects an array, got: " + items.dump());
     std::vector<Value> result;
     result.reserve(items.size());
     for (size_t i = 0; i < items.size(); ++i) {
       result.push_back(items.at(i));
     }
     auto attribute = args.get<std::string>("attribute", "");
-    std::stable_sort(result.begin(), result.end(), [&attribute](const Value &left, const Value &right) {
+    auto reverse = args.get<bool>("reverse", false);
+    auto case_sensitive = args.get<bool>("case_sensitive", false);
+    std::stable_sort(result.begin(), result.end(), [attribute, reverse, case_sensitive](const Value &left, const Value &right) {
       Value left_item = left;
       Value right_item = right;
       Value left_key = attribute.empty() ? left_item : left_item.get(attribute);
       Value right_key = attribute.empty() ? right_item : right_item.get(attribute);
-      return left_key < right_key;
+      const auto left_missing = left_key.is_null() || left_key.is_undefined();
+      const auto right_missing = right_key.is_null() || right_key.is_undefined();
+      if (left_missing || right_missing) {
+        if (left_missing && right_missing) return false;
+        return reverse ? right_missing : left_missing;
+      }
+      if (!case_sensitive && left_key.is_string() && right_key.is_string()) {
+        auto normalize = [](std::string value) {
+          std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+            return static_cast<char>(std::tolower(c));
+          });
+          return value;
+        };
+        left_key = normalize(left_key.get<std::string>());
+        right_key = normalize(right_key.get<std::string>());
+      }
+      return reverse ? right_key < left_key : left_key < right_key;
     });
-    if (args.get<bool>("reverse", false)) {
-      std::reverse(result.begin(), result.end());
-    }
     return Value::array(result); }));
     globals.set("join", simple_function("join", {"items", "d"}, [](const std::shared_ptr<Context> &, Value &args)
                                         {

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -2572,6 +2572,42 @@ TEST(OrtxTokenizerTest, MinjaSortSupportsAttribute) {
                             "{{ [{'type': 'text'}, {'type': 'image'}] | sort(attribute='type') | "
                             "map(attribute='type') | join(',') }}"),
             "image,text");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(), "{{ ['zebra', 'apple'] | sort | join(',') }}"), "apple,zebra");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(),
+                            "{{ [{'id': 'first', 'type': 'text'}, {'id': 'image', 'type': 'image'}, "
+                            "{'id': 'second', 'type': 'text'}] | sort(attribute='type', reverse=true) | "
+                            "map(attribute='id') | join(',') }}"),
+            "first,second,image");
+
+  const std::string messages_json = R"([{"role":"user","content":"hi"}])";
+  OrtxObjectPtr<OrtxTensorResult> result;
+  auto error = OrtxApplyChatTemplateWithOptions(
+      tokenizer.get(), "{{ 'not an array' | sort }}", messages_json.c_str(), nullptr, nullptr,
+      result.ToBeAssigned(), false, false);
+  EXPECT_NE(error, kOrtxOK);
+  EXPECT_NE(std::string(OrtxGetLastErrorMessage()).find("sort expects an array, got: 'not an array'"),
+            std::string::npos);
+}
+
+TEST(OrtxTokenizerTest, MinjaSortHandlesMissingKeysReverseAndCaseSensitivity) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(),
+                            "{{ [{'id': 'null', 'type': none}, {'id': 'missing'}, {'id': 'a', 'type': 'a'}, "
+                            "{'id': 'b', 'type': 'b'}] | sort(attribute='type') | map(attribute='id') | join(',') }}"),
+            "null,missing,a,b");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(),
+                            "{{ [{'id': 'first', 'type': 'b'}, {'id': 'second', 'type': 'a'}, "
+                            "{'id': 'third', 'type': 'b'}] | sort(attribute='type', reverse=true) | "
+                            "map(attribute='id') | join(',') }}"),
+            "first,third,second");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(),
+                            "{{ ['Zebra', 'apple'] | sort | join(',') }}"),
+            "apple,Zebra");
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(),
+                            "{{ ['Zebra', 'apple'] | sort(case_sensitive=true) | join(',') }}"),
+            "Zebra,apple");
 }
 
 TEST(OrtxTokenizerTest, MinjaUndefinedAndFalseyValuesWorkInCollections) {

--- a/test/pp_api_test/test_tokenizer_chat.cc
+++ b/test/pp_api_test/test_tokenizer_chat.cc
@@ -2564,6 +2564,16 @@ TEST(OrtxTokenizerTest, MinjaUndefinedAwareFiltersPreserveExplicitNull) {
             "[null, 'fallback']");
 }
 
+TEST(OrtxTokenizerTest, MinjaSortSupportsAttribute) {
+  OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
+  ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();
+
+  EXPECT_EQ(RenderMinjaExpr(tokenizer.get(),
+                            "{{ [{'type': 'text'}, {'type': 'image'}] | sort(attribute='type') | "
+                            "map(attribute='type') | join(',') }}"),
+            "image,text");
+}
+
 TEST(OrtxTokenizerTest, MinjaUndefinedAndFalseyValuesWorkInCollections) {
   OrtxObjectPtr<OrtxTokenizer> tokenizer(OrtxCreateTokenizer, "data/phi-4-base");
   ASSERT_EQ(tokenizer.Code(), kOrtxOK) << OrtxGetLastErrorMessage();


### PR DESCRIPTION
## Summary

Fixes chat-template rendering for templates that use Jinja's `sort` filter with an attribute, such as:

```jinja
message['content'] | sort(attribute='type')
```

The Minja builtins registered `dictsort`, but not `sort`. As a result, models with multimodal templates using `sort(attribute='type')` failed at runtime with `Value is not callable: null`.

This change registers a stable `sort` filter that supports sorting arrays by an `attribute` and supports `reverse=true`.

## Validation

Adds a regression test that sorts unordered image/text content blocks by `type` and verifies the rendered result is `image,text`.
